### PR TITLE
tough: Require the std feature of ring

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,5 +9,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: cargo fmt -- --check
     - run: cargo clippy --locked -- -D warnings
-    - run: cargo build --locked
+    - run: cargo build --locked -p olpc-cjson
+    - run: cargo build --locked -p tough
+    - run: cargo build --locked -p tuftool
     - run: cargo test --locked

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -14,7 +14,7 @@ hex = "0.4.0"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.7.0"
 reqwest = { version = "0.9.17", optional = true, default-features = false }
-ring = "0.16.7"
+ring = { version = "0.16.7", features = ["std"] }
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.39"
 serde_plain = "0.3.0"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
```
commit 23b65c15ff29abd690e5e923121f8ec2fd4b97eb
Author: iliana destroyer of worlds <iweller@amazon.com>
Date:   Tue Dec 17 18:08:57 2019 +0000

    tough: Require the std feature of ring
    
    ring::error::Unspecified only implements std::error::Error if the std
    feature is used, which is not enabled by default.
    
    CI didn't catch this issue because all the crates are built at once, so
    ring is built to tuftool's specification.

commit 04583f75e750a2ccd180ef7b0ef5b454bf2633dd
Author: iliana destroyer of worlds <iweller@amazon.com>
Date:   Tue Dec 17 18:10:41 2019 +0000

    ci: Build crates separately
    
    This attempts to catch problems like the one fixed in 23b65c1.
```

Fixes a bug introduced in #28.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
