### PR TITLE
tough: add documentation

### DIFF
--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 #![allow(clippy::used_underscore_binding)] // #20
 
+//! Provides a `RepositoryEditor` object for building and editing TUF repositories.
+
 mod keys;
 pub mod signed;
 mod test;

--- a/tough/src/editor/signed.rs
+++ b/tough/src/editor/signed.rs
@@ -1,6 +1,9 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Provides the `SignedRepository` object which represents the output of `RepositoryEditor` after
+//! signing, ready to be written to disk.
+
 use crate::editor::keys::get_root_keys;
 use crate::error::{self, Result};
 use crate::key_source::KeySource;
@@ -36,6 +39,7 @@ impl<T> SignedRole<T>
 where
     T: Role + Serialize,
 {
+    /// Creates a new `SignedRole`
     pub fn new(
         role: T,
         root: &Root,
@@ -102,18 +106,23 @@ where
         Ok(signed_role)
     }
 
+    /// Provides access to the internal signed metadata object.
     pub fn signed(&self) -> &Signed<T> {
         &self.signed
     }
 
+    /// Provides access to the internal buffer containing the serialized form of the signed role.
+    /// This buffer should be used anywhere this role is written to file.
     pub fn buffer(&self) -> &Vec<u8> {
         &self.buffer
     }
 
+    /// Provides the sha256 digest of the signed role.
     pub fn sha256(&self) -> &[u8] {
         &self.sha256
     }
 
+    /// Provides the length in bytes of the serialized representation of the signed role.
     pub fn length(&self) -> &u64 {
         &self.length
     }

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -19,6 +19,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum Error {
     #[snafu(display("Unable to canonicalize path '{}': {}", path.display(), source))]
     AbsolutePath {

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -1,3 +1,5 @@
+//! The `http` module provides `HttpTransport` which enables `Repository` objects to be
+//! loaded over HTTP
 use crate::error::{self, Error, Result};
 use crate::Transport;
 use log::{debug, error, trace};

--- a/tough/src/key_source.rs
+++ b/tough/src/key_source.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Provides an abstraction over the source of a signing key. This allows signing keys to be
+//! obtained, for example, from local files or from cloud provider key stores.
 use crate::error;
 use crate::sign::{parse_keypair, Sign};
 use snafu::ResultExt;
@@ -22,8 +24,10 @@ pub trait KeySource: Debug + Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
 }
 
+/// Points to a local key using a filesystem path.
 #[derive(Debug)]
 pub struct LocalKeySource {
+    /// The path to a local key file in PEM pkcs8 or RSA format.
     pub path: PathBuf,
 }
 

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -20,6 +20,8 @@
 
 #![forbid(missing_debug_implementations, missing_copy_implementations)]
 #![deny(rust_2018_idioms)]
+// missing_docs is on its own line to make it easy to comment out when making changes.
+#![deny(missing_docs)]
 #![warn(clippy::pedantic)]
 #![allow(
     clippy::module_name_repetitions,
@@ -61,7 +63,11 @@ use url::Url;
 /// it should ignore expired metadata (`Unsafe`). Only use `Unsafe` if you are sure you need it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExpirationEnforcement {
+    /// Expirations will be enforced. You MUST use this option to get TUF security guarantees.
     Safe,
+
+    /// Expirations will not be enforced. This is available for certain offline use cases, does NOT
+    /// provide TUF security guarantees, and should only be used if you are sure that you need it.
     Unsafe,
 }
 
@@ -352,6 +358,7 @@ impl<'a, T: Transport> Repository<'a, T> {
         })
     }
 
+    /// Return the named `DelegatedRole` if found.
     pub fn delegated_role(&self, name: &str) -> Option<&DelegatedRole> {
         self.targets.signed.delegated_role(name).ok()
     }

--- a/tough/src/schema/decoded.rs
+++ b/tough/src/schema/decoded.rs
@@ -1,3 +1,5 @@
+//! Provides a wrapper and traits for abstracting over decoded keys or different types.
+
 use crate::schema::error::{self, Error};
 use crate::schema::spki;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -14,6 +14,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(super)")]
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum Error {
     /// A duplicate key ID was present in the root metadata.
     #[snafu(display("Duplicate key ID: {}", keyid))]

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -6,6 +6,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashSet;
 
 impl Root {
+    /// Checks that the given metadata role is valid based on a threshold of key signatures.
     pub fn verify_role<T: Role + Serialize>(&self, role: &Signed<T>) -> Result<()> {
         let role_keys = self
             .roles

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+//! Provides the `Sign` trait which abstracts over the method of signing with different key types.
+
 use crate::error::{self, Result};
 use crate::schema::key::Key;
 use ring::rand::SecureRandom;

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -1,13 +1,19 @@
 use std::io::Read;
 use url::Url;
 
+/// A trait to abstract over the method/protocol by which files are obtained.
 pub trait Transport {
+    /// The type of `Read` object that the `fetch` function will return.
     type Stream: Read;
+
+    /// The type of error that the `fetch` function will return.
     type Error: std::error::Error + Send + Sync + 'static;
 
+    /// Opens a `Read` object for the file specified by `url`.
     fn fetch(&self, url: Url) -> Result<Self::Stream, Self::Error>;
 }
 
+/// Provides a `Transport` for local files.
 #[derive(Debug, Clone, Copy)]
 pub struct FilesystemTransport;
 


### PR DESCRIPTION
*Issue #, if available:*

Partially implements #1 

*Description of changes:*

Documents all `pub` things in `tough` and adds `#![deny(missing_docs)]` to keep it that way.

*Testing*

It builds!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
