### PR TITLE
tough v0.6.0 / tuftool v0.4.0 / tough-ssm v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1819,7 +1819,7 @@ dependencies = [
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.5.0",
+ "tough 0.6.0",
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tuftool"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1859,7 +1859,7 @@ dependencies = [
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.5.0",
+ "tough 0.6.0",
  "tough-ssm 0.1.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2020-06-11
+### Added
+- Everything!
+
+[0.1.0]: https://github.com/awslabs/tough/releases/tag/tough-ssm-v0.1.0

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -11,7 +11,7 @@ rusoto-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_ssm/
 rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.5.0", path = "../tough", features = ["http"] }
+tough = { version = "0.6.0", path = "../tough", features = ["http"] }
 rusoto_core = { version = "0.44", optional = true, default-features = false }
 rusoto_credential = { version = "0.44", optional = true }
 rusoto_ssm = { version = "0.44", optional = true, default-features = false }

--- a/tough-ssm/README.md
+++ b/tough-ssm/README.md
@@ -1,0 +1,2 @@
+tough-ssm implements the `KeySource` trait found in [tough, a Rust TUF client](https://github.com/awslabs/tough).
+By implementing this trait, AWS SSM can become a source of keys used to sign a [TUF repository](https://theupdateframework.github.io/).

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2020-06-11
+
+### Added
+- Added `Target::from_path()` method.
+- Added the `KeySource` trait, which allows users to fetch signing keys.
+- Added `RepositoryEditor`, which allow users to update a `tough::Repository`'s metadata and optionally add targets.
+
+### Changed
+- Dependency updates.
+
 ## [0.5.0] - 2020-05-18
 
 For changes that require modification of calling code see #120 and #121.

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.5.0"
+version = "0.6.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2020-06-11
+
+Major update: much of the logic in `tuftool` has been factored out and added to `tough`
+
+### Added
+- Added `tuftool update`, which allows a user to update an existing repository's metadata and optionally add targets. (This addition deprecates `tuftool refresh`; see note below)
+- `tuftool download` now creates its output directory.
+
+### Removed
+- Removed `tuftool refresh` in favor of the new `tuftool update` command
+- Lots of under-the-hood business logic, which is mostly invisible to the user. :)
+
+### Changed
+- `tuftool create`'s interface now uses flags rather than positional arguments to better align with `tuftool update`
+- Dependency updates.
+
 ## [0.3.1] - (Unreleased)
 ### Added
 - Accommodate `tough`'s change from `target_base_url` to `targets_base_url`.

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.3.1"
+version = "0.4.0"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -33,7 +33,7 @@ structopt = "0.3"
 tempfile = "3.1.0"
 url = "2.1.0"
 walkdir = "2.2.9"
-tough = { version = "0.5.0", path = "../tough", features = ["http"] }
+tough = { version = "0.6.0", path = "../tough", features = ["http"] }
 tokio = "0.2.21"
 tough-ssm = { version = "0.1.0", path = "../tough-ssm" }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Prepare for the release of tough v0.6.0 / tuftool v0.4.0 / tough-ssm v0.1.0:
* update `CHANGELOG`s
* update the version numbers in `Cargo.toml`s
* add `CHANGELOG` and `README.md` to `tough-ssm`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
