### PR TITLE
Fix new clippy lints in Rust 1.45

### DIFF
--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -172,7 +172,7 @@ impl RetryState {
                 Ordering::Greater => {
                     self.wait = settings.max_backoff;
                 }
-                _ => {}
+                Ordering::Equal => {}
             }
         }
         self.current_try += 1;

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -759,7 +759,7 @@ impl Delegations {
             if let Some(targets) = &delegated_role.targets {
                 match targets.signed.delegated_role(name) {
                     Ok(delegations) => return Ok(delegations),
-                    _ => continue,
+                    Err(_) => continue,
                 }
             } else {
                 return Err(Error::NoDelegations {});


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

CI is now on Rust 1.45 which has new lints. Whee!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
