### PR TITLE
Fixed empty string handling while parting AWS KMS key

### DIFF
--- a/tuftool/src/source.rs
+++ b/tuftool/src/source.rs
@@ -89,7 +89,11 @@ pub(crate) fn parse_key_source(input: &str) -> Result<Box<dyn KeySource>> {
                 }
             }),
             // remove first '/' from the path to get the key_id
-            key_id: url.path()[1..].to_string(),
+            key_id: if url.path().is_empty() {
+                String::from("")
+            } else {
+                url.path()[1..].to_string()
+            },
             client: None,
             signing_algorithm: KmsSigningAlgorithm::RsassaPssSha256,
         })),


### PR DESCRIPTION
*Issue #, if available:*
#226

*Description of changes:*
Handled empty URL path before extracting first '/' from the path.

Testing Done:
Modified tutool integration test to use `aws-kms://tuf-junk` and see it fail with error `Unable to parse keypair: Failed to get public key for aws-kms://tuf-junk/ : profile not found` instead of panic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
