### PR TITLE
Adds RepositoryEditor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -21,6 +21,7 @@ serde_plain = "0.3.0"
 snafu = "0.6.8"
 untrusted = "0.7.0"
 url = "2.1.0"
+walkdir = "2.2.9"
 
 [dev-dependencies]
 hex-literal = "0.2.0"

--- a/tough/src/editor/keys.rs
+++ b/tough/src/editor/keys.rs
@@ -1,0 +1,32 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+use crate::error::{self, Result};
+use crate::key_source::KeySource;
+use crate::schema::decoded::{Decoded, Hex};
+use crate::schema::Root;
+use crate::sign::Sign;
+use snafu::{ensure, ResultExt};
+use std::collections::HashMap;
+
+/// A map of key ID (from root.json) to its corresponding signing key
+pub(crate) type RootKeys = HashMap<Decoded<Hex>, Box<dyn Sign>>;
+
+/// Gets the corresponding keys from Root (root.json) for the given `KeySource`s.
+/// This is a convenience function that wraps `Root.key_id()` for multiple
+/// `KeySource`s.
+pub(crate) fn get_root_keys(root: &Root, keys: &[Box<dyn KeySource>]) -> Result<RootKeys> {
+    let mut root_keys = RootKeys::new();
+
+    for source in keys {
+        // Get a keypair from the given source
+        let key_pair = source.as_sign().context(error::KeyPairFromKeySource)?;
+
+        // If the keypair matches any of the keys in the root.json,
+        // add its ID and corresponding keypair the map to be returned
+        if let Some(key_id) = root.key_id(key_pair.as_ref()) {
+            root_keys.insert(key_id, key_pair);
+        }
+    }
+    ensure!(!root_keys.is_empty(), error::KeysNotFoundInRoot);
+    Ok(root_keys)
+}

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -1,0 +1,383 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+#![allow(clippy::used_underscore_binding)] // #20
+
+mod keys;
+pub mod signed;
+mod test;
+
+use crate::editor::signed::{SignedRepository, SignedRole};
+use crate::error::{self, Result};
+use crate::key_source::KeySource;
+use crate::schema::{
+    Hashes, Role, Root, Signed, Snapshot, SnapshotMeta, Target, Targets, Timestamp, TimestampMeta,
+};
+use crate::transport::Transport;
+use crate::Repository;
+use chrono::{DateTime, Utc};
+use ring::digest::{SHA256, SHA256_OUTPUT_LEN};
+use ring::rand::SystemRandom;
+use serde_json::Value;
+use snafu::{ensure, OptionExt, ResultExt};
+use std::collections::HashMap;
+use std::num::NonZeroU64;
+use std::path::Path;
+
+const SPEC_VERSION: &str = "1.0.0";
+
+/// `RepositoryEditor` contains the various bits of data needed to construct
+/// or edit a TUF repository.
+///
+/// A new repository may be started using the `new()` method.
+///
+/// An existing `tough::Repository` may be loaded and edited using the
+/// `from_repo()` method. When a repo is loaded in this way, versions and
+/// expirations are discarded. It is good practice to update these whenever
+/// a repo is changed.
+///
+/// Targets, versions, and expirations may be added to their respective roles
+/// via the provided "setter" methods. The final step in the process is the
+/// `sign()` method, which takes a given set of signing keys, builds each of
+/// the roles using the data provided, and signs the roles. This results in a
+/// `SignedRepository` which can be used to write the repo to disk.
+#[derive(Debug)]
+pub struct RepositoryEditor {
+    signed_root: SignedRole<Root>,
+
+    new_targets: Option<HashMap<String, Target>>,
+    existing_targets: Option<HashMap<String, Target>>,
+    targets_version: Option<NonZeroU64>,
+    targets_expires: Option<DateTime<Utc>>,
+    targets_extra: Option<HashMap<String, Value>>,
+
+    snapshot_version: Option<NonZeroU64>,
+    snapshot_expires: Option<DateTime<Utc>>,
+    snapshot_extra: Option<HashMap<String, Value>>,
+
+    timestamp_version: Option<NonZeroU64>,
+    timestamp_expires: Option<DateTime<Utc>>,
+    timestamp_extra: Option<HashMap<String, Value>>,
+}
+
+impl RepositoryEditor {
+    /// Create a new, bare `RepositoryEditor`
+    pub fn new<P>(root_path: P) -> Result<RepositoryEditor>
+    where
+        P: AsRef<Path>,
+    {
+        // Read and parse the root.json. Without a good root, it doesn't
+        // make sense to continue
+        let root_path = root_path.as_ref();
+        let root_buf = std::fs::read(root_path).context(error::FileRead { path: root_path })?;
+        let root_buf_len = root_buf.len() as u64;
+        let root = serde_json::from_slice::<Signed<Root>>(&root_buf)
+            .context(error::FileParseJson { path: root_path })?;
+        let mut digest = [0; SHA256_OUTPUT_LEN];
+        digest.copy_from_slice(ring::digest::digest(&SHA256, &root_buf).as_ref());
+
+        let signed_root = SignedRole {
+            signed: root,
+            buffer: root_buf,
+            sha256: digest,
+            length: root_buf_len,
+        };
+
+        Ok(RepositoryEditor {
+            signed_root,
+            new_targets: None,
+            existing_targets: None,
+            targets_version: None,
+            targets_expires: None,
+            targets_extra: None,
+            snapshot_version: None,
+            snapshot_expires: None,
+            snapshot_extra: None,
+            timestamp_version: None,
+            timestamp_expires: None,
+            timestamp_extra: None,
+        })
+    }
+
+    /// Given a `tough::Repository` and the path to a valid root.json, create a
+    /// `RepositoryEditor`. This `RepositoryEditor` will include all of the targets
+    /// and bits of _extra metadata from the roles included. It will not, however,
+    /// include the versions or expirations and the user is expected to set them.
+    pub fn from_repo<T, P>(root_path: P, repo: Repository<'_, T>) -> Result<RepositoryEditor>
+    where
+        P: AsRef<Path>,
+        T: Transport,
+    {
+        let mut editor = RepositoryEditor::new(root_path)?;
+        editor.targets(repo.targets.signed)?;
+        editor.snapshot(repo.snapshot.signed)?;
+        editor.timestamp(repo.timestamp.signed)?;
+
+        Ok(editor)
+    }
+
+    /// Builds and signs each required role and returns a complete signed set
+    /// of TUF repository metadata.
+    ///
+    /// While `RepositoryEditor`s fields are all `Option`s, this step requires,
+    /// at the very least, that the "version" and "expiration" field is set for
+    /// each role; e.g. `targets_version`, `targets_expires`, etc.
+    pub fn sign(self, keys: &[Box<dyn KeySource>]) -> Result<SignedRepository> {
+        let rng = SystemRandom::new();
+        let root = &self.signed_root.signed.signed;
+
+        let signed_targets = self
+            .build_targets()
+            .and_then(|targets| SignedRole::new(targets, root, keys, &rng))?;
+        let signed_snapshot = self
+            .build_snapshot(&signed_targets)
+            .and_then(|snapshot| SignedRole::new(snapshot, root, keys, &rng))?;
+        let signed_timestamp = self
+            .build_timestamp(&signed_snapshot)
+            .and_then(|timestamp| SignedRole::new(timestamp, root, keys, &rng))?;
+
+        Ok(SignedRepository {
+            root: self.signed_root,
+            targets: signed_targets,
+            snapshot: signed_snapshot,
+            timestamp: signed_timestamp,
+        })
+    }
+
+    /// Add an existing `Targets` struct to the repository. Any `Target`
+    /// objects contained in the `Targets` struct will be preserved in
+    /// `self.existing_targets`
+    pub fn targets(&mut self, targets: Targets) -> Result<&mut Self> {
+        ensure!(
+            targets.spec_version == SPEC_VERSION,
+            error::SpecVersion {
+                given: targets.spec_version,
+                supported: SPEC_VERSION
+            }
+        );
+
+        // Hold on to the existing targets
+        self.existing_targets = Some(targets.targets);
+        self.targets_extra = Some(targets._extra);
+        Ok(self)
+    }
+
+    /// Add an existing `Snapshot` to the repository. Only the `_extra` data
+    /// is preserved
+    pub fn snapshot(&mut self, snapshot: Snapshot) -> Result<&mut Self> {
+        ensure!(
+            snapshot.spec_version == SPEC_VERSION,
+            error::SpecVersion {
+                given: snapshot.spec_version,
+                supported: SPEC_VERSION
+            }
+        );
+        self.snapshot_extra = Some(snapshot._extra);
+        Ok(self)
+    }
+
+    /// Add an existing `Timestamp` to the repository. Only the `_extra` data
+    /// is preserved
+    pub fn timestamp(&mut self, timestamp: Timestamp) -> Result<&mut Self> {
+        ensure!(
+            timestamp.spec_version == SPEC_VERSION,
+            error::SpecVersion {
+                given: timestamp.spec_version,
+                supported: SPEC_VERSION
+            }
+        );
+        self.timestamp_extra = Some(timestamp._extra);
+        Ok(self)
+    }
+
+    /// Add a target to the repository using its path
+    pub fn add_target<P>(&mut self, target_path: P) -> Result<&mut Self>
+    where
+        P: AsRef<Path>,
+    {
+        let target_path = target_path.as_ref();
+
+        // Build a Target from the path given. If it is not a file, this will fail
+        let target =
+            Target::from_path(target_path).context(error::TargetFromPath { path: target_path })?;
+
+        // Get the file name as a string
+        let target_name = target_path
+            .file_name()
+            .context(error::NoFileName { path: target_path })?
+            .to_str()
+            .context(error::PathUtf8 { path: target_path })?
+            .to_owned();
+
+        self.new_targets
+            .get_or_insert_with(HashMap::new)
+            .insert(target_name, target);
+        Ok(self)
+    }
+
+    /// Add a list of target paths to the repository
+    pub fn add_targets<P>(&mut self, targets: Vec<P>) -> Result<&mut Self>
+    where
+        P: AsRef<Path>,
+    {
+        for target in targets {
+            self.add_target(target)?;
+        }
+        Ok(self)
+    }
+
+    /// Remove all targets from this repo
+    pub fn clear_targets(&mut self) -> &mut Self {
+        self.existing_targets
+            .get_or_insert_with(HashMap::new)
+            .clear();
+        self.new_targets.get_or_insert_with(HashMap::new).clear();
+        self
+    }
+
+    /// Set the `Snapshot` version
+    pub fn snapshot_version(&mut self, snapshot_version: NonZeroU64) -> &mut Self {
+        self.snapshot_version = Some(snapshot_version);
+        self
+    }
+
+    /// Set the `Snapshot` expiration
+    pub fn snapshot_expires(&mut self, snapshot_expires: DateTime<Utc>) -> &mut Self {
+        self.snapshot_expires = Some(snapshot_expires);
+        self
+    }
+
+    /// Set the `Targets` version
+    pub fn targets_version(&mut self, targets_version: NonZeroU64) -> &mut Self {
+        self.targets_version = Some(targets_version);
+        self
+    }
+
+    /// Set the `Targets` expiration
+    pub fn targets_expires(&mut self, targets_expires: DateTime<Utc>) -> &mut Self {
+        self.targets_expires = Some(targets_expires);
+        self
+    }
+
+    /// Set the `Timestamp` version
+    pub fn timestamp_version(&mut self, timestamp_version: NonZeroU64) -> &mut Self {
+        self.timestamp_version = Some(timestamp_version);
+        self
+    }
+
+    /// Set the `Timestamp` expiration
+    pub fn timestamp_expires(&mut self, timestamp_expires: DateTime<Utc>) -> &mut Self {
+        self.timestamp_expires = Some(timestamp_expires);
+        self
+    }
+
+    // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+    /// Build the `Targets` struct
+    fn build_targets(&self) -> Result<Targets> {
+        let version = self.targets_version.context(error::Missing {
+            field: "targets version",
+        })?;
+        let expires = self.targets_expires.context(error::Missing {
+            field: "targets expiration",
+        })?;
+
+        // BEWARE!!! We are allowing targets to be empty! While this isn't
+        // the most common use case, it's possible this is what a user wants.
+        // If it's important to have a non-empty targets, the object can be
+        // inspected by the calling code.
+        let mut targets: HashMap<String, Target> = HashMap::new();
+        if let Some(ref existing_targets) = self.existing_targets {
+            targets.extend(existing_targets.clone());
+        }
+        if let Some(ref new_targets) = self.new_targets {
+            targets.extend(new_targets.clone());
+        }
+
+        let _extra = self.targets_extra.clone().unwrap_or_else(HashMap::new);
+        Ok(Targets {
+            spec_version: SPEC_VERSION.to_string(),
+            version,
+            expires,
+            targets,
+            _extra,
+        })
+    }
+
+    /// Build the `Snapshot` struct
+    fn build_snapshot(&self, signed_targets: &SignedRole<Targets>) -> Result<Snapshot> {
+        let version = self.snapshot_version.context(error::Missing {
+            field: "snapshot version",
+        })?;
+        let expires = self.snapshot_expires.context(error::Missing {
+            field: "snapshot expiration",
+        })?;
+        let _extra = self.snapshot_extra.clone().unwrap_or_else(HashMap::new);
+
+        let mut snapshot = Snapshot::new(SPEC_VERSION.to_string(), version, expires);
+
+        // Snapshot stores metadata about targets and root
+        let targets_meta = Self::snapshot_meta(signed_targets);
+        let root_meta = Self::snapshot_meta(&self.signed_root);
+        snapshot
+            .meta
+            .insert("targets.json".to_owned(), targets_meta);
+        snapshot.meta.insert("root.json".to_owned(), root_meta);
+
+        Ok(snapshot)
+    }
+
+    /// Build a `SnapshotMeta` struct from a given `SignedRole<T>`. This metadata
+    /// includes the sha256 and length of the signed role.
+    fn snapshot_meta<T>(role: &SignedRole<T>) -> SnapshotMeta
+    where
+        T: Role,
+    {
+        SnapshotMeta {
+            hashes: Some(Hashes {
+                sha256: role.sha256.to_vec().into(),
+                _extra: HashMap::new(),
+            }),
+            length: Some(role.length),
+            version: role.signed.signed.version(),
+            _extra: HashMap::new(),
+        }
+    }
+
+    /// Build the `Timestamp` struct
+    fn build_timestamp(&self, signed_snapshot: &SignedRole<Snapshot>) -> Result<Timestamp> {
+        let version = self.timestamp_version.context(error::Missing {
+            field: "timestamp version",
+        })?;
+        let expires = self.timestamp_expires.context(error::Missing {
+            field: "timestamp expiration",
+        })?;
+        let _extra = self.timestamp_extra.clone().unwrap_or_else(HashMap::new);
+        let mut timestamp = Timestamp::new(SPEC_VERSION.to_string(), version, expires);
+
+        // Timestamp stores metadata about snapshot
+        let snapshot_meta = Self::timestamp_meta(signed_snapshot);
+        timestamp
+            .meta
+            .insert("snapshot.json".to_owned(), snapshot_meta);
+        timestamp._extra = _extra;
+
+        Ok(timestamp)
+    }
+
+    /// Build a `TimestampMeta` struct from a given `SignedRole<T>`. This metadata
+    /// includes the sha256 and length of the signed role.
+    fn timestamp_meta<T>(role: &SignedRole<T>) -> TimestampMeta
+    where
+        T: Role,
+    {
+        TimestampMeta {
+            hashes: Hashes {
+                sha256: role.sha256.to_vec().into(),
+                _extra: HashMap::new(),
+            },
+            length: role.length,
+            version: role.signed.signed.version(),
+            _extra: HashMap::new(),
+        }
+    }
+}

--- a/tough/src/editor/signed.rs
+++ b/tough/src/editor/signed.rs
@@ -1,0 +1,249 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::editor::keys::get_root_keys;
+use crate::error::{self, Result};
+use crate::key_source::KeySource;
+use crate::schema::{
+    Role, RoleType, Root, Signature, Signed, Snapshot, Target, Targets, Timestamp,
+};
+use olpc_cjson::CanonicalFormatter;
+use ring::digest::{digest, SHA256, SHA256_OUTPUT_LEN};
+use ring::rand::SecureRandom;
+use serde::Serialize;
+use snafu::{ensure, OptionExt, ResultExt};
+use std::os::unix::fs::symlink;
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// A signed role, including its serialized form (`buffer`) which is meant to
+/// be written to file. The `sha256` and `length` are calculated from this
+/// buffer and included in metadata for other roles, which makes it
+/// imperative that this buffer is what is written to disk.
+///
+/// Convenience methods are provided on `SignedRepository` to ensure that
+/// each role's buffer is written correctly.
+#[derive(Debug, Clone)]
+pub struct SignedRole<T> {
+    pub(crate) signed: Signed<T>,
+    pub(crate) buffer: Vec<u8>,
+    pub(crate) sha256: [u8; SHA256_OUTPUT_LEN],
+    pub(crate) length: u64,
+}
+
+impl<T> SignedRole<T>
+where
+    T: Role + Serialize,
+{
+    pub fn new(
+        role: T,
+        root: &Root,
+        keys: &[Box<dyn KeySource>],
+        rng: &dyn SecureRandom,
+    ) -> Result<Self> {
+        let root_keys = get_root_keys(root, keys)?;
+
+        let role_keys = root.roles.get(&T::TYPE).context(error::NoRoleKeysinRoot {
+            role: T::TYPE.to_string(),
+        })?;
+        // Ensure the keys we have available to us will allow us
+        // to sign this role. The role's key ids must match up with one of
+        // the keys provided.
+        let (signing_key_id, signing_key) = root_keys
+            .iter()
+            .find(|(keyid, _signing_key)| role_keys.keyids.contains(&keyid))
+            .context(error::SigningKeysNotFound {
+                role: T::TYPE.to_string(),
+            })?;
+
+        // Create the `Signed` struct for this role. This struct will be
+        // mutated later to contain the signatures.
+        let mut role = Signed {
+            signed: role,
+            signatures: Vec::new(),
+        };
+
+        let mut data = Vec::new();
+        let mut ser = serde_json::Serializer::with_formatter(&mut data, CanonicalFormatter::new());
+        role.signed
+            .serialize(&mut ser)
+            .context(error::SerializeRole {
+                role: T::TYPE.to_string(),
+            })?;
+        let sig = signing_key.sign(&data, rng)?;
+
+        // Add the signatures to the `Signed` struct for this role
+        role.signatures.push(Signature {
+            keyid: signing_key_id.clone(),
+            sig: sig.into(),
+        });
+
+        // Serialize the newly signed role, and calculate its length and
+        // sha256.
+        let mut buffer = serde_json::to_vec_pretty(&role).context(error::SerializeSignedRole {
+            role: T::TYPE.to_string(),
+        })?;
+        buffer.push(b'\n');
+        let length = buffer.len() as u64;
+
+        let mut sha256 = [0; SHA256_OUTPUT_LEN];
+        sha256.copy_from_slice(digest(&SHA256, &buffer).as_ref());
+
+        // Create the `SignedRole` containing, the `Signed<role>`, serialized
+        // buffer, length and sha256.
+        let signed_role = SignedRole {
+            signed: role,
+            buffer,
+            sha256,
+            length,
+        };
+
+        Ok(signed_role)
+    }
+
+    /// Write the current role's buffer to the given directory with the
+    /// appropriate file name.
+    pub(crate) fn write<P>(&self, outdir: P, consistent_snapshot: bool) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let outdir = outdir.as_ref();
+        std::fs::create_dir_all(outdir).context(error::DirCreate { path: outdir })?;
+
+        let filename = match T::TYPE {
+            RoleType::Targets => {
+                if consistent_snapshot {
+                    format!("{}.targets.json", self.signed.signed.version())
+                } else {
+                    "targets.json".to_string()
+                }
+            }
+            RoleType::Snapshot => {
+                if consistent_snapshot {
+                    format!("{}.snapshot.json", self.signed.signed.version())
+                } else {
+                    "snapshot.json".to_string()
+                }
+            }
+            RoleType::Timestamp => "timestamp.json".to_string(),
+            RoleType::Root => format!("{}.root.json", self.signed.signed.version()),
+        };
+
+        let path = outdir.join(filename);
+        std::fs::write(&path, &self.buffer).context(error::FileWrite { path })
+    }
+}
+
+// =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=
+
+/// A set of signed TUF Repository metadata.
+///
+/// This metadata represents a signed TUF repository and provides the ability
+/// to write the metadata to disk.
+///
+/// Note: without the target files, the repository cannot be used. It is up
+/// to the user to ensure all the target files referenced by the metadata are
+/// available. There are convenience methods to help with this.
+#[derive(Debug)]
+pub struct SignedRepository {
+    pub(crate) root: SignedRole<Root>,
+    pub(crate) targets: SignedRole<Targets>,
+    pub(crate) snapshot: SignedRole<Snapshot>,
+    pub(crate) timestamp: SignedRole<Timestamp>,
+}
+
+impl SignedRepository {
+    /// Writes the metadata to the given directory. If consistent snapshots
+    /// are used, the appropriate files are prefixed with their version.
+    pub fn write<P>(&self, outdir: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let consistent_snapshot = self.root.signed.signed.consistent_snapshot;
+        self.root.write(&outdir, consistent_snapshot)?;
+        self.targets.write(&outdir, consistent_snapshot)?;
+        self.snapshot.write(&outdir, consistent_snapshot)?;
+        self.timestamp.write(&outdir, consistent_snapshot)
+    }
+
+    /// Crawls a given directory and symlinks any targets found to the given
+    /// "out" directory. If consistent snapshots are used, the target files
+    /// are prefixed with their `sha256`.
+    ///
+    /// For each file found in the `indir`, the method gets the filename and
+    /// if the filename exists in `Targets`, the file's sha256 is compared
+    /// against the data in `Targets`. If this data does not match, the
+    /// method will fail. If all is well, the target is symlinked.
+    pub fn link_targets<P1, P2>(&self, indir: P1, outdir: P2) -> Result<()>
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+    {
+        let outdir = outdir.as_ref();
+        let indir = indir.as_ref();
+        std::fs::create_dir_all(outdir).context(error::DirCreate { path: outdir })?;
+
+        // Get the absolute path of the indir and outdir
+        let abs_indir =
+            std::fs::canonicalize(indir).context(error::AbsolutePath { path: indir })?;
+        let abs_outdir =
+            std::fs::canonicalize(outdir).context(error::AbsolutePath { path: outdir })?;
+        let repo_targets = &self.targets.signed.signed.targets;
+
+        // Walk the absolute path of the indir. Using the absolute path here
+        // means that `entry.path()` call will return its absolute path.
+        let walker = WalkDir::new(&abs_indir).follow_links(true);
+        for entry in walker {
+            let entry = entry.context(error::WalkDir {
+                directory: &abs_indir,
+            })?;
+
+            // If the entry is not a file, move on
+            if !entry.file_type().is_file() {
+                continue;
+            };
+
+            // If the entry is a file, get the filename
+            let file_name = entry
+                .file_name()
+                .to_str()
+                .context(error::PathUtf8 { path: entry.path() })?;
+
+            // Use the file name to see if a target exists in the repo
+            // with that name. If so...
+            let repo_target = match repo_targets.get(file_name) {
+                Some(repo_target) => repo_target,
+                None => continue,
+            };
+            // create a Target object using the entry's path, and then...
+            let target_from_path = Target::from_path(entry.path())
+                .context(error::TargetFromPath { path: entry.path() })?;
+
+            // compare the hashes of the target from the repo and the
+            // target we just created. If they are the same, this must
+            // be the same file, symlink it.
+            ensure!(
+                target_from_path.hashes.sha256 == repo_target.hashes.sha256,
+                error::HashMismatch {
+                    context: "target",
+                    calculated: hex::encode(target_from_path.hashes.sha256),
+                    expected: hex::encode(&repo_target.hashes.sha256),
+                }
+            );
+
+            let dest = if self.root.signed.signed.consistent_snapshot {
+                abs_outdir.join(format!(
+                    "{}.{}",
+                    hex::encode(&target_from_path.hashes.sha256),
+                    file_name
+                ))
+            } else {
+                abs_outdir.join(&file_name)
+            };
+
+            symlink(entry.path(), &dest).context(error::LinkCreate { path: &dest })?;
+        }
+
+        Ok(())
+    }
+}

--- a/tough/src/editor/test.rs
+++ b/tough/src/editor/test.rs
@@ -1,0 +1,176 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use crate::editor::RepositoryEditor;
+    use crate::key_source::LocalKeySource;
+    use crate::schema::{Signed, Snapshot, Targets, Timestamp};
+    use chrono::{Duration, Utc};
+    use std::num::NonZeroU64;
+    use std::path::PathBuf;
+
+    // Path to the root.json in the reference implementation
+    fn tuf_root_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("data")
+            .join("tuf-reference-impl")
+            .join("metadata")
+            .join("root.json")
+    }
+
+    // Path to the root.json that corresponds with snakeoil.pem
+    fn root_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("data")
+            .join("simple-rsa")
+            .join("root.json")
+    }
+
+    fn key_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("data")
+            .join("snakeoil.pem")
+    }
+
+    // Path to fake targets in the reference implementation
+    fn targets_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("data")
+            .join("tuf-reference-impl")
+            .join("targets")
+    }
+
+    // Make sure we can't create a repo without any data
+    #[test]
+    fn empty_repository() {
+        let root_key = key_path();
+        let key_source = LocalKeySource { path: root_key };
+        let root_path = root_path();
+
+        let editor = RepositoryEditor::new(&root_path).unwrap();
+        assert!(editor.sign(&[Box::new(key_source)]).is_err());
+    }
+
+    // Make sure we can add targets from different sources
+    #[test]
+    fn add_targets() {
+        let targets: Signed<Targets> = serde_json::from_str(include_str!(
+            "../../tests/data/tuf-reference-impl/metadata/targets.json"
+        ))
+        .unwrap();
+        let target3 = targets_path().join("file3.txt");
+        let root_path = tuf_root_path();
+
+        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        editor
+            .targets(targets.signed)
+            .unwrap()
+            .add_target(target3)
+            .unwrap();
+
+        let existing_targets = editor.existing_targets.unwrap();
+        assert_eq!(existing_targets.len(), 2);
+        assert!(existing_targets.get("file1.txt").is_some());
+        assert!(existing_targets.get("file2.txt").is_some());
+
+        let new_targets = editor.new_targets.unwrap();
+        assert_eq!(new_targets.len(), 1);
+        assert!(new_targets.get("file3.txt").is_some());
+    }
+
+    #[test]
+    fn clear_targets() {
+        let targets: Signed<Targets> = serde_json::from_str(include_str!(
+            "../../tests/data/tuf-reference-impl/metadata/targets.json"
+        ))
+        .unwrap();
+        let target3 = targets_path().join("file3.txt");
+        let root_path = tuf_root_path();
+
+        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        editor
+            .targets(targets.signed)
+            .unwrap()
+            .add_target(target3)
+            .unwrap()
+            .clear_targets();
+
+        assert!(editor.existing_targets.unwrap().is_empty());
+        assert!(editor.new_targets.unwrap().is_empty());
+    }
+
+    // Create and fully sign a repo
+    #[test]
+    fn complete_repository() {
+        let root = root_path();
+        let root_key = key_path();
+        let key_source = LocalKeySource { path: root_key };
+        let timestamp_expiration = Utc::now().checked_add_signed(Duration::days(3)).unwrap();
+        let timestamp_version = NonZeroU64::new(1234).unwrap();
+        let snapshot_expiration = Utc::now().checked_add_signed(Duration::days(21)).unwrap();
+        let snapshot_version = NonZeroU64::new(5432).unwrap();
+        let targets_expiration = Utc::now().checked_add_signed(Duration::days(13)).unwrap();
+        let targets_version = NonZeroU64::new(789).unwrap();
+        let target1 = targets_path().join("file1.txt");
+        let target2 = targets_path().join("file2.txt");
+        let target3 = targets_path().join("file3.txt");
+        let target_list = vec![target1, target2, target3];
+
+        let mut editor = RepositoryEditor::new(&root).unwrap();
+        editor
+            .targets_expires(targets_expiration)
+            .targets_version(targets_version)
+            .snapshot_expires(snapshot_expiration)
+            .snapshot_version(snapshot_version)
+            .timestamp_expires(timestamp_expiration)
+            .timestamp_version(timestamp_version)
+            .add_targets(target_list)
+            .unwrap();
+
+        assert!(editor.sign(&[Box::new(key_source)]).is_ok());
+    }
+
+    // Make sure we can add existing role structs and the proper data is kept.
+    #[test]
+    fn existing_roles() {
+        let targets: Signed<Targets> = serde_json::from_str(include_str!(
+            "../../tests/data/tuf-reference-impl/metadata/targets.json"
+        ))
+        .unwrap();
+        let snapshot: Signed<Snapshot> = serde_json::from_str(include_str!(
+            "../../tests/data/tuf-reference-impl/metadata/snapshot.json"
+        ))
+        .unwrap();
+        let timestamp: Signed<Timestamp> = serde_json::from_str(include_str!(
+            "../../tests/data/tuf-reference-impl/metadata/timestamp.json"
+        ))
+        .unwrap();
+        let root_path = tuf_root_path();
+
+        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        editor
+            .targets(targets.signed)
+            .unwrap()
+            .snapshot(snapshot.signed)
+            .unwrap()
+            .timestamp(timestamp.signed)
+            .unwrap();
+
+        assert!(editor.targets_version.is_none());
+        assert!(editor.snapshot_version.is_none());
+        assert!(editor.timestamp_version.is_none());
+
+        assert!(editor.targets_expires.is_none());
+        assert!(editor.snapshot_expires.is_none());
+        assert!(editor.timestamp_expires.is_none());
+
+        let existing_targets = editor.existing_targets.unwrap();
+        assert!(existing_targets.get("file1.txt").is_some());
+        assert!(existing_targets.get("file2.txt").is_some());
+    }
+}

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod cache;
 mod datastore;
+pub mod editor;
 pub mod error;
 mod fetch;
 mod io;

--- a/tough/tests/repo_editor.rs
+++ b/tough/tests/repo_editor.rs
@@ -1,0 +1,152 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use chrono::{Duration, Utc};
+use std::fs::File;
+use std::io::Read;
+use std::num::NonZeroU64;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use test_utils::{dir_url, test_data};
+use tough::editor::RepositoryEditor;
+use tough::key_source::LocalKeySource;
+use tough::{ExpirationEnforcement, FilesystemTransport, Limits, Repository, Settings};
+
+mod test_utils;
+
+struct RepoPaths {
+    root_path: PathBuf,
+    datastore: TempDir,
+    metadata_base_url: String,
+    targets_base_url: String,
+}
+
+impl RepoPaths {
+    fn new() -> Self {
+        let base = test_data().join("tuf-reference-impl");
+        RepoPaths {
+            root_path: base.join("metadata").join("1.root.json"),
+            datastore: TempDir::new().unwrap(),
+            metadata_base_url: dir_url(base.join("metadata")),
+            targets_base_url: dir_url(base.join("targets")),
+        }
+    }
+
+    fn root(&self) -> File {
+        File::open(&self.root_path).unwrap()
+    }
+}
+
+fn load_tuf_reference_impl<'a>(paths: &'a mut RepoPaths) -> Repository<'a, FilesystemTransport> {
+    Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: &mut paths.root(),
+            datastore: paths.datastore.as_ref(),
+            metadata_base_url: paths.metadata_base_url.as_str(),
+            targets_base_url: paths.targets_base_url.as_str(),
+            limits: Limits::default(),
+            expiration_enforcement: ExpirationEnforcement::Safe,
+        },
+    )
+    .unwrap()
+}
+
+// Test a RepositoryEditor can be created from an existing Repo
+#[test]
+fn repository_editor_from_repository() {
+    // Load the reference_impl repo
+    let mut repo_paths = RepoPaths::new();
+    let root = repo_paths.root_path.clone();
+    let repo = load_tuf_reference_impl(&mut repo_paths);
+
+    assert!(RepositoryEditor::from_repo(&root, repo).is_ok());
+}
+
+// Load a repository, edit it, and write it to disk. Ensure it loads correctly
+// and attempt to read a target
+#[test]
+fn repo_load_edit_write_load() {
+    let mut repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&mut repo_paths);
+
+    let root = test_data().join("simple-rsa").join("root.json");
+    let root_key = test_data().join("snakeoil.pem");
+    let key_source = LocalKeySource { path: root_key };
+    let timestamp_expiration = Utc::now().checked_add_signed(Duration::days(3)).unwrap();
+    let timestamp_version = NonZeroU64::new(1234).unwrap();
+    let snapshot_expiration = Utc::now().checked_add_signed(Duration::days(21)).unwrap();
+    let snapshot_version = NonZeroU64::new(5432).unwrap();
+    let targets_expiration = Utc::now().checked_add_signed(Duration::days(13)).unwrap();
+    let targets_version = NonZeroU64::new(789).unwrap();
+    let targets_location = test_data().join("tuf-reference-impl").join("targets");
+    let target3 = targets_location.join("file3.txt");
+
+    // Load the reference_impl repo
+    let mut editor = RepositoryEditor::from_repo(&root, repo).unwrap();
+
+    // Add the required data and a new target
+    // We clear the targets first because the reference implementation includes
+    // "file1.txt" and "file2.txt". The reference implementation's "targets"
+    // directory includes all 3 targets. We want to explicitly add "file3.txt"
+    // as a target, and later ensure that "file3" is the only target in the
+    // new repo and the only target that gets symlinked. Doing so tests the
+    // implementation of `SignedRepository.link_targets()`.
+    editor
+        .targets_expires(targets_expiration)
+        .targets_version(targets_version)
+        .snapshot_expires(snapshot_expiration)
+        .snapshot_version(snapshot_version)
+        .timestamp_expires(timestamp_expiration)
+        .timestamp_version(timestamp_version)
+        .clear_targets()
+        .add_target(target3)
+        .unwrap();
+
+    // Sign the newly updated repo
+    let signed_repo = editor.sign(&[Box::new(key_source)]).unwrap();
+
+    // Create the directories and write the repo to disk
+    let destination = TempDir::new().unwrap();
+    let metadata_destination = destination.as_ref().join("metadata");
+    let targets_destination = destination.as_ref().join("targets");
+    assert!(signed_repo.write(&metadata_destination).is_ok());
+    assert!(signed_repo
+        .link_targets(&targets_location, &targets_destination)
+        .is_ok());
+
+    // Load the repo we just created
+    let datastore = TempDir::new().unwrap();
+    let metadata_base_url = dir_url(&metadata_destination);
+    let targets_base_url = dir_url(&targets_destination);
+    let new_repo = Repository::load(
+        &tough::FilesystemTransport,
+        Settings {
+            root: File::open(&root).unwrap(),
+            datastore: datastore.as_ref(),
+            metadata_base_url: metadata_base_url.as_str(),
+            targets_base_url: targets_base_url.as_str(),
+            limits: Limits::default(),
+            expiration_enforcement: ExpirationEnforcement::Safe,
+        },
+    )
+    .unwrap();
+
+    // Ensure the new repo only has the single target
+    assert_eq!(new_repo.targets().signed.targets.len(), 1);
+
+    // The repo shouldn't contain file1 or file2
+    // `read_target()` returns a Result(Option<>) which is why we unwrap
+    assert!(new_repo.read_target("file1.txt").unwrap().is_none());
+    assert!(new_repo.read_target("file2.txt").unwrap().is_none());
+
+    // Read file3.txt
+    let mut file_data = Vec::new();
+    let file_size = new_repo
+        .read_target("file3.txt")
+        .unwrap()
+        .unwrap()
+        .read_to_end(&mut file_data)
+        .unwrap();
+    assert_eq!(28, file_size);
+}


### PR DESCRIPTION
*This PR builds on the [`KeySource` trait PR](https://github.com/awslabs/tough/pull/103) that needs a Rusoto release to be merged. Once that PR is merged we can merge this one*

*Issue #, if available:*
Related to #43 
Builds on #103 

*Description of changes:*
This commit adds a RepositoryEditor struct, which allows a user
to build a new repository from scratch or edit an existing
`tough::Repository` using a pseudo builder-style pattern.

Users supply a path to a valid `root.json`, add targets, versions, and expiration dates, and then call `sign()` with signing keys. Provided all goes well, a user is given a `SignedRepository` struct which they can then use to write to disk. Convenience methods are provided to symlink targets to a location provided they exist in the `SignedRepository` and the checksums match.

`SignedRepository` does not keep track of locations of given targets. This responsibility is left to the calling code.

*Considerations and questions:*
* `RepositoryEditor` currently provides no facilities to manipulate versions or expirations; they must be provided. I think it would be nice to do so, but it's difficult to know what users could be using for versions and how they would want to increment them. Expiration dates could (should?) be unique for each role, so I didn't want to blanket implement something when a user should either update them, or save the current date and use it in the builder methods.

* While this abstracts away most of the logic from `tuftool` it does not help a user sign a *single* role (timstamp, targets, etc). We could make this possible by moving some of the logic into a `SignedRole.from_role(<ROLE HERE>)` method? I'm not sure how much of this we want to expose. It's also a bit weird to have `SignedRole` own this logic.

*Testing:*
* All unit tests pass and clippy is happy
* Added a few simple unit tests
* Currently working on an "integration" style test that (hopefully) can "sign" a repo, and then test the symlink methods on that signed repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
