### PR TITLE
tough: add method for caching a repo with its metadata

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -1,0 +1,209 @@
+use crate::error::{self, Result};
+use crate::fetch::{fetch_max_size, fetch_sha256};
+use crate::schema::{RoleType, Target};
+use crate::{Repository, Transport};
+use snafu::{OptionExt, ResultExt};
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::Path;
+
+impl<'a, T: Transport> Repository<'a, T> {
+    /// Cache an entire or partial repository to disk, including all required metadata.
+    /// The cached repo will be local, using filesystem paths.
+    ///
+    /// * `metadata_outdir` is the directory where cached metadata files will be saved.
+    /// * `targets_outdir` is the directory where cached targets files will be saved.
+    /// * `targets_subset` is the list of targets to include in the cached repo. If no subset is
+    /// specified (`None`), then *all* targets are included in the cache.
+    /// * `cache_root_chain` specifies whether or not we will cache all versions of `root.json`.
+    pub fn cache<P1, P2, S>(
+        &self,
+        metadata_outdir: P1,
+        targets_outdir: P2,
+        targets_subset: Option<&[S]>,
+        cache_root_chain: bool,
+    ) -> Result<()>
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+        S: AsRef<str>,
+    {
+        // Create the output directories if the do not exist.
+        std::fs::create_dir_all(metadata_outdir.as_ref()).context(error::CacheDirectoryCreate {
+            path: metadata_outdir.as_ref(),
+        })?;
+        std::fs::create_dir_all(targets_outdir.as_ref()).context(error::CacheDirectoryCreate {
+            path: targets_outdir.as_ref(),
+        })?;
+
+        // Fetch targets and save them to the outdir
+        if let Some(target_list) = targets_subset {
+            for target_name in target_list.iter() {
+                self.cache_target(&targets_outdir, target_name.as_ref())?;
+            }
+        } else {
+            let targets = &self.targets.signed.targets;
+            for target_name in targets.keys() {
+                self.cache_target(&targets_outdir, target_name)?;
+            }
+        }
+
+        // Save the snapshot, targets and timestamp metadata files, and (optionally) the root files.
+        // TODO - support role delegation https://github.com/awslabs/tough/issues/5
+        self.cache_file_from_transport(
+            self.snapshot_filename().as_str(),
+            self.max_snapshot_size()?,
+            "timestamp.json",
+            &metadata_outdir,
+        )?;
+        self.cache_file_from_transport(
+            self.targets_filename().as_str(),
+            self.limits.max_targets_size,
+            "max_targets_size argument",
+            &metadata_outdir,
+        )?;
+        self.cache_file_from_transport(
+            "timestamp.json",
+            self.limits.max_timestamp_size,
+            "max_timestamp_size argument",
+            &metadata_outdir,
+        )?;
+        if cache_root_chain {
+            // Copy all versions of root.json less than or equal to the current version.
+            for ver in (1..=self.root.signed.version.get()).rev() {
+                let root_json_filename = format!("{}.root.json", ver);
+                self.cache_file_from_transport(
+                    root_json_filename.as_str(),
+                    self.limits.max_root_size,
+                    "max_root_size argument",
+                    &metadata_outdir,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Prepends the version number to the snapshot.json filename if using consistent snapshot mode.
+    fn snapshot_filename(&self) -> String {
+        if self.root.signed.consistent_snapshot {
+            format!("{}.snapshot.json", self.snapshot.signed.version)
+        } else {
+            "snapshot.json".to_owned()
+        }
+    }
+
+    /// Prepends the version number to the targets.json filename if using consistent snapshot mode.
+    fn targets_filename(&self) -> String {
+        if self.root.signed.consistent_snapshot {
+            format!("{}.targets.json", self.targets.signed.version)
+        } else {
+            "targets.json".to_owned()
+        }
+    }
+
+    /// Copies a file using `Transport` to `outdir`.
+    fn cache_file_from_transport<P: AsRef<Path>>(
+        &self,
+        filename: &str,
+        max_size: u64,
+        max_size_specifier: &'static str,
+        outdir: P,
+    ) -> Result<()> {
+        let mut read = fetch_max_size(
+            self.transport,
+            self.metadata_base_url
+                .join(filename)
+                .context(error::JoinUrl {
+                    path: filename,
+                    url: self.metadata_base_url.to_owned(),
+                })?,
+            max_size,
+            max_size_specifier,
+        )?;
+        let outpath = outdir.as_ref().join(&filename);
+        let mut file = std::fs::File::create(&outpath).context(error::CacheFileWrite {
+            path: outpath.clone(),
+        })?;
+        let mut root_file_data = Vec::new();
+        read.read_to_end(&mut root_file_data)
+            .context(error::CacheFileRead {
+                url: self.metadata_base_url.to_owned(),
+            })?;
+        file.write_all(&root_file_data)
+            .context(error::CacheFileWrite { path: outpath })
+    }
+
+    /// Saves a signed target to the specified `outdir`. Retains the digest-prepended filename if
+    /// consistent snapshots are used.
+    fn cache_target<P: AsRef<Path>>(&self, outdir: P, name: &str) -> Result<()> {
+        let t = self
+            .targets
+            .signed
+            .targets
+            .get(name)
+            .context(error::CacheTargetMissing {
+                target_name: name.to_owned(),
+            })?;
+        let (sha, filename) = self.target_digest_and_filename(&t, name);
+        let mut reader = self.fetch_target(t, &sha, filename.as_str())?;
+        let path = outdir.as_ref().join(filename);
+        let mut f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .context(error::CacheTargetWrite { path: path.clone() })?;
+        let _ = std::io::copy(&mut reader, &mut f).context(error::CacheTargetWrite { path })?;
+        Ok(())
+    }
+
+    /// Gets the max size of the snapshot.json file as specified by the timestamp file.
+    fn max_snapshot_size(&self) -> Result<u64> {
+        let snapshot_meta =
+            self.timestamp()
+                .signed
+                .meta
+                .get("snapshot.json")
+                .context(error::MetaMissing {
+                    file: "snapshot.json",
+                    role: RoleType::Timestamp,
+                })?;
+        Ok(snapshot_meta.length)
+    }
+
+    /// Prepends the target digest to the name if using consistent snapshots. Returns both the
+    /// digest and the filename.
+    pub(crate) fn target_digest_and_filename(
+        &self,
+        target: &Target,
+        name: &str,
+    ) -> (Vec<u8>, String) {
+        let sha256 = &target.hashes.sha256.clone().into_vec();
+        if self.consistent_snapshot {
+            (sha256.clone(), format!("{}.{}", hex::encode(sha256), name))
+        } else {
+            (sha256.clone(), name.to_owned())
+        }
+    }
+
+    /// Fetches the signed target using `Transport`. Aborts with error if the fetched target is
+    /// larger than its signed size.
+    pub(crate) fn fetch_target(
+        &self,
+        target: &Target,
+        digest: &[u8],
+        filename: &str,
+    ) -> Result<impl Read> {
+        fetch_sha256(
+            self.transport,
+            self.targets_base_url
+                .join(&filename)
+                .context(error::JoinUrl {
+                    path: filename,
+                    url: self.targets_base_url.to_owned(),
+                })?,
+            target.length,
+            "targets.json",
+            digest,
+        )
+    }
+}

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -9,6 +9,7 @@ use crate::schema::RoleType;
 use chrono::{DateTime, Utc};
 use snafu::{Backtrace, Snafu};
 use std::path::PathBuf;
+use url::Url;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -212,6 +213,40 @@ pub enum Error {
         role: RoleType,
         fetched: u64,
         expected: u64,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Error reading data from '{}': {}", url, source))]
+    CacheFileRead {
+        url: Url,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Error writing data to '{}': {}", path.display(), source))]
+    CacheFileWrite {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Error creating the directory '{}': {}", path.display(), source))]
+    CacheDirectoryCreate {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Error writing target file to '{}': {}", path.display(), source))]
+    CacheTargetWrite {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("The target '{}' was not found", target_name))]
+    CacheTargetMissing {
+        target_name: String,
         backtrace: Backtrace,
     },
 }

--- a/tough/src/io.rs
+++ b/tough/src/io.rs
@@ -54,6 +54,9 @@ impl<T: Read> Read for DigestAdapter<T> {
 
 pub(crate) struct MaxSizeAdapter<T> {
     reader: T,
+    /// How the `max_size` was specified. For example the max size of `root.json` is specified by
+    /// the `max_root_size` argument in `Settings`. `specifier` is used to construct an error
+    /// message when the `MaxSizeAdapter` detects that too many bytes have been read.
     specifier: &'static str,
     max_size: u64,
     counter: u64,

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -3,10 +3,11 @@
 
 use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+use test_utils::{dir_url, test_data};
 use tough::{Limits, Repository, Settings};
-use url::Url;
+
+mod test_utils;
 
 #[cfg(feature = "http")]
 use tough::HttpTransport;
@@ -17,15 +18,8 @@ use mockito::mock;
 #[cfg(feature = "http")]
 use std::str::FromStr;
 
-fn test_data() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("data")
-}
-
-fn dir_url<P: AsRef<Path>>(path: P) -> String {
-    Url::from_directory_path(path).unwrap().to_string()
-}
+#[cfg(feature = "http")]
+use url::Url;
 
 fn read_to_end<R: Read>(mut reader: R) -> Vec<u8> {
     let mut v = Vec::new();

--- a/tough/tests/repo_cache.rs
+++ b/tough/tests/repo_cache.rs
@@ -1,0 +1,209 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use test_utils::{dir_url, test_data};
+use tough::{FilesystemTransport, Limits, Repository, Settings};
+
+mod test_utils;
+
+struct RepoPaths {
+    root_path: PathBuf,
+    datastore: TempDir,
+    metadata_base_url: String,
+    targets_base_url: String,
+}
+
+impl RepoPaths {
+    fn new() -> Self {
+        let base = test_data().join("tuf-reference-impl");
+        RepoPaths {
+            root_path: base.join("metadata").join("1.root.json"),
+            datastore: TempDir::new().unwrap(),
+            metadata_base_url: dir_url(base.join("metadata")),
+            targets_base_url: dir_url(base.join("targets")),
+        }
+    }
+
+    fn root(&self) -> File {
+        File::open(&self.root_path).unwrap()
+    }
+}
+
+fn load_tuf_reference_impl<'a>(paths: &'a mut RepoPaths) -> Repository<'a, FilesystemTransport> {
+    Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: &mut paths.root(),
+            datastore: paths.datastore.as_ref(),
+            metadata_base_url: paths.metadata_base_url.as_str(),
+            targets_base_url: paths.targets_base_url.as_str(),
+            limits: Limits::default(),
+        },
+    )
+    .unwrap()
+}
+
+/// Test that the repo.cache() function works when given a list of multiple targets.
+#[test]
+fn test_repo_cache_all_targets() {
+    // load the reference_impl repo
+    let mut repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&mut repo_paths);
+
+    // cache the repo for future use
+    let destination = TempDir::new().unwrap();
+    let metadata_destination = destination.as_ref().join("metadata");
+    let targets_destination = destination.as_ref().join("targets");
+    repo.cache(
+        &metadata_destination,
+        &targets_destination,
+        None::<&[&str]>,
+        true,
+    )
+    .unwrap();
+
+    // check that we can load the copied repo.
+    let datastore = TempDir::new().unwrap();
+    let metadata_base_url = dir_url(&metadata_destination);
+    let targets_base_url = dir_url(&targets_destination);
+    let copied_repo = Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: repo_paths.root(),
+            datastore: datastore.as_ref(),
+            metadata_base_url: metadata_base_url.as_str(),
+            targets_base_url: targets_base_url.as_str(),
+            limits: Limits::default(),
+        },
+    )
+    .unwrap();
+
+    // the copied repo should have file1 and file2 (i.e. all of targets).
+    let mut file_data = Vec::new();
+    let file_size = copied_repo
+        .read_target("file1.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(31, file_size);
+
+    let mut file_data = Vec::new();
+    let file_size = copied_repo
+        .read_target("file2.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(39, file_size);
+}
+
+/// Test that the repo.cache() function works when given a list of multiple targets.
+#[test]
+fn test_repo_cache_list_of_two_targets() {
+    // load the reference_impl repo
+    let mut repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&mut repo_paths);
+
+    // cache the repo for future use
+    let destination = TempDir::new().unwrap();
+    let metadata_destination = destination.as_ref().join("metadata");
+    let targets_destination = destination.as_ref().join("targets");
+    let targets_subset = vec!["file1.txt".to_string(), "file2.txt".to_string()];
+    repo.cache(
+        &metadata_destination,
+        &targets_destination,
+        Some(&targets_subset),
+        true,
+    )
+    .unwrap();
+
+    // check that we can load the copied repo.
+    let datastore = TempDir::new().unwrap();
+    let metadata_base_url = dir_url(&metadata_destination);
+    let targets_base_url = dir_url(&targets_destination);
+    let copied_repo = Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: repo_paths.root(),
+            datastore: datastore.as_ref(),
+            metadata_base_url: metadata_base_url.as_str(),
+            targets_base_url: targets_base_url.as_str(),
+            limits: Limits::default(),
+        },
+    )
+    .unwrap();
+
+    // the copied repo should have file1 and file2 (i.e. all of the listed targets).
+    let mut file_data = Vec::new();
+    let file_size = copied_repo
+        .read_target("file1.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(31, file_size);
+
+    let mut file_data = Vec::new();
+    let file_size = copied_repo
+        .read_target("file2.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(39, file_size);
+}
+
+/// Test that the repo.cache() function works when given a list of only one of the targets.
+#[test]
+fn test_repo_cache_some() {
+    // load the reference_impl repo
+    let mut repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&mut repo_paths);
+
+    // cache the repo for future use
+    let destination = TempDir::new().unwrap();
+    let metadata_destination = destination.as_ref().join("metadata");
+    let targets_destination = destination.as_ref().join("targets");
+    let targets_subset = vec!["file2.txt".to_string()];
+    repo.cache(
+        &metadata_destination,
+        &targets_destination,
+        Some(&targets_subset),
+        true,
+    )
+    .unwrap();
+
+    // check that we can load the copied repo.
+    let datastore = TempDir::new().unwrap();
+    let metadata_base_url = dir_url(&metadata_destination);
+    let targets_base_url = dir_url(&targets_destination);
+    let copied_repo = Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: repo_paths.root(),
+            datastore: datastore.as_ref(),
+            metadata_base_url: metadata_base_url.as_str(),
+            targets_base_url: targets_base_url.as_str(),
+            limits: Limits::default(),
+        },
+    )
+    .unwrap();
+
+    // the copied repo should have file2 but not file1 (i.e. only the listed targets).
+    let read_target_result = copied_repo.read_target("file1.txt");
+    assert!(read_target_result.is_err());
+
+    let mut file_data = Vec::new();
+    let file_size = copied_repo
+        .read_target("file2.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(39, file_size);
+}

--- a/tough/tests/test_utils.rs
+++ b/tough/tests/test_utils.rs
@@ -1,0 +1,17 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// Returns the path to our test data directory
+pub fn test_data() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("data")
+}
+
+/// Converts a filepath into a URI formatted string
+pub fn dir_url<P: AsRef<Path>>(path: P) -> String {
+    Url::from_directory_path(path).unwrap().to_string()
+}

--- a/tuftool/src/source.rs
+++ b/tuftool/src/source.rs
@@ -16,9 +16,6 @@ use tough::schema::key::Key;
 use tough::sign::{parse_keypair, Sign};
 use url::Url;
 
-#[cfg(any(feature = "rusoto-native-tls", feature = "rusoto-rustls"))]
-use tokio;
-
 #[derive(Debug)]
 pub(crate) enum KeySource {
     Local(PathBuf),


### PR DESCRIPTION
*Issue #, if available:*

Closes #80
Supports  https://github.com/bottlerocket-os/bottlerocket/issues/91
Supports https://github.com/bottlerocket-os/bottlerocket/issues/905

*Description of changes:*

In support of Bottlerocket's datastore migrations, we need to locally cache TUF targets along with the metadata that they were signed with.
This PR adds a function, named `cache` to the `Repository` object, which takes a list of targets, and stores them along with the repo metadata into directories for future use.

*Testing Performed*

Ran existing unit/integ tests and added integ tests for the new cache function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
