### PR TITLE
rename target_base_url to targets_base_url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2004,7 +2004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tuftool"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2023,7 +2023,7 @@ dependencies = [
  "snafu 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.4.0",
+ "tough 0.5.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - (Unreleased)
+- Rename `target_base_url` to `targets_base_url`.
+
 ## [0.4.0] - 2020-02-11
 - Updated `reqwest` to `0.10.1` to fix an issue with https failures. Note this requires use of `reqwest::blocking::*` instead of `reqwest::*` in code that is using HttpTransport.
 - Update all dependencies with `cargo update`.

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.4.0"
+version = "0.5.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Settings<'a, R: Read> {
     pub metadata_base_url: &'a str,
 
     /// The URL base for targets.
-    pub target_base_url: &'a str,
+    pub targets_base_url: &'a str,
 
     /// Limits used when fetching repository metadata.
     ///
@@ -124,7 +124,7 @@ pub struct Repository<'a, T: Transport> {
     snapshot: Signed<Snapshot>,
     timestamp: Signed<Timestamp>,
     targets: Signed<crate::schema::Targets>,
-    target_base_url: Url,
+    targets_base_url: Url,
 }
 
 impl<'a, T: Transport> Repository<'a, T> {
@@ -146,11 +146,11 @@ impl<'a, T: Transport> Repository<'a, T> {
     /// endless data attack (defined by TUF as an attacker responding to clients with extremely
     /// large files that interfere with the client's system).
     ///
-    /// `metadata_base_url` and `target_base_url` are the HTTP(S) base URLs for where the client
+    /// `metadata_base_url` and `targets_base_url` are the HTTP(S) base URLs for where the client
     /// can find metadata (such as root.json) and targets (as listed in targets.json).
     pub fn load<R: Read>(transport: &'a T, settings: Settings<'a, R>) -> Result<Self> {
         let metadata_base_url = parse_url(settings.metadata_base_url)?;
-        let target_base_url = parse_url(settings.target_base_url)?;
+        let targets_base_url = parse_url(settings.targets_base_url)?;
 
         let datastore = Datastore::new(settings.datastore);
 
@@ -205,7 +205,7 @@ impl<'a, T: Transport> Repository<'a, T> {
             snapshot,
             timestamp,
             targets,
-            target_base_url,
+            targets_base_url,
         })
     }
 
@@ -277,9 +277,9 @@ impl<'a, T: Transport> Repository<'a, T> {
 
             Some(fetch_sha256(
                 self.transport,
-                self.target_base_url.join(&file).context(error::JoinUrl {
+                self.targets_base_url.join(&file).context(error::JoinUrl {
                     path: file,
-                    url: self.target_base_url.to_owned(),
+                    url: self.targets_base_url.to_owned(),
                 })?,
                 target.length,
                 "targets.json",

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -34,7 +34,7 @@ fn test_tuf_reference_impl() {
     let datastore = TempDir::new().unwrap();
 
     let metadata_base_url = &dir_url(base.join("metadata"));
-    let target_base_url = &dir_url(base.join("targets"));
+    let targets_base_url = &dir_url(base.join("targets"));
 
     let repo = Repository::load(
         &tough::FilesystemTransport,
@@ -42,7 +42,7 @@ fn test_tuf_reference_impl() {
             root: File::open(base.join("metadata").join("1.root.json")).unwrap(),
             datastore: datastore.as_ref(),
             metadata_base_url,
-            target_base_url,
+            targets_base_url,
             limits: Limits::default(),
         },
     )

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - (Unreleased)
+### Added
+- Accommodate `tough`'s change from `target_base_url` to `targets_base_url`.
+
 ## [0.3.0] - 2020-02-11
 ### Added
 - Added the `refresh` command for refreshing metadata files.

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.3.0"
+version = "0.3.1"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -33,7 +33,7 @@ structopt = "0.3"
 tempfile = "3.1.0"
 url = "2.1.0"
 walkdir = "2.2.9"
-tough = { version = "0.4.0", path = "../tough", features = ["http"] }
+tough = { version = "0.5.0", path = "../tough", features = ["http"] }
 
 [dev-dependencies]
 assert_cmd = "0.12"

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -28,7 +28,7 @@ pub(crate) struct DownloadArgs {
 
     /// TUF repository target base URL
     #[structopt(short = "t", long = "target-url")]
-    target_base_url: String,
+    targets_base_url: String,
 
     /// Allow downloading the root.json file (unsafe)
     #[structopt(long)]
@@ -97,7 +97,7 @@ impl DownloadArgs {
                 root: File::open(&root_path).context(error::OpenRoot { path: &root_path })?,
                 datastore: repo_dir.path(),
                 metadata_base_url: &self.metadata_base_url,
-                target_base_url: &self.target_base_url,
+                targets_base_url: &self.targets_base_url,
                 limits: Limits {
                     ..tough::Limits::default()
                 },

--- a/tuftool/src/refresh.rs
+++ b/tuftool/src/refresh.rs
@@ -83,7 +83,7 @@ impl RefreshArgs {
             root: File::open(&self.root).unwrap(),
             datastore: self.workdir.as_path(),
             metadata_base_url: self.metadata_base_url.as_str(),
-            target_base_url: self.metadata_base_url.as_str(),
+            targets_base_url: self.metadata_base_url.as_str(),
             limits: Limits::default(),
         };
 

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -53,14 +53,14 @@ fn create_command() {
 
     // Load our newly created repo
     let metadata_base_url = &utl::dir_url(repo_dir.path().join("metadata"));
-    let target_base_url = &utl::dir_url(repo_dir.path().join("targets"));
+    let targets_base_url = &utl::dir_url(repo_dir.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
             datastore: load_dir.as_ref(),
             metadata_base_url,
-            target_base_url,
+            targets_base_url,
             limits: Limits::default(),
         },
     )

--- a/tuftool/tests/refresh_command.rs
+++ b/tuftool/tests/refresh_command.rs
@@ -64,7 +64,7 @@ fn refresh_command() {
 
     // Use the refresh command to update the expiration dates.
     let metadata_base_url = &utl::dir_url(repo_dir.path().join("metadata"));
-    let target_base_url = &utl::dir_url(repo_dir.path().join("targets"));
+    let targets_base_url = &utl::dir_url(repo_dir.path().join("targets"));
     Command::cargo_bin("tuftool")
         .unwrap()
         .args(&[
@@ -113,7 +113,7 @@ fn refresh_command() {
             root: File::open(root_json).unwrap(),
             datastore: load_dir.as_ref(),
             metadata_base_url,
-            target_base_url,
+            targets_base_url,
             limits: Limits::default(),
         },
     )


### PR DESCRIPTION
*Issue #, if available:*

#65 

*Description of changes:*

`targets_base_url` is a better name than `target_base_url` because it is more consistent with the naming throughout tough, tuftool and the tuf spec. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing Done*
`cargo test` at the workspace level.