### PR TITLE
refactor Command::run because it was too long

### DIFF
--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -100,136 +100,157 @@ macro_rules! role_keys {
 }
 
 impl Command {
-    #[allow(clippy::too_many_lines)] // #21
     pub(crate) fn run(&self) -> Result<()> {
         match self {
-            Command::Init { path } => write_file(
-                path,
-                &Signed {
-                    signed: Root {
-                        spec_version: crate::SPEC_VERSION.to_owned(),
-                        consistent_snapshot: true,
-                        version: NonZeroU64::new(1).unwrap(),
-                        expires: round_time(Utc::now()),
-                        keys: HashMap::new(),
-                        roles: hashmap! {
-                            RoleType::Root => role_keys!(),
-                            RoleType::Snapshot => role_keys!(),
-                            RoleType::Targets => role_keys!(),
-                            RoleType::Timestamp => role_keys!(),
-                        },
-                        _extra: HashMap::new(),
-                    },
-                    signatures: Vec::new(),
-                },
-            ),
-            Command::BumpVersion { path } => {
-                let mut root: Signed<Root> = load_file(path)?;
-                root.signed.version = NonZeroU64::new(
-                    root.signed
-                        .version
-                        .get()
-                        .checked_add(1)
-                        .context(error::VersionOverflow)?,
-                )
-                .context(error::VersionZero)?;
-                clear_sigs(&mut root);
-                write_file(path, &root)
-            }
-            Command::Expire { path, time } => {
-                let mut root: Signed<Root> = load_file(path)?;
-                root.signed.expires = round_time(*time);
-                clear_sigs(&mut root);
-                write_file(path, &root)
-            }
+            Command::Init { path } => Command::init(path),
+            Command::BumpVersion { path } => Command::bump_version(path),
+            Command::Expire { path, time } => Command::expire(path, time),
             Command::SetThreshold {
                 path,
                 role,
                 threshold,
-            } => {
-                let mut root: Signed<Root> = load_file(path)?;
-                root.signed
-                    .roles
-                    .entry(*role)
-                    .and_modify(|rk| rk.threshold = *threshold)
-                    .or_insert_with(|| role_keys!(*threshold));
-                clear_sigs(&mut root);
-                write_file(path, &root)
-            }
+            } => Command::set_threshold(path, *role, *threshold),
             Command::AddKey {
                 path,
                 roles,
                 key_path,
-            } => {
-                let mut root: Signed<Root> = load_file(path)?;
-                let key_pair = key_path.as_public_key()?;
-                let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair)?);
-                clear_sigs(&mut root);
-                println!("{}", key_id);
-                write_file(path, &root)
-            }
-            Command::RemoveKey { path, key_id, role } => {
-                let mut root: Signed<Root> = load_file(path)?;
-                if let Some(role) = role {
-                    if let Some(role_keys) = root.signed.roles.get_mut(role) {
-                        role_keys
-                            .keyids
-                            .iter()
-                            .position(|k| k.eq(key_id))
-                            .map(|pos| role_keys.keyids.remove(pos));
-                    }
-                } else {
-                    for role_keys in root.signed.roles.values_mut() {
-                        role_keys
-                            .keyids
-                            .iter()
-                            .position(|k| k.eq(key_id))
-                            .map(|pos| role_keys.keyids.remove(pos));
-                    }
-                    root.signed.keys.remove(key_id);
-                }
-                clear_sigs(&mut root);
-                write_file(path, &root)
-            }
+            } => Command::add_key(path, roles, key_path),
+            Command::RemoveKey { path, key_id, role } => Command::remove_key(path, key_id, *role),
             Command::GenRsaKey {
                 path,
                 roles,
                 key_path,
                 bits,
                 exponent,
-            } => {
-                let mut root: Signed<Root> = load_file(path)?;
-
-                // ring doesn't support RSA key generation yet
-                // https://github.com/briansmith/ring/issues/219
-                let mut command = std::process::Command::new("openssl");
-                command.args(&["genpkey", "-algorithm", "RSA", "-pkeyopt"]);
-                command.arg(format!("rsa_keygen_bits:{}", bits));
-                command.arg("-pkeyopt");
-                command.arg(format!("rsa_keygen_pubexp:{}", exponent));
-
-                let command_str = format!("{:?}", command);
-                let output = command.output().context(error::CommandExec {
-                    command_str: &command_str,
-                })?;
-                ensure!(
-                    output.status.success(),
-                    error::CommandStatus {
-                        command_str: &command_str,
-                        status: output.status
-                    }
-                );
-                let stdout =
-                    String::from_utf8(output.stdout).context(error::CommandUtf8 { command_str })?;
-
-                let key_pair = parse_keypair(stdout.as_bytes()).context(error::KeyPairParse)?;
-                let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.tuf_key())?);
-                key_path.write(&stdout, &key_id)?;
-                clear_sigs(&mut root);
-                println!("{}", key_id);
-                write_file(path, &root)
-            }
+            } => Command::gen_rsa_key(path, roles, key_path, *bits, *exponent),
         }
+    }
+
+    fn init(path: &PathBuf) -> Result<()> {
+        write_file(
+            path,
+            &Signed {
+                signed: Root {
+                    spec_version: crate::SPEC_VERSION.to_owned(),
+                    consistent_snapshot: true,
+                    version: NonZeroU64::new(1).unwrap(),
+                    expires: round_time(Utc::now()),
+                    keys: HashMap::new(),
+                    roles: hashmap! {
+                        RoleType::Root => role_keys!(),
+                        RoleType::Snapshot => role_keys!(),
+                        RoleType::Targets => role_keys!(),
+                        RoleType::Timestamp => role_keys!(),
+                    },
+                    _extra: HashMap::new(),
+                },
+                signatures: Vec::new(),
+            },
+        )
+    }
+
+    fn bump_version(path: &PathBuf) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        root.signed.version = NonZeroU64::new(
+            root.signed
+                .version
+                .get()
+                .checked_add(1)
+                .context(error::VersionOverflow)?,
+        )
+        .context(error::VersionZero)?;
+        clear_sigs(&mut root);
+        write_file(path, &root)
+    }
+
+    fn expire(path: &PathBuf, time: &DateTime<Utc>) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        root.signed.expires = round_time(*time);
+        clear_sigs(&mut root);
+        write_file(path, &root)
+    }
+
+    fn set_threshold(path: &PathBuf, role: RoleType, threshold: NonZeroU64) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        root.signed
+            .roles
+            .entry(role)
+            .and_modify(|rk| rk.threshold = threshold)
+            .or_insert_with(|| role_keys!(threshold));
+        clear_sigs(&mut root);
+        write_file(path, &root)
+    }
+
+    fn add_key(path: &PathBuf, roles: &[RoleType], key_path: &KeySource) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        let key_pair = key_path.as_public_key()?;
+        let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair)?);
+        clear_sigs(&mut root);
+        println!("{}", key_id);
+        write_file(path, &root)
+    }
+
+    fn remove_key(path: &PathBuf, key_id: &Decoded<Hex>, role: Option<RoleType>) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        if let Some(role) = role {
+            if let Some(role_keys) = root.signed.roles.get_mut(&role) {
+                role_keys
+                    .keyids
+                    .iter()
+                    .position(|k| k.eq(key_id))
+                    .map(|pos| role_keys.keyids.remove(pos));
+            }
+        } else {
+            for role_keys in root.signed.roles.values_mut() {
+                role_keys
+                    .keyids
+                    .iter()
+                    .position(|k| k.eq(key_id))
+                    .map(|pos| role_keys.keyids.remove(pos));
+            }
+            root.signed.keys.remove(key_id);
+        }
+        clear_sigs(&mut root);
+        write_file(path, &root)
+    }
+
+    fn gen_rsa_key(
+        path: &PathBuf,
+        roles: &[RoleType],
+        key_path: &KeySource,
+        bits: u16,
+        exponent: u32,
+    ) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+
+        // ring doesn't support RSA key generation yet
+        // https://github.com/briansmith/ring/issues/219
+        let mut command = std::process::Command::new("openssl");
+        command.args(&["genpkey", "-algorithm", "RSA", "-pkeyopt"]);
+        command.arg(format!("rsa_keygen_bits:{}", bits));
+        command.arg("-pkeyopt");
+        command.arg(format!("rsa_keygen_pubexp:{}", exponent));
+
+        let command_str = format!("{:?}", command);
+        let output = command.output().context(error::CommandExec {
+            command_str: &command_str,
+        })?;
+        ensure!(
+            output.status.success(),
+            error::CommandStatus {
+                command_str: &command_str,
+                status: output.status
+            }
+        );
+        let stdout =
+            String::from_utf8(output.stdout).context(error::CommandUtf8 { command_str })?;
+
+        let key_pair = parse_keypair(stdout.as_bytes()).context(error::KeyPairParse)?;
+        let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.tuf_key())?);
+        key_path.write(&stdout, &key_id)?;
+        clear_sigs(&mut root);
+        println!("{}", key_id);
+        write_file(path, &root)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

#21

*Description of changes:*

Clippy had identified `Command::run` in `tuftool/src/root.rs` as being too long. Refactored this function breaking each match arm into its own function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing Done*

`cargo test` at the workspace level.
Also some of the nit-level type changes were to pacify clippy, so clippy was part of the testing workflow as well.