### PR TITLE
Integration of delegated targets described in the TUF spec for repo loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +516,18 @@ dependencies = [
 name = "gimli"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "globset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "h2"
@@ -1791,12 +1811,12 @@ name = "tough"
 version = "0.6.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.25.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2136,6 +2156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+"checksum bstr 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 "checksum bumpalo 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -2182,6 +2203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum gimli 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+"checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 "checksum h2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,6 +1796,7 @@ dependencies = [
  "mockito 0.25.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4.11", features = ["serde"] }
+globset = { version = "0.4.5" }
 hex = "0.4.2"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.7.0"
-regex = "1.3.9"
 reqwest = { version = "0.10.4", optional = true, default-features = false, features = ["blocking"] }
 ring = { version = "0.16.13", features = ["std"] }
 serde = { version = "1.0.110", features = ["derive"] }

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4.11", features = ["serde"] }
 hex = "0.4.2"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.7.0"
+regex = "1.3.9"
 reqwest = { version = "0.10.4", optional = true, default-features = false, features = ["blocking"] }
 ring = { version = "0.16.13", features = ["std"] }
 serde = { version = "1.0.110", features = ["derive"] }

--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -69,7 +69,7 @@ impl<'a, T: Transport> Repository<'a, T> {
             &metadata_outdir,
         )?;
 
-        for name in self.targets.signed.roles_str() {
+        for name in self.targets.signed.role_names() {
             self.cache_file_from_transport(
                 self.delegated_filename(name).as_str(),
                 self.limits.max_targets_size,

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -313,6 +313,7 @@ impl RepositoryEditor {
             expires,
             targets,
             _extra,
+            delegations: None,
         })
     }
 

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -348,6 +348,7 @@ pub enum Error {
     #[snafu(display("The target '{}' was not found", target_name))]
     CacheTargetMissing {
         target_name: String,
+        source: crate::schema::Error,
         backtrace: Backtrace,
     },
 
@@ -360,6 +361,25 @@ pub enum Error {
 
     #[snafu(display("Target File not Delegated: {}", target_url))]
     TargetNotFound { target_url: String },
+
+    #[snafu(display("Delegated role not found: {}", name))]
+    DelegateNotFound { name: String },
+
+    #[snafu(display("Delegation didn't contain targets field"))]
+    NoTargets {},
+
+    #[snafu(display("Targets didn't contain delegations field"))]
+    NoDelegations {},
+
+    #[snafu(display("Delegated roles are not consistent for {}", name))]
+    DelegatedRolesNotConsistent { name: String },
+
+    /// Target doesn't have proper permissions from parent delegations
+    #[snafu(display("Invalid file permissions"))]
+    InvalidPath { source: crate::schema::Error },
+
+    #[snafu(display("Role Missing from snapshot meta: {}", name))]
+    RoleNotInMeta { name: String },
 }
 
 // used in `std::io::Read` implementations

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -369,10 +369,10 @@ pub enum Error {
     },
 
     #[snafu(display("Delegation doesn't contain targets field"))]
-    NoTargets {},
+    NoTargets,
 
     #[snafu(display("Targets doesn't contain delegations field"))]
-    NoDelegations {},
+    NoDelegations,
 
     #[snafu(display("Delegated roles are not consistent for {}", name))]
     DelegatedRolesNotConsistent { name: String },

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -357,6 +357,9 @@ pub enum Error {
         source: walkdir::Error,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Target File not Delegated: {}", target_url))]
+    TargetNotFound { target_url: String },
 }
 
 // used in `std::io::Read` implementations

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -359,16 +359,19 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Target File not Delegated: {}", target_url))]
+    #[snafu(display("Target file not delegated: {}", target_url))]
     TargetNotFound { target_url: String },
 
     #[snafu(display("Delegated role not found: {}", name))]
-    DelegateNotFound { name: String },
+    DelegateNotFound {
+        name: String,
+        source: crate::schema::Error,
+    },
 
-    #[snafu(display("Delegation didn't contain targets field"))]
+    #[snafu(display("Delegation doesn't contain targets field"))]
     NoTargets {},
 
-    #[snafu(display("Targets didn't contain delegations field"))]
+    #[snafu(display("Targets doesn't contain delegations field"))]
     NoDelegations {},
 
     #[snafu(display("Delegated roles are not consistent for {}", name))]
@@ -378,7 +381,7 @@ pub enum Error {
     #[snafu(display("Invalid file permissions"))]
     InvalidPath { source: crate::schema::Error },
 
-    #[snafu(display("Role Missing from snapshot meta: {}", name))]
+    #[snafu(display("Role missing from snapshot meta: {}", name))]
     RoleNotInMeta { name: String },
 }
 

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -291,7 +291,8 @@ impl<'a, T: Transport> Repository<'a, T> {
         &self.timestamp
     }
 
-    pub fn delegated_targets(&self) -> Vec<&Target> {
+    ///return a vec of all targets including all target files delegated by targets
+    pub fn all_targets(&self) -> Vec<&Target> {
         self.targets.signed.targets()
     }
 
@@ -343,12 +344,13 @@ impl<'a, T: Transport> Repository<'a, T> {
     }
 
     pub fn role(&self, name: &str) -> Result<&DelegatedRole> {
-        match self.targets.signed.del_role(name) {
-            Ok(del_role) => Ok(del_role),
-            _ => Err(error::Error::DelegateNotFound {
+        Ok(self
+            .targets
+            .signed
+            .delegated_role(name)
+            .context(error::DelegateNotFound {
                 name: name.to_string(),
-            }),
-        }
+            })?)
     }
 }
 
@@ -912,17 +914,17 @@ fn load_delegations<T: Transport>(
 ) -> Result<()> {
     let mut delegated_roles: HashMap<String, Option<Signed<crate::schema::Targets>>> =
         HashMap::new();
-    for del_role in &delegation.roles {
+    for delegated_role in &delegation.roles {
         //find the role file metadata
         let role_meta = snapshot
             .signed
             .meta
-            .get(&format!("{}.json", &del_role.name))
+            .get(&format!("{}.json", &delegated_role.name))
             .context(error::RoleNotInMeta {
-                name: del_role.name.clone(),
+                name: delegated_role.name.clone(),
             })?;
 
-        let path = format!("{}.json", &del_role.name);
+        let path = format!("{}.json", &delegated_role.name);
         let role_url = metadata_base_url.join(&path).context(error::JoinUrl {
             path: path.clone(),
             url: metadata_base_url.to_owned(),
@@ -942,7 +944,7 @@ fn load_delegations<T: Transport>(
             })?;
         //verify each role with the delegation
         delegation
-            .verify_role(&role, &del_role.name)
+            .verify_role(&role, &delegated_role.name)
             .context(error::VerifyMetadata {
                 role: RoleType::Targets,
             })?;
@@ -961,17 +963,16 @@ fn load_delegations<T: Transport>(
         }
 
         datastore.create(&path, &role)?;
-        delegated_roles.insert(del_role.name.clone(), Some(role));
+        delegated_roles.insert(delegated_role.name.clone(), Some(role));
     }
     //load all roles delegated by this role
-    for del_role in &mut delegation.roles {
-        del_role.targets =
-            delegated_roles
-                .remove(&del_role.name)
-                .context(error::DelegatedRolesNotConsistent {
-                    name: del_role.name.clone(),
-                })?;
-        if let Some(targets) = &mut del_role.targets {
+    for delegated_role in &mut delegation.roles {
+        delegated_role.targets = delegated_roles.remove(&delegated_role.name).context(
+            error::DelegatedRolesNotConsistent {
+                name: delegated_role.name.clone(),
+            },
+        )?;
+        if let Some(targets) = &mut delegated_role.targets {
             if let Some(delegations) = &mut targets.signed.delegations {
                 load_delegations(
                     transport,

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -103,7 +103,7 @@ pub enum Error {
     UnmatchedPath { child: String },
 
     /// No valid targets claims target_url
-    #[snafu(display("Target File not Delegated: {}", target_url))]
+    #[snafu(display("Target file not delegated: {}", target_url))]
     TargetNotFound { target_url: String },
 
     #[snafu(display("Delegation didn't contain targets field"))]

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -18,6 +18,10 @@ pub enum Error {
     #[snafu(display("Duplicate key ID: {}", keyid))]
     DuplicateKeyId { keyid: String },
 
+    /// A duplicate key ID was present in the root metadata.
+    #[snafu(display("Duplicate role name: {}", name))]
+    DuplicateRoleName { name: String },
+
     /// Unable to open a file
     #[snafu(display("Failed to open '{}': {}", path.display(), source))]
     FileOpen {
@@ -93,6 +97,14 @@ pub enum Error {
     /// Unable to create a TUF target from anything but a file
     #[snafu(display("TUF targets must be files, given: '{}'", path.display()))]
     TargetNotAFile { path: PathBuf, backtrace: Backtrace },
+
+    /// Target doesn't have proper permissions from parent delegations
+    #[snafu(display("Invalid file permissions: {}", child))]
+    UnmatchedPath { child: String },
+
+    /// No valid targets claims target_url
+    #[snafu(display("Target File not Delegated: {}", target_url))]
+    TargetNotFound { target_url: String },
 }
 
 /// Wrapper for error types that don't impl [`std::error::Error`].

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     #[snafu(display("Duplicate key ID: {}", keyid))]
     DuplicateKeyId { keyid: String },
 
-    /// A duplicate key ID was present in the root metadata.
+    /// A duplicate role was present in the delegations metadata.
     #[snafu(display("Duplicate role name: {}", name))]
     DuplicateRoleName { name: String },
 
@@ -99,21 +99,18 @@ pub enum Error {
     TargetNotAFile { path: PathBuf, backtrace: Backtrace },
 
     /// Target doesn't have proper permissions from parent delegations
-    #[snafu(display("Invalid file permissions: {}", child))]
+    #[snafu(display("Invalid file permissions from parent delegation: {}", child))]
     UnmatchedPath { child: String },
 
-    /// No valid targets claims target_url
-    #[snafu(display("Target file not delegated: {}", target_url))]
-    TargetNotFound { target_url: String },
+    /// No valid targets claims `target_file`
+    #[snafu(display("Target file not delegated: {}", target_file))]
+    TargetNotFound { target_file: String },
 
-    #[snafu(display("Delegation didn't contain targets field"))]
-    NoTargets {},
+    #[snafu(display("Delegation doesn't contain targets field"))]
+    NoTargets,
 
-    #[snafu(display("Targets didn't contain delegations field"))]
-    NoDelegations {},
-
-    #[snafu(display("Invalid Regex: {}", regex))]
-    BadRegex { regex: String },
+    #[snafu(display("Targets doesn't contain delegations field"))]
+    NoDelegations,
 }
 
 /// Wrapper for error types that don't impl [`std::error::Error`].

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -105,6 +105,15 @@ pub enum Error {
     /// No valid targets claims target_url
     #[snafu(display("Target File not Delegated: {}", target_url))]
     TargetNotFound { target_url: String },
+
+    #[snafu(display("Delegation didn't contain targets field"))]
+    NoTargets {},
+
+    #[snafu(display("Targets didn't contain delegations field"))]
+    NoDelegations {},
+
+    #[snafu(display("Invalid Regex: {}", regex))]
+    BadRegex { regex: String },
 }
 
 /// Wrapper for error types that don't impl [`std::error::Error`].

--- a/tough/tests/expiration_enforcement.rs
+++ b/tough/tests/expiration_enforcement.rs
@@ -69,6 +69,5 @@ fn test_expiration_enforcement_unsafe() {
             expiration_enforcement: ExpirationEnforcement::Unsafe,
         },
     );
-
     assert!(result.is_ok())
 }

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -78,7 +78,7 @@ fn test_tuf_reference_impl() {
         .delegations
         .as_ref()
         .unwrap()
-        .check_target(&"file3.txt".to_string()));
+        .target_is_delegated(&"file3.txt".to_string()));
 }
 
 #[cfg(feature = "http")]

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -71,6 +71,14 @@ fn test_tuf_reference_impl() {
             .unwrap(),
         "0644"
     );
+
+    assert!(repo
+        .targets()
+        .signed
+        .delegations
+        .as_ref()
+        .unwrap()
+        .check_target(&"file3.txt".to_string()));
 }
 
 #[cfg(feature = "http")]
@@ -94,6 +102,8 @@ fn test_tuf_http_transport() {
     let mock_timestamp = create_successful_get_mock("metadata/timestamp.json");
     let mock_snapshot = create_successful_get_mock("metadata/snapshot.json");
     let mock_targets = create_successful_get_mock("metadata/targets.json");
+    let mock_role1 = create_successful_get_mock("metadata/role1.json");
+    let mock_role2 = create_successful_get_mock("metadata/role2.json");
     let mock_file1_txt = create_successful_get_mock("targets/file1.txt");
     let mock_file2_txt = create_successful_get_mock("targets/file2.txt");
     let datastore = TempDir::new().unwrap();
@@ -137,6 +147,8 @@ fn test_tuf_http_transport() {
     mock_timestamp.assert();
     mock_snapshot.assert();
     mock_targets.assert();
+    mock_role1.assert();
+    mock_role2.assert();
     mock_file1_txt.assert();
     mock_file2_txt.assert();
 }


### PR DESCRIPTION
**This is the first part of the integration of delegated targets with tough, featuring the loading of delegated targets of an existing repository. An upcoming PR will contain the additions for creating/delegating targets and signing delegated targets.**

*Issue #, if available:*
Related to #5 

*Description of changes:*
* Delegations Struct for serialization and deserialization
* DelegatedRole manages the metadata that was delegated and the targets struct that was delegated
* Delegations describe paths using PathSet, which is either a set of shell style paths or path hash prefixes
* Delegated targets are loaded in a pre-order as specified by the TUF spec

*Testing Done*
* Integration with current tests

**Thorough testing requires complex delegations structures that need to be signed properly. This will be completed after the write and sign portion is completed**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
