### PR TITLE
tough v0.7.0 / tough-ssm v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rusoto_core 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1819,7 +1819,7 @@ dependencies = [
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.6.0",
+ "tough 0.7.0",
 ]
 
 [[package]]
@@ -1859,8 +1859,8 @@ dependencies = [
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.6.0",
- "tough-ssm 0.1.0",
+ "tough 0.7.0",
+ "tough-ssm 0.2.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-06-26
+### Changed
+- Update `tough` dependency to 0.7.0.
+
 ## [0.1.0] - 2020-06-11
 ### Added
 - Everything!

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.1.0"
+version = "0.2.0"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rusoto-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_ssm/
 rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.6.0", path = "../tough", features = ["http"] }
+tough = { version = "0.7.0", path = "../tough", features = ["http"] }
 rusoto_core = { version = "0.44", optional = true, default-features = false }
 rusoto_credential = { version = "0.44", optional = true }
 rusoto_ssm = { version = "0.44", optional = true, default-features = false }

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2020-06-26
+
+### Added
+- Added `#[non_exhaustive]` to `tough::Error` and `tough::schema::Error`
+- `editor::signed::SignedRepository`:
+  - Added `copy_targets`, which does the same as `link_targets` except copies rather than symlinks
+  - Added `link_target` and `copy_target`, which are used by the above functions and allow for handling single files with custom filenames
+
 ## [0.6.0] - 2020-06-11
 
 ### Added

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -18,6 +18,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The error type for this library.
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
+#[non_exhaustive]
 pub enum Error {
     #[snafu(display("Unable to canonicalize path '{}': {}", path.display(), source))]
     AbsolutePath {

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -13,6 +13,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// The error type for this library.
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(super)")]
+#[non_exhaustive]
 pub enum Error {
     /// A duplicate key ID was present in the root metadata.
     #[snafu(display("Duplicate key ID: {}", keyid))]

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Bumped `tough` to 0.7.0
+- Bumped `tough-ssm` to 0.2.0
+
 ## [0.4.0] - 2020-06-11
 
 Major update: much of the logic in `tuftool` has been factored out and added to `tough`

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -33,9 +33,9 @@ structopt = "0.3"
 tempfile = "3.1.0"
 url = "2.1.0"
 walkdir = "2.2.9"
-tough = { version = "0.6.0", path = "../tough", features = ["http"] }
+tough = { version = "0.7.0", path = "../tough", features = ["http"] }
 tokio = "0.2.21"
-tough-ssm = { version = "0.1.0", path = "../tough-ssm" }
+tough-ssm = { version = "0.2.0", path = "../tough-ssm" }
 
 [dev-dependencies]
 assert_cmd = "1.0"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Prepare `tough` to release `0.7.0` to incorporate changes from #158 
* Update `tough-ssm` to depend on `tough 0.7.0`
* Bump `tough-ssm` to `0.2.0`
* Update `tuftool`'s dependencies to reflect new versions of `tough` and `tough-ssm`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
