### PR TITLE
Allow multiple signatures in editor

### DIFF
--- a/tough/src/editor/signed.rs
+++ b/tough/src/editor/signed.rs
@@ -54,12 +54,9 @@ where
         // Ensure the keys we have available to us will allow us
         // to sign this role. The role's key ids must match up with one of
         // the keys provided.
-        let (signing_key_id, signing_key) = root_keys
+        let valid_keys = root_keys
             .iter()
-            .find(|(keyid, _signing_key)| role_keys.keyids.contains(&keyid))
-            .context(error::SigningKeysNotFound {
-                role: T::TYPE.to_string(),
-            })?;
+            .filter(|(keyid, _signing_key)| role_keys.keyids.contains(&keyid));
 
         // Create the `Signed` struct for this role. This struct will be
         // mutated later to contain the signatures.
@@ -75,13 +72,20 @@ where
             .context(error::SerializeRole {
                 role: T::TYPE.to_string(),
             })?;
-        let sig = signing_key.sign(&data, rng)?;
+        for (signing_key_id, signing_key) in valid_keys {
+            let sig = signing_key.sign(&data, rng)?;
 
-        // Add the signatures to the `Signed` struct for this role
-        role.signatures.push(Signature {
-            keyid: signing_key_id.clone(),
-            sig: sig.into(),
-        });
+            // Add the signatures to the `Signed` struct for this role
+            role.signatures.push(Signature {
+                keyid: signing_key_id.clone(),
+                sig: sig.into(),
+            });
+        }
+        if role_keys.threshold.get() > role.signatures.len() as u64 {
+            return Err(error::Error::SigningKeysNotFound {
+                role: T::TYPE.to_string(),
+            });
+        }
 
         // Serialize the newly signed role, and calculate its length and
         // sha256.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Creating a `SignedRole` from a `RepositoryEditor` doesn't allow for multiple keys to sign the role, so if a role had a threshold of 2 signatures, it could never be properly signed.
Collects all valid signing keys instead of the first one and signs the role using all of them

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
