### PR TITLE
Make output directory when downloading repository

### DIFF
--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -108,6 +108,7 @@ impl DownloadArgs {
 
         // copy all available targets
         println!("Downloading targets to {:?}", &self.outdir);
+        std::fs::create_dir_all(&self.outdir).context(error::DirCreate { path: &self.outdir })?;
         for target in repository.targets().signed.targets.keys() {
             let path = PathBuf::from(&self.outdir).join(target);
             println!("\t-> {}", &target);

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -51,6 +51,13 @@ pub(crate) enum Error {
         source: std::num::ParseIntError,
     },
 
+    #[snafu(display("Failed to create directory '{}': {}", path.display(), source))]
+    DirCreate {
+        path: PathBuf,
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to copy {} to {}: {}", src.display(), dst.display(), source))]
     FileCopy {
         src: PathBuf,


### PR DESCRIPTION
*Issue #, if available:*
Fixes #8 

*Description of changes:*
Creates the given `outdir` before writing the targets to it.

*Testing done:*
* All tests pass
* Manually downloaded a repo to a directory that didn't exist beforeheand.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
