### PR TITLE
tuftool: truncate targets when downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockito 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "olpc-cjson 0.1.0",
  "pem 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -41,3 +41,4 @@ walkdir = "2.2.9"
 
 [dev-dependencies]
 assert_cmd = "1.0"
+mockito = "0.26"

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{self, Result};
 use snafu::{OptionExt, ResultExt};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{self};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
@@ -78,11 +78,7 @@ impl DownloadArgs {
 
             root_warning(&path);
 
-            let mut f = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .open(&path)
-                .context(error::OpenFile { path: &path })?;
+            let mut f = File::create(&path).context(error::OpenFile { path: &path })?;
             reqwest::blocking::get(url.as_str())
                 .context(error::ReqwestGet)?
                 .copy_to(&mut f)
@@ -118,11 +114,7 @@ impl DownloadArgs {
                 .read_target(target)
                 .context(error::Metadata)?
                 .context(error::TargetNotFound { target })?;
-            let mut f = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .open(&path)
-                .context(error::OpenFile { path: &path })?;
+            let mut f = File::create(&path).context(error::OpenFile { path: &path })?;
             io::copy(&mut reader, &mut f).context(error::WriteTarget)?;
             Ok(())
         };

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-mod utl;
+mod test_utils;
 
 use assert_cmd::Command;
 use chrono::{Duration, Utc};
@@ -18,9 +18,11 @@ fn create_command() {
     let snapshot_version: u64 = 5432;
     let targets_expiration = Utc::now().checked_add_signed(Duration::days(13)).unwrap();
     let targets_version: u64 = 789;
-    let targets_input_dir = utl::test_data().join("tuf-reference-impl").join("targets");
-    let root_json = utl::test_data().join("simple-rsa").join("root.json");
-    let root_key = utl::test_data().join("snakeoil.pem");
+    let targets_input_dir = test_utils::test_data()
+        .join("tuf-reference-impl")
+        .join("targets");
+    let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
+    let root_key = test_utils::test_data().join("snakeoil.pem");
     let repo_dir = TempDir::new().unwrap();
     let load_dir = TempDir::new().unwrap();
 
@@ -54,8 +56,8 @@ fn create_command() {
         .success();
 
     // Load our newly created repo
-    let metadata_base_url = &utl::dir_url(repo_dir.path().join("metadata"));
-    let targets_base_url = &utl::dir_url(repo_dir.path().join("targets"));
+    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
+    let targets_base_url = &test_utils::dir_url(repo_dir.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
@@ -71,15 +73,15 @@ fn create_command() {
 
     // Ensure we can read the targets
     assert_eq!(
-        utl::read_to_end(repo.read_target("file1.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file1.txt").unwrap().unwrap()),
         &b"This is an example target file."[..]
     );
     assert_eq!(
-        utl::read_to_end(repo.read_target("file2.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file2.txt").unwrap().unwrap()),
         &b"This is an another example target file."[..]
     );
     assert_eq!(
-        utl::read_to_end(repo.read_target("file3.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file3.txt").unwrap().unwrap()),
         &b"This is role1's target file."[..]
     );
 
@@ -117,9 +119,9 @@ fn create_command() {
 #[test]
 // Ensure that the create command fails if none of the keys we give it match up with root.json.
 fn create_with_incorrect_key() {
-    let base = utl::test_data().join("tuf-reference-impl");
+    let base = test_utils::test_data().join("tuf-reference-impl");
     let root_json = base.join("metadata").join("1.root.json");
-    let bad_key = utl::test_data().join("snakeoil.pem");
+    let bad_key = test_utils::test_data().join("snakeoil.pem");
 
     // Call the create command passing a single key that cannot be found in root.json. Assert that
     // the command fails.

--- a/tuftool/tests/download_command.rs
+++ b/tuftool/tests/download_command.rs
@@ -1,0 +1,107 @@
+mod test_utils;
+
+use assert_cmd::Command;
+use mockito::mock;
+use std::fs::{read_to_string, OpenOptions};
+use std::io::Write;
+use std::str::FromStr;
+use tempfile::TempDir;
+use url::Url;
+
+/// Create a path in a mock HTTP server which serves a file from `tuf-reference-impl`.
+fn create_successful_get_mock(relative_path: &str) -> mockito::Mock {
+    let repo_dir = test_utils::test_data().join("tuf-reference-impl");
+    let file_bytes = std::fs::read(&repo_dir.join(relative_path)).unwrap();
+    mock("GET", ("/".to_owned() + relative_path).as_str())
+        .with_status(200)
+        .with_header("content-type", "application/octet-stream")
+        .with_body(file_bytes.as_slice())
+        .create()
+}
+
+/// Asserts that the named file in `outdir` exactly matches the file in `tuf-reference-impl/targets`
+fn assert_file_match(outdir: &TempDir, filename: &str) {
+    let got = read_to_string(outdir.path().join(filename)).unwrap();
+    let want = read_to_string(
+        test_utils::test_data()
+            .join("tuf-reference-impl")
+            .join("targets")
+            .join(filename),
+    )
+    .unwrap();
+    assert_eq!(got, want, "{} contents do not match.", filename);
+}
+
+#[test]
+// Ensure that the download command works, and that we truncate files when downloading into a non-
+// empty directory (i.e. that issue #173 is fixed).
+fn download_command_truncates() {
+    // let repo_dir = utl::test_data().join("tuf-reference-impl");
+    let _role_1 = create_successful_get_mock("metadata/role1.json");
+    let _role_2 = create_successful_get_mock("metadata/role2.json");
+    let _snapshot = create_successful_get_mock("metadata/snapshot.json");
+    let _targets = create_successful_get_mock("metadata/targets.json");
+    let _timestamp = create_successful_get_mock("metadata/timestamp.json");
+    let _file1 = create_successful_get_mock("targets/file1.txt");
+    let _file2 = create_successful_get_mock("targets/file2.txt");
+    let _file3 = create_successful_get_mock("targets/file3.txt");
+    let base_url = Url::from_str(mockito::server_url().as_str()).unwrap();
+    let metadata_base_url = base_url.join("metadata").unwrap().to_string();
+    let targets_base_url = base_url.join("targets").unwrap().to_string();
+
+    let outdir = TempDir::new().unwrap();
+    let root_json = test_utils::test_data()
+        .join("tuf-reference-impl")
+        .join("metadata")
+        .join("root.json");
+
+    // Download a test repo.
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "download",
+            "-r",
+            root_json.to_str().unwrap(),
+            "--metadata-url",
+            metadata_base_url.as_str(),
+            "--target-url",
+            targets_base_url.as_str(),
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Assert the files are exactly correct
+    assert_file_match(&outdir, "file1.txt");
+    assert_file_match(&outdir, "file2.txt");
+    // TODO - assert_file_match(&outdir, "file3.txt"); when delegate support lands.
+
+    // Add "bloop" to the end of file1.txt so that we can prove that the file is truncated when we
+    // download the repo a second time into the same outdir.
+    let mut f = OpenOptions::write(&mut OpenOptions::new(), true)
+        .append(true)
+        .open(outdir.path().join("file1.txt"))
+        .unwrap();
+    writeln!(f, "bloop").unwrap();
+
+    // Download again into the same outdir
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "download",
+            "-r",
+            root_json.to_str().unwrap(),
+            "--metadata-url",
+            metadata_base_url.as_str(),
+            "--target-url",
+            targets_base_url.as_str(),
+            outdir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Assert the files are exactly correct
+    assert_file_match(&outdir, "file1.txt");
+    assert_file_match(&outdir, "file2.txt");
+    // TODO - assert_file_match(&outdir, "file3.txt"); when delegate support lands.
+}

--- a/tuftool/tests/test_utils.rs
+++ b/tuftool/tests/test_utils.rs
@@ -5,7 +5,10 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use url::Url;
 
+/// Utilities for tests. Not every test module uses every function, so we suppress unused warnings.
+
 /// Returns the path to our test data directory
+#[allow(unused)]
 pub fn test_data() -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     p.pop();
@@ -13,11 +16,13 @@ pub fn test_data() -> PathBuf {
 }
 
 /// Converts a filepath into a URI formatted string
+#[allow(unused)]
 pub fn dir_url<P: AsRef<Path>>(path: P) -> String {
     Url::from_directory_path(path).unwrap().to_string()
 }
 
 /// Returns a vector of bytes from any object with the Read trait
+#[allow(unused)]
 pub fn read_to_end<R: Read>(mut reader: R) -> Vec<u8> {
     let mut v = Vec::new();
     reader.read_to_end(&mut v).unwrap();

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-mod utl;
+mod test_utils;
 
 use assert_cmd::Command;
 use chrono::{Duration, Utc};
@@ -17,9 +17,11 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
     let snapshot_version: u64 = 25;
     let targets_expiration = Utc::now().checked_add_signed(Duration::days(3)).unwrap();
     let targets_version: u64 = 17;
-    let targets_input_dir = utl::test_data().join("tuf-reference-impl").join("targets");
-    let root_json = utl::test_data().join("simple-rsa").join("root.json");
-    let root_key = utl::test_data().join("snakeoil.pem");
+    let targets_input_dir = test_utils::test_data()
+        .join("tuf-reference-impl")
+        .join("targets");
+    let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
+    let root_key = test_utils::test_data().join("snakeoil.pem");
 
     // Create a repo using tuftool and the reference tuf implementation data
     Command::cargo_bin("tuftool")
@@ -54,8 +56,8 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
 #[test]
 // Ensure we can read a repo that has had its metadata updated by `tuftool create`
 fn update_command_without_new_targets() {
-    let root_json = utl::test_data().join("simple-rsa").join("root.json");
-    let root_key = utl::test_data().join("snakeoil.pem");
+    let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
+    let root_key = test_utils::test_data().join("snakeoil.pem");
     let repo_dir = TempDir::new().unwrap();
 
     // Create a repo using tuftool and the reference tuf implementation data
@@ -68,7 +70,7 @@ fn update_command_without_new_targets() {
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(Duration::days(6)).unwrap();
     let new_targets_version: u64 = 170;
-    let metadata_base_url = &utl::dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -102,8 +104,8 @@ fn update_command_without_new_targets() {
 
     // Load the updated repo
     let temp_datastore = TempDir::new().unwrap();
-    let updated_metadata_base_url = &utl::dir_url(update_out.path().join("metadata"));
-    let updated_targets_base_url = &utl::dir_url(update_out.path().join("targets"));
+    let updated_metadata_base_url = &test_utils::dir_url(update_out.path().join("metadata"));
+    let updated_targets_base_url = &test_utils::dir_url(update_out.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
@@ -133,8 +135,8 @@ fn update_command_without_new_targets() {
 // Ensure we can read a repo that has had its metadata and targets updated
 // by `tuftool create`
 fn update_command_with_new_targets() {
-    let root_json = utl::test_data().join("simple-rsa").join("root.json");
-    let root_key = utl::test_data().join("snakeoil.pem");
+    let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
+    let root_key = test_utils::test_data().join("snakeoil.pem");
     let repo_dir = TempDir::new().unwrap();
 
     // Create a repo using tuftool and the reference tuf implementation data
@@ -147,8 +149,8 @@ fn update_command_with_new_targets() {
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(Duration::days(6)).unwrap();
     let new_targets_version: u64 = 170;
-    let new_targets_input_dir = utl::test_data().join("targets");
-    let metadata_base_url = &utl::dir_url(repo_dir.path().join("metadata"));
+    let new_targets_input_dir = test_utils::test_data().join("targets");
+    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -184,8 +186,8 @@ fn update_command_with_new_targets() {
 
     // Load the updated repo.
     let temp_datastore = TempDir::new().unwrap();
-    let updated_metadata_base_url = &utl::dir_url(update_out.path().join("metadata"));
-    let updated_targets_base_url = &utl::dir_url(update_out.path().join("targets"));
+    let updated_metadata_base_url = &test_utils::dir_url(update_out.path().join("metadata"));
+    let updated_targets_base_url = &test_utils::dir_url(update_out.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
@@ -204,15 +206,15 @@ fn update_command_with_new_targets() {
 
     // Ensure we can read the newly added targets
     assert_eq!(
-        utl::read_to_end(repo.read_target("file4.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file4.txt").unwrap().unwrap()),
         &b"This is an example target file."[..]
     );
     assert_eq!(
-        utl::read_to_end(repo.read_target("file5.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file5.txt").unwrap().unwrap()),
         &b"This is another example target file."[..]
     );
     assert_eq!(
-        utl::read_to_end(repo.read_target("file6.txt").unwrap().unwrap()),
+        test_utils::read_to_end(repo.read_target("file6.txt").unwrap().unwrap()),
         &b"This is yet another example target file."[..]
     );
 
@@ -228,9 +230,9 @@ fn update_command_with_new_targets() {
 #[test]
 // Ensure that the update command fails if none of the keys we give it match up with root.json.
 fn update_with_incorrect_key() {
-    let base = utl::test_data().join("tuf-reference-impl");
+    let base = test_utils::test_data().join("tuf-reference-impl");
     let root_json = base.join("metadata").join("1.root.json");
-    let bad_key = utl::test_data().join("snakeoil.pem");
+    let bad_key = test_utils::test_data().join("snakeoil.pem");
 
     Command::cargo_bin("tuftool")
         .unwrap()


### PR DESCRIPTION
*Issue #, if available:*

Fixes #173 

*Description of changes:*

Use `File::create` instead of `OpenOptions` in `tuftool download`. `File::create` includes `create(true).open(true).truncate(true)` which is how we want to open our files for writing. By including `truncate(true)` the buggy behaviour seen in #173 is fixed.

*Testing*

I added an integ test of the `download` command. It adds some text to the end of one of the targets in the `outdir` after download. It then downloads the repo again and asserts the the file is correct.

This test was observed to fail before implementing the fix:

```
thread 'download_command_truncates' panicked at 'assertion failed: `(left == right)`
  left: `"This is an example target file.bloop
"`,
 right: `"This is an example target file."`: file1.txt contents do not match.', tuftool/tests/download_command.rs:34:5
```

After implementing the fix, the test passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
