### PR TITLE
Supported file:// url for tuftool download

### DIFF
--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -10,9 +10,9 @@ cargo install --force tuftool
 
 By default, cargo installs binaries to `~/.cargo/bin`, so you will need this in your path. See the [cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for more about installing Rust binary crates.
 
-## Creating a Minimal TUF Repo
+## Minimal TUF Repo
 
-The following is an example of how you can create a TUF repository using `tuftool`.
+The following is an example of how you can create and download a TUF repository using `tuftool`.
 First, create a working directory:
 
 ```sh
@@ -73,7 +73,7 @@ mkdir -p "${WRK}/input"
 echo "1" > "${WRK}/input/1.txt"
 echo "2" > "${WRK}/input/2.txt"
 
-# finally, create a tuf repo!
+# create a tuf repo!
 tuftool create \
   --root "${ROOT}" \
   --key "${WRK}/keys/root.pem" \
@@ -96,7 +96,7 @@ ls "${WRK}/tuf-repo/targets"
 # Change one of the target files
 echo "1.1" > "${WRK}/input/1.txt"
 
-# finally, update tuf repo!
+# update tuf repo!
 tuftool update \
    --root "${ROOT}" \
    --key "${WRK}/keys/root.pem" \
@@ -109,6 +109,20 @@ tuftool update \
    --timestamp-version 2 \
    --outdir "${WRK}/tuf-repo" \
    --metadata-url file:///$WRK/tuf-repo/metadata
+```
+
+### Download TUF Repo
+Now that we have created TUF repo, we can inspect it using download command. 
+Download command is usually used to download a remote repo using HTTP/S url, but 
+for this example we will use a file based url to download from local repo.
+
+```sh
+# downlaod tuf repo
+tuftool download \
+   --root "${ROOT}" \
+   -t "file://${WRK}/tuf-repo/targets" \
+   -m "file://${WRK}/tuf-repo/metadata" \
+   "${WRK}/tuf-downlaod"
 ```
 
 ## Testing

--- a/tuftool/tests/download_command.rs
+++ b/tuftool/tests/download_command.rs
@@ -32,23 +32,7 @@ fn assert_file_match(outdir: &TempDir, filename: &str) {
     assert_eq!(got, want, "{} contents do not match.", filename);
 }
 
-#[test]
-// Ensure that the download command works, and that we truncate files when downloading into a non-
-// empty directory (i.e. that issue #173 is fixed).
-fn download_command_truncates() {
-    // let repo_dir = utl::test_data().join("tuf-reference-impl");
-    let _role_1 = create_successful_get_mock("metadata/role1.json");
-    let _role_2 = create_successful_get_mock("metadata/role2.json");
-    let _snapshot = create_successful_get_mock("metadata/snapshot.json");
-    let _targets = create_successful_get_mock("metadata/targets.json");
-    let _timestamp = create_successful_get_mock("metadata/timestamp.json");
-    let _file1 = create_successful_get_mock("targets/file1.txt");
-    let _file2 = create_successful_get_mock("targets/file2.txt");
-    let _file3 = create_successful_get_mock("targets/file3.txt");
-    let base_url = Url::from_str(mockito::server_url().as_str()).unwrap();
-    let metadata_base_url = base_url.join("metadata").unwrap().to_string();
-    let targets_base_url = base_url.join("targets").unwrap().to_string();
-
+fn download_command(metadata_base_url: String, targets_base_url: String) {
     let outdir = TempDir::new().unwrap();
     let root_json = test_utils::test_data()
         .join("tuf-reference-impl")
@@ -104,4 +88,34 @@ fn download_command_truncates() {
     assert_file_match(&outdir, "file1.txt");
     assert_file_match(&outdir, "file2.txt");
     // TODO - assert_file_match(&outdir, "file3.txt"); when delegate support lands.
+}
+
+#[test]
+// Ensure that the download command works with http url, and that we truncate files when downloading into a non-
+// empty directory (i.e. that issue #173 is fixed).
+fn download_command_truncates_http() {
+    // let repo_dir = utl::test_data().join("tuf-reference-impl");
+    let _role_1 = create_successful_get_mock("metadata/role1.json");
+    let _role_2 = create_successful_get_mock("metadata/role2.json");
+    let _snapshot = create_successful_get_mock("metadata/snapshot.json");
+    let _targets = create_successful_get_mock("metadata/targets.json");
+    let _timestamp = create_successful_get_mock("metadata/timestamp.json");
+    let _file1 = create_successful_get_mock("targets/file1.txt");
+    let _file2 = create_successful_get_mock("targets/file2.txt");
+    let _file3 = create_successful_get_mock("targets/file3.txt");
+    let base_url = Url::from_str(mockito::server_url().as_str()).unwrap();
+    base_url.join("metadata").unwrap().to_string();
+    let metadata_base_url = base_url.join("metadata").unwrap().to_string();
+    let targets_base_url = base_url.join("targets").unwrap().to_string();
+    download_command(metadata_base_url, targets_base_url);
+}
+
+#[test]
+// Ensure that the download command works with file url, and that we truncate files when downloading into a non-
+// empty directory (i.e. that issue #173 is fixed).
+fn download_command_truncates_file() {
+    let repo_dir = test_utils::test_data().join("tuf-reference-impl");
+    let metadata_base_url = test_utils::dir_url(repo_dir.join("metadata").to_str().unwrap());
+    let targets_base_url = test_utils::dir_url(repo_dir.join("targets").to_str().unwrap());
+    download_command(metadata_base_url, targets_base_url);
 }


### PR DESCRIPTION
*Issue #, if available:*
#222 

*Description of changes:*
* Updated tuftool README.md with an example of `tuftool downlaod`
* Added test to download using file:// form local repository.

Testing:
* Followed updated tuftool README.md to create and download tuf repo
* Ran the added test case to download form local repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
