### PR TITLE
ci: add cargo build --locked -p tough-ssm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ jobs:
     - run: cargo clippy --locked -- -D warnings
     - run: cargo build --locked -p olpc-cjson
     - run: cargo build --locked -p tough
+    - run: cargo build --locked -p tough-ssm
     - run: cargo build --locked -p tuftool
     - run: cargo test --locked
     - run: cd tough && cargo test --all-features --locked


### PR DESCRIPTION
*Issue #, if available:*

Closes #172

*Description of changes:*

Add `cargo build --locked -p tough-ssm` to CI.

*Testing*

Just CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
