### PR TITLE
Add `from_path()` to Target

### DIFF
--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -5,6 +5,7 @@
 use crate::schema::RoleType;
 use snafu::{Backtrace, Snafu};
 use std::fmt::{self, Debug, Display};
+use std::path::PathBuf;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -16,6 +17,22 @@ pub enum Error {
     /// A duplicate key ID was present in the root metadata.
     #[snafu(display("Duplicate key ID: {}", keyid))]
     DuplicateKeyId { keyid: String },
+
+    /// Unable to open a file
+    #[snafu(display("Failed to open '{}': {}", path.display(), source))]
+    FileOpen {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    /// Unable to read the file
+    #[snafu(display("Failed to read '{}': {}", path.display(), source))]
+    FileRead {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
 
     /// A downloaded target's checksum does not match the checksum listed in the repository
     /// metadata.
@@ -72,6 +89,10 @@ pub enum Error {
     /// Failed to extract a bit string from a `SubjectPublicKeyInfo` document.
     #[snafu(display("Invalid SubjectPublicKeyInfo document"))]
     SpkiDecode { backtrace: Backtrace },
+
+    /// Unable to create a TUF target from anything but a file
+    #[snafu(display("TUF targets must be files, given: '{}'", path.display()))]
+    TargetNotAFile { path: PathBuf, backtrace: Backtrace },
 }
 
 /// Wrapper for error types that don't impl [`std::error::Error`].


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This function allows you to get a Target object from a given Path, provided it is a file.

This code comes from a piece of `tuftool/src/create.rs` and will be wholesale removed from `tuftool` in an upcoming PR. I opted to split this small change up into its own PR as the upcoming changes are much much further reaching and this is small and easy to review.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
