### PR TITLE
Added tuftool support for specifying root.json's version using set-version command 

### DIFF
--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -51,6 +51,13 @@ pub(crate) enum Command {
         /// The new threshold
         threshold: NonZeroU64,
     },
+    /// Set the version number for root.json
+    SetVersion {
+        /// Path to root.json
+        path: PathBuf,
+        /// Version number
+        version: NonZeroU64,
+    },
     /// Add a key (public or private) to a role
     AddKey {
         /// Path to root.json
@@ -128,6 +135,7 @@ impl Command {
                 role,
                 threshold,
             } => Command::set_threshold(&path, role, threshold),
+            Command::SetVersion { path, version } => Command::set_version(&path, version),
             Command::AddKey {
                 path,
                 roles,
@@ -200,6 +208,13 @@ impl Command {
             .entry(role)
             .and_modify(|rk| rk.threshold = threshold)
             .or_insert_with(|| role_keys!(threshold));
+        clear_sigs(&mut root);
+        write_file(path, &root)
+    }
+
+    fn set_version(path: &PathBuf, version: NonZeroU64) -> Result<()> {
+        let mut root: Signed<Root> = load_file(path)?;
+        root.signed.version = version;
         clear_sigs(&mut root);
         write_file(path, &root)
     }


### PR DESCRIPTION
*Issue #225 :*

*Description of changes:*
Added a tuftool  command `tuftool root set-version <root.json> <version>` to specify root.json's version number after intializing root.json 

*Testing done*
1. Added testcase to verify that specified version number is set
2. Manual executed the above command, created repo and verified that correct filename (`<version>.root.json` ) is generated as a part of metadata


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
