### PR TITLE
Move signing functionality out of tuftool into tough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "tuftool"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1984,7 +1984,7 @@ dependencies = [
  "snafu 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.2.0",
+ "tough 0.3.0",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.2.0"
+version = "0.3.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -81,6 +81,15 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Private key rejected: {}", source))]
+    KeyRejected {
+        source: ring::error::KeyRejected,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Unrecognized private key format"))]
+    KeyUnrecognized { backtrace: Backtrace },
+
     /// A file's maximum size exceeded a limit set by the consumer of this library or the metadata.
     #[snafu(display("Maximum size {} (specified by {}) exceeded", max_size, specifier))]
     MaxSizeExceeded {
@@ -149,6 +158,12 @@ pub enum Error {
     ParseUrl {
         url: String,
         source: url::ParseError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to sign message"))]
+    Sign {
+        source: ring::error::Unspecified,
         backtrace: Backtrace,
     },
 

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -21,6 +21,7 @@ pub mod error;
 mod fetch;
 mod io;
 pub mod schema;
+pub mod sign;
 mod transport;
 
 #[cfg(feature = "http")]

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -1,0 +1,64 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::error::{self, Result};
+use crate::schema::key::Key;
+use ring::rand::SecureRandom;
+use ring::signature::{KeyPair, RsaKeyPair};
+use snafu::ResultExt;
+use std::collections::HashMap;
+
+/// This trait must be implemented for each type of key with which you will
+/// sign things.
+pub trait Sign: Sync + Send {
+    /// Returns the decoded key along with its scheme and other metadata
+    fn tuf_key(&self) -> crate::schema::key::Key;
+
+    /// Signs the supplied message
+    fn sign(&self, msg: &[u8], rng: &dyn SecureRandom) -> Result<Vec<u8>>;
+}
+
+/// Implements the Sign trait for RSA keypairs
+impl Sign for RsaKeyPair {
+    fn tuf_key(&self) -> Key {
+        use crate::schema::key::{RsaKey, RsaScheme};
+
+        Key::Rsa {
+            keyval: RsaKey {
+                public: self.public_key().as_ref().to_vec().into(),
+                _extra: HashMap::new(),
+            },
+            scheme: RsaScheme::RsassaPssSha256,
+            _extra: HashMap::new(),
+        }
+    }
+
+    fn sign(&self, msg: &[u8], rng: &dyn SecureRandom) -> Result<Vec<u8>> {
+        let mut signature = vec![0; self.public_modulus_len()];
+        self.sign(&ring::signature::RSA_PSS_SHA256, rng, msg, &mut signature)
+            .context(error::Sign)?;
+        Ok(signature)
+    }
+}
+
+/// Parses a supplied keypair and if it is recognized, returns an object that
+/// implements the Sign trait
+pub fn parse_keypair(key: &[u8]) -> Result<impl Sign> {
+    if let Ok(pem) = pem::parse(key) {
+        match pem.tag.as_str() {
+            "PRIVATE KEY" => {
+                if let Ok(rsa_key_pair) = RsaKeyPair::from_pkcs8(&pem.contents) {
+                    Ok(rsa_key_pair)
+                } else {
+                    error::KeyUnrecognized.fail()
+                }
+            }
+            "RSA PRIVATE KEY" => {
+                Ok(RsaKeyPair::from_der(&pem.contents).context(error::KeyRejected)?)
+            }
+            _ => error::KeyUnrecognized.fail(),
+        }
+    } else {
+        error::KeyUnrecognized.fail()
+    }
+}

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.1.1"
+version = "0.2.0"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ structopt = "0.3"
 tempfile = "3.1.0"
 url = "2.1.0"
 walkdir = "2.2.9"
-tough = { version = "0.2.0", path = "../tough", features = ["http"] }
+tough = { version = "0.3.0", path = "../tough", features = ["http"] }

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -145,14 +145,11 @@ pub(crate) enum Error {
         source: tough::schema::Error,
     },
 
-    #[snafu(display("Private key rejected: {}", source))]
-    KeyRejected {
-        source: ring::error::KeyRejected,
+    #[snafu(display("Unable to parse keypair: {}", source))]
+    KeyPairParse {
+        source: tough::error::Error,
         backtrace: Backtrace,
     },
-
-    #[snafu(display("Unrecognized private key format"))]
-    KeyUnrecognized { backtrace: Backtrace },
 
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
@@ -225,7 +222,7 @@ pub(crate) enum Error {
 
     #[snafu(display("Failed to sign message"))]
     Sign {
-        source: ring::error::Unspecified,
+        source: tough::error::Error,
         backtrace: Backtrace,
     },
 

--- a/tuftool/src/key.rs
+++ b/tuftool/src/key.rs
@@ -5,86 +5,24 @@ use crate::error::{self, Result};
 use crate::source::KeySource;
 use olpc_cjson::CanonicalFormatter;
 use ring::rand::SecureRandom;
-use ring::signature::{KeyPair as _, RsaKeyPair};
 use serde::Serialize;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use tough::schema::decoded::{Decoded, Hex};
-use tough::schema::key::Key;
 use tough::schema::{Role, RoleType, Root, Signature, Signed};
+use tough::sign::Sign;
 
-#[derive(Debug)]
-pub(crate) enum KeyPair {
-    Rsa(RsaKeyPair),
-}
-
-impl KeyPair {
-    pub(crate) fn parse(key: &[u8]) -> Result<Self> {
-        if let Ok(pem) = pem::parse(key) {
-            match pem.tag.as_str() {
-                "PRIVATE KEY" => {
-                    if let Ok(key_pair) = RsaKeyPair::from_pkcs8(&pem.contents) {
-                        Ok(KeyPair::Rsa(key_pair))
-                    } else {
-                        error::KeyUnrecognized.fail()
-                    }
-                }
-                "RSA PRIVATE KEY" => Ok(KeyPair::Rsa(
-                    RsaKeyPair::from_der(&pem.contents).context(error::KeyRejected)?,
-                )),
-                _ => error::KeyUnrecognized.fail(),
-            }
-        } else {
-            error::KeyUnrecognized.fail()
-        }
-    }
-
-    pub(crate) fn sign(&self, msg: &[u8], rng: &dyn SecureRandom) -> Result<Vec<u8>> {
-        match self {
-            KeyPair::Rsa(key_pair) => {
-                let mut signature = vec![0; key_pair.public_modulus_len()];
-                key_pair
-                    .sign(&ring::signature::RSA_PSS_SHA256, rng, msg, &mut signature)
-                    .context(error::Sign)?;
-                Ok(signature)
-            }
-        }
-    }
-
-    pub(crate) fn public_key(&self) -> Key {
-        use tough::schema::key::{RsaKey, RsaScheme};
-
-        match self {
-            KeyPair::Rsa(key_pair) => Key::Rsa {
-                keyval: RsaKey {
-                    public: key_pair.public_key().as_ref().to_vec().into(),
-                    _extra: HashMap::new(),
-                },
-                scheme: RsaScheme::RsassaPssSha256,
-                _extra: HashMap::new(),
-            },
-        }
-    }
-}
-
-impl PartialEq<Key> for KeyPair {
-    fn eq(&self, key: &Key) -> bool {
-        match (self, key) {
-            (KeyPair::Rsa(key_pair), Key::Rsa { keyval, .. }) => {
-                key_pair.public_key().as_ref() == keyval.public.as_ref()
-            }
-            _ => false,
-        }
-    }
-}
-
-pub(crate) type RootKeys = HashMap<Decoded<Hex>, KeyPair>;
+pub(crate) type RootKeys = HashMap<Decoded<Hex>, Box<dyn Sign>>;
 
 pub(crate) fn keys_for_root(keys: &[KeySource], root: &Root) -> Result<RootKeys> {
     let mut map = HashMap::new();
     for source in keys {
-        let key_pair = source.as_keypair()?;
-        if let Some((keyid, _)) = root.keys.iter().find(|(_, key)| key_pair == **key) {
+        let key_pair = source.as_sign()?;
+        if let Some((keyid, _)) = root
+            .keys
+            .iter()
+            .find(|(_, key)| key_pair.tuf_key() == **key)
+        {
             map.insert(keyid.clone(), key_pair);
         }
     }
@@ -114,7 +52,7 @@ pub(crate) fn sign_metadata_inner<T: Serialize>(
                 let mut ser =
                     serde_json::Serializer::with_formatter(&mut data, CanonicalFormatter::new());
                 role.signed.serialize(&mut ser).context(error::SignJson)?;
-                let sig = key.sign(&data, rng)?;
+                let sig = key.sign(&data, rng).context(error::Sign)?;
                 role.signatures.push(Signature {
                     keyid: keyid.clone(),
                     sig: sig.into(),

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -3,7 +3,6 @@
 
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
-use crate::key::KeyPair;
 use crate::source::KeySource;
 use crate::{load_file, write_file};
 use chrono::{DateTime, Timelike, Utc};
@@ -15,6 +14,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use tough::schema::decoded::{Decoded, Hex};
 use tough::schema::{key::Key, RoleKeys, RoleType, Root, Signed};
+use tough::sign::{parse_keypair, Sign};
 
 #[derive(Debug, StructOpt)]
 pub(crate) enum Command {
@@ -222,8 +222,8 @@ impl Command {
                 let stdout =
                     String::from_utf8(output.stdout).context(error::CommandUtf8 { command_str })?;
 
-                let key_pair = KeyPair::parse(stdout.as_bytes())?;
-                let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.public_key())?);
+                let key_pair = parse_keypair(stdout.as_bytes()).context(error::KeyPairParse)?;
+                let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.tuf_key())?);
                 key_path.write(&stdout, &key_id)?;
                 clear_sigs(&mut root);
                 println!("{}", key_id);


### PR DESCRIPTION
This commit makes an API-breaking change both to the `tough` library
and `tuftool`. It adds a new `Sign` trait to `tough`, which allows
users to implement this trait for different types of signing keys.
It also allows users to sign data using the `tough` library! :party:

A new method `canonical_form` is added to the `Role` trait, which
serializes the role into its canonical JSON form.

This commit removes the `KeyPair` enum and its corresponding methods
from `tuftool`. Areas that reference this enum have been updated to
use the new `Sign` trait.

*Issue #, if available:*
Fixes #26

*Description of changes:*
* Create new `Sign` trait
* Implement said trait for RSA keypairs
* Remove `KeyPair` enum and associated methods from tuftool
* Add `canonical_form` method to `Role` trait and items that implement the trait
* Fix up any remaining references to `KeyPair` in `tuftool`

*Testing done:*
* Unit tests pass
* Clippy is happy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
