### PR TITLE
Provide access to fetched signed metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2004,7 +2004,7 @@ dependencies = [
  "structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.1.0",
+ "tough 0.2.0",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.1.0"
+version = "0.2.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -58,6 +58,8 @@ fn test_tuf_reference_impl() {
     );
     assert_eq!(
         repo.targets()
+            .signed
+            .targets
             .get("file1.txt")
             .unwrap()
             .custom

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -36,4 +36,4 @@ tempfile = "3.1.0"
 url = "2.1.0"
 walkdir = "2.2.9"
 tempdir = "0.3.7"
-tough = { version = "0.1.0", path = "../tough", features = ["http"] }
+tough = { version = "0.2.0", path = "../tough", features = ["http"] }

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -107,7 +107,7 @@ impl DownloadArgs {
 
         // copy all available targets
         println!("Downloading targets to {:?}", &self.indir);
-        for target in repository.targets().keys() {
+        for target in repository.targets().signed.targets.keys() {
             let path = PathBuf::from(&self.indir).join(target);
             println!("\t-> {}", &target);
             let mut reader = repository


### PR DESCRIPTION
This commit makes an API-breaking change to the `tough` library. It adds
`root`, `snapshot`, and `timestamp` methods to `Repository` which return
references to the signed metadata. The `targets` method for `Repository`
has been updated to do the same.

`DownloadArgs.run()` in `tuftool` has been updated to reflect the
aforementioned change to `Repository.targets()`.

*Issue #, if available:*
Fixes #15 

*Description of changes:*
* Add `root`, `snapshot`, and `timestamp` methods to `Repository`
* Change `targets` method to return reference to signed metadata (`Signed<crate::schema::Targets`)
* Bump `tough` version to `0.2.0`
* Fix one breaking test
* Update `tuftool` to make use of the new `Repository.targets()` return value

*Testing done:*
* All unit tests pass
* `clippy` is only warning about things this PR doesn't touch 🤷‍♂ 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
