### PR TITLE
Link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # tough
 
-**tough** is a Rust client for [The Update Framework](https://theupdateframework.github.io/) (TUF) repositories.
+**tough** is a Rust client library for [The Update Framework](https://theupdateframework.github.io/) (TUF) repositories.
 
 **tuftool** is a Rust command-line utility for generating and signing TUF repositories.
+
+## Documentation
+See [tough - Rust](https://docs.rs/tough/) for the latest documentation.
+
 
 ## License
 


### PR DESCRIPTION
*Issue #, if available:*
Partially implements #1

*Description of changes:*
I'm a newbie, and don't know if there are already best practices for how to link to documentation from github README.md files,
but for people like me who didn't know how to find the latest documentation of a given crate, this seems like a useful addition.

Also noting that `tough` itself is a library, not a stand-alone client. But again, I don't really know Rust terminology....

Thanks for this!!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
