### PR TITLE
tough and tuftool: setup logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1731,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1877,7 @@ dependencies = [
  "globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1910,6 +1929,7 @@ dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1921,6 +1941,7 @@ dependencies = [
  "rusoto_ssm 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2358,6 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+"checksum simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7f5aed652511f5c9123cf2afbe9c244c29db6effa2abb05c866e965c82405ce"
 "checksum snafu-derive 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ebf8f7d5720104a9df0f7076a8682024e958bba0fe9848767bb44f251f3648e9"
@@ -2375,6 +2397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 chrono = { version = "0.4.11", features = ["serde"] }
 globset = { version = "0.4.5" }
 hex = "0.4.2"
+log = "0.4.8"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.8.1"
 reqwest = { version = "0.10.4", optional = true, default-features = false, features = ["blocking"] }

--- a/tough/src/datastore.rs
+++ b/tough/src/datastore.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::error::{self, Result};
+use log::debug;
 use serde::Serialize;
 use snafu::ResultExt;
 use std::fs::{self, File};
@@ -53,6 +54,7 @@ impl<'a> Datastore<'a> {
 
     pub(crate) fn remove(&self, file: &str) -> Result<()> {
         let path = self.write().join(file);
+        debug!("removing '{}'", path.display());
         match fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(err) => match err.kind() {

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -17,6 +17,7 @@ rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 [dependencies]
 chrono = "0.4.11"
 hex = "0.4.2"
+log = "0.4.8"
 maplit = "1.0.1"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.8.1"
@@ -28,14 +29,15 @@ rusoto_credential = { version = "0.44", optional = true }
 rusoto_ssm = { version = "0.44", optional = true, default-features = false }
 serde = "1.0.110"
 serde_json = "1.0.53"
+simplelog = "0.8.0"
 snafu = { version = "0.6.8", features = ["backtraces-impl-backtrace-crate"] }
 structopt = "0.3"
 tempfile = "3.1.0"
+tokio = "0.2.21"
+tough = { version = "0.7.0", path = "../tough", features = ["http"] }
+tough-ssm = { version = "0.2.0", path = "../tough-ssm" }
 url = "2.1.0"
 walkdir = "2.2.9"
-tough = { version = "0.7.0", path = "../tough", features = ["http"] }
-tokio = "0.2.21"
-tough-ssm = { version = "0.2.0", path = "../tough-ssm" }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -162,6 +162,12 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Unable to initialize logger: {}", source))]
+    Logger {
+        source: simplelog::TermLogError,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Metadata error: {}", source))]
     Metadata {
         source: tough::error::Error,


### PR DESCRIPTION
*Issue #, if available:*

Closes #9

*Description of changes:*

Add `log` to `tough` and `simplelogger` to `tuftool`. 
I didn't add a lot of logging because I expect these to be added organically over time. I added a couple that I know will be useful to `http`. Also, from #9: 

> some outstanding events can be noted, for example removal of datastore files upon rotation.

So I added a trace in the spot that I think was being referred.

*Testing*

I used a `tuftool` download command and confirmed that it worked both with and without adding `--log-level trace`. I confirmed that `tuftool` and `tough` traces showed up, but `hyper` and `reqwest` traces did not (I think this is the desired behavior).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
