### PR TITLE
Update code for clippy's new 'option-if-let-else' check

### DIFF
--- a/olpc-cjson/src/lib.rs
+++ b/olpc-cjson/src/lib.rs
@@ -91,15 +91,15 @@ impl CanonicalFormatter {
     ///
     /// If we are not currently writing an object, pass through `writer`.
     fn writer<'a, W: Write + ?Sized>(&'a mut self, writer: &'a mut W) -> Box<dyn Write + 'a> {
-        if let Some(object) = self.object_stack.last_mut() {
-            if object.key_done {
-                Box::new(&mut object.next_value)
-            } else {
-                Box::new(&mut object.next_key)
-            }
-        } else {
-            Box::new(writer)
-        }
+        self.object_stack
+            .last_mut()
+            .map_or(Box::new(writer), |object| {
+                if object.key_done {
+                    Box::new(&mut object.next_value)
+                } else {
+                    Box::new(&mut object.next_key)
+                }
+            })
     }
 
     /// Returns a mutable reference to the top of the object stack.

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -353,11 +353,10 @@ impl<'a, T: Transport> TargetsEditor<'a, T> {
         if recursive {
             // Keep all roles that do not delegate `role` down the chain of delegations
             delegations.roles.retain(|delegated_role| {
-                if let Some(targets) = delegated_role.targets.as_ref() {
-                    targets.signed.delegated_role(role).is_err()
-                } else {
-                    true
-                }
+                delegated_role
+                    .targets
+                    .as_ref()
+                    .map_or(true, |targets| targets.signed.delegated_role(role).is_err())
             });
         }
         Ok(self)

--- a/tuftool/src/add_role.rs
+++ b/tuftool/src/add_role.rs
@@ -151,6 +151,7 @@ impl AddRoleArgs {
         Ok(())
     }
 
+    #[allow(clippy::option_if_let_else)]
     /// Adds a role to metadata using targets Editor
     fn with_targets_editor<T>(&self, role: &str, mut editor: TargetsEditor<'_, T>) -> Result<()>
     where
@@ -187,6 +188,7 @@ impl AddRoleArgs {
         Ok(())
     }
 
+    #[allow(clippy::option_if_let_else)]
     /// Adds a role to metadata using repo Editor
     fn with_repo_editor<T>(&self, role: &str, mut editor: RepositoryEditor<'_, T>) -> Result<()>
     where


### PR DESCRIPTION
*Issue #, if available:*
N/A
Related to #234 

*Description of changes:*
Clippy appears to have a new check... it is very pedantic about using `Option::map_or()`

I made the changes in the spots where it made sense.  I opted to ignore the suggestion in 2 places where there were long `if/else` chains, as it made the code very hard to follow there.

*Testing done:*
Basically ran all the same checks as the GH actions runs.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
