### PR TITLE
tuftool root sign performs check of root.json

### DIFF
--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -221,6 +221,16 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display(
+        "Root was signed with less than {} signatures: {}",
+        threshold,
+        signature_count
+    ))]
+    SignatureRoot {
+        threshold: u64,
+        signature_count: usize,
+    },
+
     #[snafu(display("Failed to sign '{}': {}", path.display(), source))]
     SignRoot {
         path: PathBuf,
@@ -259,6 +269,10 @@ pub(crate) enum Error {
         scheme: String,
         backtrace: Backtrace,
     },
+
+    /// Root creates an unloadable repo
+    #[snafu(display("Unstable root, less keys then threshold for: {}", role))]
+    UnstableRoot { role: tough::schema::RoleType },
 
     #[snafu(display("Failed to parse URL \"{}\": {}", url, source))]
     UrlParse {

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -222,9 +222,9 @@ pub(crate) enum Error {
     },
 
     #[snafu(display(
-        "Root was signed with less than {} signatures: {}",
+        "Root was signed with {} signatures; it must be signed with at least {}",
+        signature_count,
         threshold,
-        signature_count
     ))]
     SignatureRoot {
         threshold: u64,
@@ -271,8 +271,17 @@ pub(crate) enum Error {
     },
 
     /// Root creates an unloadable repo
-    #[snafu(display("Unstable root, less keys then threshold for: {}", role))]
-    UnstableRoot { role: tough::schema::RoleType },
+    #[snafu(display(
+        "Unstable root: '{}' role contains {} keys, threshold is {}",
+        role,
+        actual,
+        threshold
+    ))]
+    UnstableRoot {
+        role: tough::schema::RoleType,
+        threshold: u64,
+        actual: usize,
+    },
 
     #[snafu(display("Failed to parse URL \"{}\": {}", url, source))]
     UrlParse {

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -289,7 +289,11 @@ impl Command {
         // Sanity check of root
         for (roletype, rolekeys) in &signed_root.signed().signed.roles {
             if rolekeys.threshold.get() > rolekeys.keyids.len() as u64 {
-                return Err(error::Error::UnstableRoot { role: *roletype });
+                return Err(error::Error::UnstableRoot {
+                    role: *roletype,
+                    threshold: rolekeys.threshold.get(),
+                    actual: rolekeys.keyids.len(),
+                });
             }
         }
 
@@ -300,7 +304,10 @@ impl Command {
             .roles
             .get(&RoleType::Root)
             .ok_or_else(|| error::Error::UnstableRoot {
+                // The code should never reach this point
                 role: RoleType::Root,
+                threshold: 0,
+                actual: 0,
             })?
             .threshold
             .get();

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -286,7 +286,7 @@ impl Command {
         )
         .context(error::SignRoot { path })?;
 
-        // Sanity check of root
+        // Quick check that root is signed by enough key IDs
         for (roletype, rolekeys) in &signed_root.signed().signed.roles {
             if rolekeys.threshold.get() > rolekeys.keyids.len() as u64 {
                 return Err(error::Error::UnstableRoot {

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -1,0 +1,274 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod test_utils;
+
+use assert_cmd::Command;
+
+#[ignore]
+#[test]
+// Ensure we can create and sign a root file
+fn create_root() {
+    let key = test_utils::test_data().join("snakeoil.pem");
+    // Create root.json
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&["root", "init", "tests/root_test/root.json"])
+        .assert()
+        .success();
+
+    // Set the threshold for roles
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "root",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "targets",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "snapshot",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "timestamp",
+            "1",
+        ])
+        .assert()
+        .success();
+
+    // Add keys for all roles
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "add-key",
+            "tests/root_test/root.json",
+            key.to_str().unwrap(),
+            "-r",
+            "root",
+            "-r",
+            "targets",
+            "-r",
+            "snapshot",
+            "-r",
+            "timestamp",
+        ])
+        .assert()
+        .success();
+
+    // Sign root.json
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "sign",
+            "tests/root_test/root.json",
+            key.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[ignore]
+#[test]
+// Ensure creating an unstable root throws error
+fn create_unstable_root() {
+    let key = test_utils::test_data().join("snakeoil.pem");
+    // Create root.json
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&["root", "init", "tests/root_test/root.json"])
+        .assert()
+        .success();
+
+    // Set the threshold for roles with targets being more than 1
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "root",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "targets",
+            "2",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "snapshot",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "timestamp",
+            "1",
+        ])
+        .assert()
+        .success();
+
+    // Add keys for all roles
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "add-key",
+            "tests/root_test/root.json",
+            key.to_str().unwrap(),
+            "-r",
+            "root",
+            "-r",
+            "targets",
+            "-r",
+            "snapshot",
+            "-r",
+            "timestamp",
+        ])
+        .assert()
+        .success();
+
+    // Sign root.json (error because targets can never be validated root has 1 key but targets requires 2 signatures)
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "sign",
+            "tests/root_test/root.json",
+            key.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+}
+
+#[ignore]
+#[test]
+// Ensure signing a root with insuffecient keys throws error
+fn create_invalid_root() {
+    let key = test_utils::test_data().join("snakeoil.pem");
+    // Create root.json
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&["root", "init", "tests/root_test/root.json"])
+        .assert()
+        .success();
+
+    // Set the threshold for roles
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "root",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "targets",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "snapshot",
+            "1",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "set-threshold",
+            "tests/root_test/root.json",
+            "timestamp",
+            "1",
+        ])
+        .assert()
+        .success();
+
+    // Add keys for all roles
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "root",
+            "add-key",
+            "tests/root_test/root.json",
+            key.to_str().unwrap(),
+            "-r",
+            "root",
+            "-r",
+            "targets",
+            "-r",
+            "snapshot",
+            "-r",
+            "timestamp",
+        ])
+        .assert()
+        .success();
+
+    // Sign root.json (error because key is not valid)
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&["root", "sign", "tests/root_test/root.json"])
+        .assert()
+        .failure();
+}

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -2,18 +2,23 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 mod test_utils;
+use tempfile::TempDir;
 
 use assert_cmd::Command;
 
-#[ignore]
 #[test]
 // Ensure we can create and sign a root file
 fn create_root() {
     let key = test_utils::test_data().join("snakeoil.pem");
+    let outdir = TempDir::new().unwrap();
     // Create root.json
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "init", "tests/root_test/root.json"])
+        .args(&[
+            "root",
+            "init",
+            outdir.path().join("root.json").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -23,7 +28,7 @@ fn create_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "root",
             "1",
         ])
@@ -34,7 +39,7 @@ fn create_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "targets",
             "1",
         ])
@@ -45,7 +50,7 @@ fn create_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "snapshot",
             "1",
         ])
@@ -56,7 +61,7 @@ fn create_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "timestamp",
             "1",
         ])
@@ -69,7 +74,7 @@ fn create_root() {
         .args(&[
             "root",
             "add-key",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             key.to_str().unwrap(),
             "-r",
             "root",
@@ -89,22 +94,26 @@ fn create_root() {
         .args(&[
             "root",
             "sign",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             key.to_str().unwrap(),
         ])
         .assert()
         .success();
 }
 
-#[ignore]
 #[test]
 // Ensure creating an unstable root throws error
 fn create_unstable_root() {
+    let outdir = TempDir::new().unwrap();
     let key = test_utils::test_data().join("snakeoil.pem");
     // Create root.json
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "init", "tests/root_test/root.json"])
+        .args(&[
+            "root",
+            "init",
+            outdir.path().join("root.json").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -114,7 +123,7 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "root",
             "1",
         ])
@@ -125,7 +134,7 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "targets",
             "2",
         ])
@@ -136,7 +145,7 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "snapshot",
             "1",
         ])
@@ -147,7 +156,7 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "timestamp",
             "1",
         ])
@@ -160,7 +169,7 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "add-key",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             key.to_str().unwrap(),
             "-r",
             "root",
@@ -180,22 +189,26 @@ fn create_unstable_root() {
         .args(&[
             "root",
             "sign",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             key.to_str().unwrap(),
         ])
         .assert()
         .failure();
 }
 
-#[ignore]
 #[test]
 // Ensure signing a root with insuffecient keys throws error
 fn create_invalid_root() {
+    let outdir = TempDir::new().unwrap();
     let key = test_utils::test_data().join("snakeoil.pem");
     // Create root.json
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "init", "tests/root_test/root.json"])
+        .args(&[
+            "root",
+            "init",
+            outdir.path().join("root.json").to_str().unwrap(),
+        ])
         .assert()
         .success();
 
@@ -205,7 +218,7 @@ fn create_invalid_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "root",
             "1",
         ])
@@ -216,7 +229,7 @@ fn create_invalid_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "targets",
             "1",
         ])
@@ -227,7 +240,7 @@ fn create_invalid_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "snapshot",
             "1",
         ])
@@ -238,7 +251,7 @@ fn create_invalid_root() {
         .args(&[
             "root",
             "set-threshold",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             "timestamp",
             "1",
         ])
@@ -251,7 +264,7 @@ fn create_invalid_root() {
         .args(&[
             "root",
             "add-key",
-            "tests/root_test/root.json",
+            outdir.path().join("root.json").to_str().unwrap(),
             key.to_str().unwrap(),
             "-r",
             "root",
@@ -268,7 +281,11 @@ fn create_invalid_root() {
     // Sign root.json (error because key is not valid)
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "sign", "tests/root_test/root.json"])
+        .args(&[
+            "root",
+            "sign",
+            outdir.path().join("root.json").to_str().unwrap(),
+        ])
         .assert()
         .failure();
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #119

*Description of changes:*
Adds a sanity check in `tuftool root sign` to make sure it's possible for all roles to be adequately signed
Adds a signature check in `tuftool root sign` to make sure `root.json` has enough signatures

*Testing*
root_command contains tests, but must be run locally with directory `root_test` added to `tuftool/tests`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
