### PR TITLE
[editor] Adds the ability to copy or link individual targets

### DIFF
--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -224,6 +224,12 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Requested copy/link of '{}' which is not a file", path.display()))]
+    PathIsNotFile { path: PathBuf, backtrace: Backtrace },
+
+    #[snafu(display("Requested copy/link of '{}' which is not a repo target", path.display()))]
+    PathIsNotTarget { path: PathBuf, backtrace: Backtrace },
+
     /// Path isn't a valid UTF8 string
     #[snafu(display("Path {} is not valid UTF-8", path.display()))]
     PathUtf8 { path: PathBuf, backtrace: Backtrace },


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Refactored `link_targets` to separate the walking from linking
* Added `copy_targets`, which does the same except copies rather than symlinks
* Added `link_target` and `copy_target`, which are used by the above functions and allow for handling single files with custom filenames

*Testing:*
* Unit tests pass
* Built multiple repos with copied and linked targets
* Added `copy_targets` to the integration test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
