### PR TITLE
Drop sha2 for ring::digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,6 @@ dependencies = [
  "rusoto_ssm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,6 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -18,7 +18,6 @@ ring = "0.16.7"
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.39"
 serde_plain = "0.3.0"
-sha2 = "0.8.0"
 snafu = "0.5.0"
 untrusted = "0.7.0"
 url = "2.1.0"

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -3,10 +3,10 @@
 use crate::schema::decoded::{Decoded, EcdsaPem, Hex, RsaPem};
 use crate::schema::error::{self, Result};
 use olpc_cjson::CanonicalFormatter;
+use ring::digest::{digest, SHA256};
 use ring::signature::VerificationAlgorithm;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::fmt;
@@ -89,7 +89,7 @@ impl Key {
         self.serialize(&mut ser).context(error::JsonSerialization {
             what: "key".to_owned(),
         })?;
-        Ok(Sha256::digest(&buf).as_slice().to_vec().into())
+        Ok(digest(&SHA256, &buf).as_ref().to_vec().into())
     }
 
     /// Verify a signature of an object made with this key.

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -29,7 +29,6 @@ rusoto_credential = { version = "0.41", optional = true }
 rusoto_ssm = { version = "0.41", optional = true, default-features = false }
 serde = "1.0.99"
 serde_json = "1.0.39"
-sha2 = "0.8.0"
 snafu = { version = "0.5.0", features = ["backtrace-crate"] }
 structopt = "0.3"
 tempfile = "3.1.0"


### PR DESCRIPTION
*Issue #, if available:* fixes #16 

*Description of changes:*
Drops the direct sha2 dependency and uses ring's digest functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
