### PR TITLE
tough v0.8.0 / tuftool v0.4.1 / tough-ssm v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rusoto_core 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.44.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1904,7 +1904,7 @@ dependencies = [
  "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.7.1",
+ "tough 0.8.0",
 ]
 
 [[package]]
@@ -1924,7 +1924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tuftool"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1947,8 +1947,8 @@ dependencies = [
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "tough 0.7.1",
- "tough-ssm 0.2.0",
+ "tough 0.8.0",
+ "tough-ssm 0.3.0",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2020-07-20
+### Added
+- Added CI build of `tough-ssm`.
+
+### Changed
+- Update `tough` dependency to 0.8.0.
+
 ## [0.2.0] - 2020-06-26
 ### Changed
 - Update `tough` dependency to 0.7.0.
@@ -12,4 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[0.3.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.2.0...tough-ssm-v0.3.0
+[0.2.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.1.0...tough-ssm-v0.2.0
 [0.1.0]: https://github.com/awslabs/tough/releases/tag/tough-ssm-v0.1.0

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.2.0"
+version = "0.3.0"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rusoto-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_ssm/
 rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.7.0", path = "../tough", features = ["http"] }
+tough = { version = "0.8.0", path = "../tough", features = ["http"] }
 rusoto_core = { version = "0.44", optional = true, default-features = false }
 rusoto_credential = { version = "0.44", optional = true }
 rusoto_ssm = { version = "0.44", optional = true, default-features = false }

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,12 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2020-07-20
 ### Breaking Changes
 - The `HttpTransport` type and the `Read` and `Error` types that it uses have changed.
+- Remove `root.json` from Snapshot metadata per [theupdateframework/specification#40](https://github.com/theupdateframework/specification/pull/40) 
 
 ### Added
-- Added HTTP retry logic. #143
+- Added HTTP retry logic.
+- Added early support for delegations.
+- Added logging.
+- Added documentation to all remaining items.
+- Allow control of link/copy behavior for existing paths.
+
+### Changed
+- Dependency updates.
+- Fix new clippy lints in Rust 1.45.
 
 ## [0.7.1] - 2020-07-09
 
@@ -69,7 +78,9 @@ For changes that require modification of calling code see #120 and #121.
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.7.0...HEAD
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.8.0...HEAD
+[0.8.0]: https://github.com/awslabs/tough/compare/tough-v0.7.1...tough-v0.8.0
+[0.7.1]: https://github.com/awslabs/tough/compare/tough-v0.7.0...tough-v0.7.1
 [0.7.0]: https://github.com/awslabs/tough/compare/tough-v0.6.0...tough-v0.7.0
 [0.6.0]: https://github.com/awslabs/tough/compare/tough-v0.5.0...tough-v0.6.0
 [0.5.0]: https://github.com/awslabs/tough/compare/tough-v0.4.0...tough-v0.5.0

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.7.1"
+version = "0.8.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.1] - 2020-07-20
+### Added
+- Added logging.
+- Added downloading of specific targets.
+- Allow control of link/copy behavior for existing paths.
+
 ### Changed
-- Bumped `tough` to 0.7.0
-- Bumped `tough-ssm` to 0.2.0
+- Bumped `tough` to 0.8.0.
+- Bumped `tough-ssm` to 0.2.1.
+- Truncate targets that already exist before downloading with `tuftool`.
 
 ## [0.4.0] - 2020-06-11
 
@@ -66,6 +72,9 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
+[0.4.1]: https://github.com/awslabs/tough/compare/tuftool-v0.4.0...tuftool-v0.4.1
+[0.4.0]: https://github.com/awslabs/tough/compare/tuftool-v0.3.1...tuftool-v0.4.0
+[0.3.1]: https://github.com/awslabs/tough/compare/tuftool-v0.3.0...tuftool-v0.3.1
 [0.3.0]: https://github.com/awslabs/tough/compare/tuftool-v0.2.0...tuftool-v0.3.0
 [0.2.0]: https://github.com/awslabs/tough/compare/tuftool-v0.1.1...tuftool-v0.2.0
 [0.1.1]: https://github.com/awslabs/tough/compare/tuftool-v0.1.0...tuftool-v0.1.1

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.4.0"
+version = "0.4.1"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -34,8 +34,8 @@ snafu = { version = "0.6.8", features = ["backtraces-impl-backtrace-crate"] }
 structopt = "0.3"
 tempfile = "3.1.0"
 tokio = "0.2.21"
-tough = { version = "0.7.0", path = "../tough", features = ["http"] }
-tough-ssm = { version = "0.2.0", path = "../tough-ssm" }
+tough = { version = "0.8.0", path = "../tough", features = ["http"] }
+tough-ssm = { version = "0.3.0", path = "../tough-ssm" }
 url = "2.1.0"
 walkdir = "2.2.9"
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Prepare the release of `tough`, `tuftool`, and `tough-ssm`

*Testing done:*
* `cargo test` passes
* We've been using these changes locally to build repos for Bottlerocket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
