### PR TITLE
Create an error if the proposed root.json is unstable

### DIFF
--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -78,7 +78,11 @@ impl RepositoryEditor {
         // Sanity check of root
         for (roletype, rolekeys) in &root.signed.roles {
             if rolekeys.threshold.get() > rolekeys.keyids.len() as u64 {
-                return Err(error::Error::UnstableRoot { role: *roletype });
+                return Err(error::Error::UnstableRoot {
+                    role: *roletype,
+                    threshold: rolekeys.threshold.get(),
+                    actual: rolekeys.keyids.len(),
+                });
             }
         }
 

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -74,6 +74,14 @@ impl RepositoryEditor {
         let root_buf_len = root_buf.len() as u64;
         let root = serde_json::from_slice::<Signed<Root>>(&root_buf)
             .context(error::FileParseJson { path: root_path })?;
+
+        // Sanity check of root
+        for (roletype, rolekeys) in &root.signed.roles {
+            if rolekeys.threshold.get() > rolekeys.keyids.len() as u64 {
+                return Err(error::Error::UnstableRoot { role: *roletype });
+            }
+        }
+
         let mut digest = [0; SHA256_OUTPUT_LEN];
         digest.copy_from_slice(ring::digest::digest(&SHA256, &root_buf).as_ref());
 

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -75,7 +75,7 @@ impl RepositoryEditor {
         let root = serde_json::from_slice::<Signed<Root>>(&root_buf)
             .context(error::FileParseJson { path: root_path })?;
 
-        // Sanity check of root
+        // Quick check that root is signed by enough key IDs
         for (roletype, rolekeys) in &root.signed.roles {
             if rolekeys.threshold.get() > rolekeys.keyids.len() as u64 {
                 return Err(error::Error::UnstableRoot {

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -442,8 +442,17 @@ pub enum Error {
     RoleNotInMeta { name: String },
 
     /// Root creates an unloadable repo
-    #[snafu(display("Unstable root, less keys then threshold for: {}", role))]
-    UnstableRoot { role: RoleType },
+    #[snafu(display(
+        "Unstable root; found {} keys for role {}, threshold is {}",
+        role,
+        actual,
+        threshold
+    ))]
+    UnstableRoot {
+        role: RoleType,
+        actual: usize,
+        threshold: u64,
+    },
 }
 
 // used in `std::io::Read` implementations

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -440,6 +440,10 @@ pub enum Error {
 
     #[snafu(display("Role missing from snapshot meta: {}", name))]
     RoleNotInMeta { name: String },
+
+    /// Root creates an unloadable repo
+    #[snafu(display("Unstable root, less keys then threshold for: {}", role))]
+    UnstableRoot { role: RoleType },
 }
 
 // used in `std::io::Read` implementations


### PR DESCRIPTION
*Issue #, if available:*
Closes #123 
*Description of changes:*
The pr adds a sanity check to `RepositoryEditor::new()` to make sure the number of keyids is more than the threshold for each role.
*Testing*
Created a root.json with a high threshold than keyids for targets and calling tuftool create reported that root was unstable
All other tests work as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
