### PR TITLE
remove copyright headers

### DIFF
--- a/olpc-cjson/src/lib.rs
+++ b/olpc-cjson/src/lib.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 //! `olpc-cjson` provides a [`serde_json::Formatter`] to serialize data as [canonical JSON], as
 //! defined by OLPC and used in [TUF].
 //!

--- a/olpc-cjson/src/main.rs
+++ b/olpc-cjson/src/main.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 //! Convenience binary for reading a JSON document on stdin and outputting the canonical JSON form
 //! on stdout.
 

--- a/tough-ssm/src/client.rs
+++ b/tough-ssm/src/client.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::error::{self, Result};
 use rusoto_core::{HttpClient, Region};
 use rusoto_credential::ProfileProvider;

--- a/tough-ssm/src/error.rs
+++ b/tough-ssm/src/error.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use snafu::{Backtrace, Snafu};
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tough-ssm/src/lib.rs
+++ b/tough-ssm/src/lib.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 mod client;
 pub mod error;
 

--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::build_targets;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};

--- a/tuftool/src/datetime.rs
+++ b/tuftool/src/datetime.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::error::{self, Result};
 
 use chrono::{DateTime, Duration, FixedOffset, Utc};

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::error::{self, Result};
 use snafu::{OptionExt, ResultExt};
 use std::fs::{File, OpenOptions};

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 // Not really worried about the memory penalty of large enum variants here
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::default_trait_access)]

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 #![deny(rust_2018_idioms)]
 #![warn(clippy::pedantic)]
 #![allow(

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;

--- a/tuftool/src/source.rs
+++ b/tuftool/src/source.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 #![allow(clippy::doc_markdown)]
 //! Private keys are generally provided as paths, but may sometimes be provided as a URL. For
 //! example, when one of the Rusoto features is enabled, you can use an aws-ssm:// special URL

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -1,6 +1,3 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use crate::build_targets;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -1,6 +1,3 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 mod utl;
 
 use assert_cmd::Command;

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -1,6 +1,3 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 mod utl;
 
 use assert_cmd::Command;

--- a/tuftool/tests/utl.rs
+++ b/tuftool/tests/utl.rs
@@ -1,6 +1,3 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: MIT OR Apache-2.0
-
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use url::Url;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Remove copyright headers that are no longer needed or desired. Note #174 removes/removed these in the `tough` crate.

*Testing*

CI only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
