### PR TITLE
tough: remove lifetime annotation from settings

### DIFF
--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.58"
 serde_plain = "0.3.0"
 snafu = "0.6.8"
+tempfile = "3.1.0"
 untrusted = "0.7.0"
 url = "2.1.0"
 walkdir = "2.2.9"
@@ -28,7 +29,6 @@ walkdir = "2.2.9"
 [dev-dependencies]
 hex-literal = "0.2.0"
 mockito = "0.26"
-tempfile = "3.1.0"
 
 [features]
 http = ["reqwest"]

--- a/tough/src/datastore.rs
+++ b/tough/src/datastore.rs
@@ -7,30 +7,35 @@ use serde::Serialize;
 use snafu::ResultExt;
 use std::fs::{self, File};
 use std::io::{ErrorKind, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tempfile::TempDir;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Datastore<'a>(Arc<RwLock<&'a Path>>);
+pub(crate) struct Datastore(Arc<RwLock<DatastorePath>>);
 
-impl<'a> Datastore<'a> {
-    pub(crate) fn new(path: &'a Path) -> Self {
-        Self(Arc::new(RwLock::new(path)))
+impl Datastore {
+    pub(crate) fn new(path: Option<PathBuf>) -> Result<Self> {
+        // using pattern matching instead of mapping because TempDir::new() can error
+        Ok(Self(Arc::new(RwLock::new(match path {
+            None => DatastorePath::TempDir(TempDir::new().context(error::DatastoreInit)?),
+            Some(p) => DatastorePath::Path(p),
+        }))))
     }
 
     // Because we are not actually changing the underlying data in the lock, we can ignore when a
     // lock is poisoned.
 
-    fn read(&self) -> RwLockReadGuard<'_, &'a Path> {
+    fn read(&self) -> RwLockReadGuard<'_, DatastorePath> {
         self.0.read().unwrap_or_else(PoisonError::into_inner)
     }
 
-    fn write(&self) -> RwLockWriteGuard<'_, &'a Path> {
+    fn write(&self) -> RwLockWriteGuard<'_, DatastorePath> {
         self.0.write().unwrap_or_else(PoisonError::into_inner)
     }
 
     pub(crate) fn reader(&self, file: &str) -> Result<Option<impl Read>> {
-        let path = self.read().join(file);
+        let path = self.read().path().join(file);
         match File::open(&path) {
             Ok(file) => Ok(Some(file)),
             Err(err) => match err.kind() {
@@ -41,7 +46,7 @@ impl<'a> Datastore<'a> {
     }
 
     pub(crate) fn create<T: Serialize>(&self, file: &str, value: &T) -> Result<()> {
-        let path = self.write().join(file);
+        let path = self.write().path().join(file);
         serde_json::to_writer_pretty(
             File::create(&path).context(error::DatastoreCreate { path: &path })?,
             value,
@@ -53,7 +58,7 @@ impl<'a> Datastore<'a> {
     }
 
     pub(crate) fn remove(&self, file: &str) -> Result<()> {
-        let path = self.write().join(file);
+        let path = self.write().path().join(file);
         debug!("removing '{}'", path.display());
         match fs::remove_file(&path) {
             Ok(()) => Ok(()),
@@ -61,6 +66,27 @@ impl<'a> Datastore<'a> {
                 ErrorKind::NotFound => Ok(()),
                 _ => Err(err).context(error::DatastoreRemove { path: &path }),
             },
+        }
+    }
+}
+
+/// Because `TempDir` is an RAII object, we need to hold on to it. This private enum allows us to
+/// hold either a `TempDir` or a `PathBuf` depending on whether or not the user wants to manage the
+/// directory.
+#[derive(Debug)]
+enum DatastorePath {
+    /// Path to a user-managed directory.
+    Path(PathBuf),
+    /// A `TempDir` that we created on the user's behalf.
+    TempDir(TempDir),
+}
+
+impl DatastorePath {
+    /// Provides convenient access to the underlying filepath.
+    fn path(&self) -> &Path {
+        match self {
+            DatastorePath::Path(p) => p,
+            DatastorePath::TempDir(t) => t.path(),
         }
     }
 }

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -29,6 +29,15 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display(
+        "Failed to create temp directory for the repository datastore: {}",
+        source
+    ))]
+    DatastoreInit {
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
     /// The library failed to create a file in the datastore.
     #[snafu(display("Failed to create file at datastore path {}: {}", path.display(), source))]
     DatastoreCreate {
@@ -215,13 +224,13 @@ pub enum Error {
 
     /// The library failed to parse a metadata file, either because it was not valid JSON or it did
     /// not conform to the expected schema.
-    //
-    // Invalid JSON errors read like:
-    // * EOF while parsing a string at line 1 column 14
-    //
-    // Schema non-conformance errors read like:
-    // * invalid type: integer `2`, expected a string at line 1 column 11
-    // * missing field `sig` at line 1 column 16
+    ///
+    /// Invalid JSON errors read like:
+    /// * EOF while parsing a string at line 1 column 14
+    ///
+    /// Schema non-conformance errors read like:
+    /// * invalid type: integer `2`, expected a string at line 1 column 11
+    /// * missing field `sig` at line 1 column 16
     #[snafu(display("Failed to parse {} metadata: {}", role, source))]
     ParseMetadata {
         role: RoleType,

--- a/tough/tests/expiration_enforcement.rs
+++ b/tough/tests/expiration_enforcement.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fs::File;
-use tempfile::TempDir;
 use test_utils::{dir_url, test_data};
 use tough::error::Error::ExpiredMetadata;
 use tough::schema::RoleType;
@@ -15,18 +14,14 @@ mod test_utils;
 #[test]
 fn test_expiration_enforcement_safe() {
     let base = test_data().join("expired-repository");
-    let datastore = TempDir::new().unwrap();
-
-    let metadata_base_url = &dir_url(base.join("metadata"));
-    let targets_base_url = &dir_url(base.join("targets"));
 
     let result = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(base.join("metadata").join("1.root.json")).unwrap(),
-            datastore: datastore.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(base.join("metadata")),
+            targets_base_url: dir_url(base.join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -53,18 +48,13 @@ fn test_expiration_enforcement_safe() {
 #[test]
 fn test_expiration_enforcement_unsafe() {
     let base = test_data().join("expired-repository");
-    let datastore = TempDir::new().unwrap();
-
-    let metadata_base_url = &dir_url(base.join("metadata"));
-    let targets_base_url = &dir_url(base.join("targets"));
-
     let result = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(base.join("metadata").join("1.root.json")).unwrap(),
-            datastore: datastore.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(base.join("metadata")),
+            targets_base_url: dir_url(base.join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Unsafe,
         },

--- a/tough/tests/http.rs
+++ b/tough/tests/http.rs
@@ -7,7 +7,6 @@ mod http_happy {
     use mockito::mock;
     use std::fs::File;
     use std::str::FromStr;
-    use tempfile::TempDir;
     use tough::{ExpirationEnforcement, HttpTransport, Limits, Repository, Settings};
     use url::Url;
 
@@ -34,18 +33,15 @@ mod http_happy {
         let mock_role2 = create_successful_get_mock("metadata/role2.json");
         let mock_file1_txt = create_successful_get_mock("targets/file1.txt");
         let mock_file2_txt = create_successful_get_mock("targets/file2.txt");
-        let datastore = TempDir::new().unwrap();
         let base_url = Url::from_str(mockito::server_url().as_str()).unwrap();
-        let metadata_base_url = base_url.join("metadata").unwrap().to_string();
-        let targets_base_url = base_url.join("targets").unwrap().to_string();
         let transport = HttpTransport::default();
         let repo = Repository::load(
             &transport,
             Settings {
                 root: File::open(repo_dir.join("metadata").join("1.root.json")).unwrap(),
-                datastore: datastore.as_ref(),
-                metadata_base_url: metadata_base_url.as_str(),
-                targets_base_url: targets_base_url.as_str(),
+                datastore: None,
+                metadata_base_url: base_url.join("metadata").unwrap().to_string(),
+                targets_base_url: base_url.join("targets").unwrap().to_string(),
                 limits: Limits::default(),
                 expiration_enforcement: ExpirationEnforcement::Safe,
             },
@@ -89,7 +85,6 @@ mod http_integ {
     use std::fs::File;
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
-    use tempfile::TempDir;
     use tough::{
         ClientSettings, ExpirationEnforcement, HttpTransport, Limits, Repository, Settings,
     };
@@ -151,14 +146,13 @@ mod http_integ {
                 backoff_factor: 1.5,
             });
             let root_path = tuf_reference_impl_root_json();
-            let tempdir = TempDir::new().unwrap();
             Repository::load(
                 &transport,
                 Settings {
                     root: File::open(&root_path).unwrap(),
-                    datastore: tempdir.path(),
-                    metadata_base_url: "http://localhost:10103/metadata",
-                    targets_base_url: "http://localhost:10103/targets",
+                    datastore: None,
+                    metadata_base_url: "http://localhost:10103/metadata".into(),
+                    targets_base_url: "http://localhost:10103/targets".into(),
                     limits: Limits::default(),
                     expiration_enforcement: ExpirationEnforcement::Safe,
                 },

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::fs::File;
-use tempfile::TempDir;
 use test_utils::{dir_url, read_to_end, test_data};
 use tough::{ExpirationEnforcement, Limits, Repository, Settings};
 
@@ -15,18 +14,14 @@ mod test_utils;
 #[test]
 fn test_tuf_reference_impl() {
     let base = test_data().join("tuf-reference-impl");
-    let datastore = TempDir::new().unwrap();
-
-    let metadata_base_url = &dir_url(base.join("metadata"));
-    let targets_base_url = &dir_url(base.join("targets"));
 
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(base.join("metadata").join("1.root.json")).unwrap(),
-            datastore: datastore.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(base.join("metadata")),
+            targets_base_url: dir_url(base.join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tough/tests/repo_cache.rs
+++ b/tough/tests/repo_cache.rs
@@ -12,7 +12,6 @@ mod test_utils;
 
 struct RepoPaths {
     root_path: PathBuf,
-    datastore: TempDir,
     metadata_base_url: String,
     targets_base_url: String,
 }
@@ -22,7 +21,6 @@ impl RepoPaths {
         let base = test_data().join("tuf-reference-impl");
         RepoPaths {
             root_path: base.join("metadata").join("1.root.json"),
-            datastore: TempDir::new().unwrap(),
             metadata_base_url: dir_url(base.join("metadata")),
             targets_base_url: dir_url(base.join("targets")),
         }
@@ -38,9 +36,9 @@ fn load_tuf_reference_impl<'a>(paths: &'a mut RepoPaths) -> Repository<'a, Files
         &tough::FilesystemTransport,
         Settings {
             root: &mut paths.root(),
-            datastore: paths.datastore.as_ref(),
-            metadata_base_url: paths.metadata_base_url.as_str(),
-            targets_base_url: paths.targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: paths.metadata_base_url.clone(),
+            targets_base_url: paths.targets_base_url.clone(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -68,16 +66,13 @@ fn test_repo_cache_all_targets() {
     .unwrap();
 
     // check that we can load the copied repo.
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let copied_repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: repo_paths.root(),
-            datastore: datastore.as_ref(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -125,16 +120,13 @@ fn test_repo_cache_list_of_two_targets() {
     .unwrap();
 
     // check that we can load the copied repo.
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let copied_repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: repo_paths.root(),
-            datastore: datastore.as_ref(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -182,16 +174,13 @@ fn test_repo_cache_some() {
     .unwrap();
 
     // check that we can load the copied repo.
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let copied_repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: repo_paths.root(),
-            datastore: datastore.as_ref(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tough/tests/repo_editor.rs
+++ b/tough/tests/repo_editor.rs
@@ -23,7 +23,6 @@ mod test_utils;
 
 struct RepoPaths {
     root_path: PathBuf,
-    datastore: TempDir,
     metadata_base_url: String,
     targets_base_url: String,
 }
@@ -33,7 +32,6 @@ impl RepoPaths {
         let base = test_data().join("tuf-reference-impl");
         RepoPaths {
             root_path: base.join("metadata").join("1.root.json"),
-            datastore: TempDir::new().unwrap(),
             metadata_base_url: dir_url(base.join("metadata")),
             targets_base_url: dir_url(base.join("targets")),
         }
@@ -71,9 +69,9 @@ fn load_tuf_reference_impl<'a>(paths: &'a mut RepoPaths) -> Repository<'a, Files
         &tough::FilesystemTransport,
         Settings {
             root: &mut paths.root(),
-            datastore: paths.datastore.as_ref(),
-            metadata_base_url: paths.metadata_base_url.as_str(),
-            targets_base_url: paths.targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: paths.metadata_base_url.clone(),
+            targets_base_url: paths.targets_base_url.clone(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -236,15 +234,13 @@ fn create_sign_write_reload_repo() {
         .link_targets(&targets_path(), &targets_destination, PathExists::Skip)
         .is_ok());
     // Load the repo we just created
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let _new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &create_dir.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -289,16 +285,13 @@ fn create_role_flow() {
 
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -348,16 +341,13 @@ fn create_role_flow() {
     // reload repo and verify that A role is included
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -380,16 +370,13 @@ fn create_role_flow() {
 
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -427,16 +414,13 @@ fn create_role_flow() {
     // reload repo and add in A and B metadata and update snapshot
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -470,16 +454,13 @@ fn create_role_flow() {
 
     // reload repo and verify that A and B role are included
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -529,16 +510,13 @@ fn update_targets_flow() {
 
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -588,16 +566,13 @@ fn update_targets_flow() {
     // reload repo and verify that A role is included
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -620,16 +595,13 @@ fn update_targets_flow() {
 
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -667,16 +639,13 @@ fn update_targets_flow() {
     // reload repo and add in A and B metadata and update snapshot
     // reload repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -710,16 +679,13 @@ fn update_targets_flow() {
 
     // reload repo and verify that A and B role are included
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -761,16 +727,13 @@ fn update_targets_flow() {
     // Add in edited A targets and update snapshot (update-repo)
     // load repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -806,16 +769,13 @@ fn update_targets_flow() {
 
     //load the updated repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -862,16 +822,13 @@ fn update_targets_flow() {
     // Add in edited A targets and update snapshot (update-repo)
     // load repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -908,16 +865,13 @@ fn update_targets_flow() {
 
     //load the updated repo
     let root = root_path();
-    let datastore = TempDir::new().unwrap();
-    let metadata_base_url = dir_url(&metadata_destination);
-    let targets_base_url = dir_url(&targets_destination);
     let new_repo = Repository::load(
         &FilesystemTransport,
         Settings {
             root: File::open(&root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: metadata_base_url.as_str(),
-            targets_base_url: targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: dir_url(&metadata_destination),
+            targets_base_url: dir_url(&targets_destination),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tough/tests/rotated_root.rs
+++ b/tough/tests/rotated_root.rs
@@ -4,25 +4,20 @@
 mod test_utils;
 
 use std::fs::File;
-use tempfile::TempDir;
 use test_utils::{dir_url, test_data};
 use tough::{ExpirationEnforcement, Limits, Repository, Settings};
 
 #[test]
 fn rotated_root() {
     let base = test_data().join("rotated-root");
-    let datastore = TempDir::new().unwrap();
-
-    let metadata_base_url = &dir_url(&base);
-    let targets_base_url = &dir_url(base.join("targets"));
 
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(base.join("1.root.json")).unwrap(),
-            datastore: datastore.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(&base),
+            targets_base_url: dir_url(base.join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -11,7 +11,6 @@ use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::targets::TargetsEditor;
 use tough::http::HttpTransport;
 use tough::key_source::KeySource;
@@ -58,13 +57,12 @@ pub(crate) struct AddKeyArgs {
 impl AddKeyArgs {
     pub(crate) fn run(&self, role: &str) -> Result<()> {
         // load the repo
-        let datastore = tempdir().context(error::TempDir)?;
         // We don't do anything with targets so we will use metadata url
         let settings = tough::Settings {
             root: File::open(&self.root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
-            targets_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         };

--- a/tuftool/src/add_role.rs
+++ b/tuftool/src/add_role.rs
@@ -10,7 +10,6 @@ use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::{targets::TargetsEditor, RepositoryEditor};
 use tough::http::HttpTransport;
 use tough::key_source::KeySource;
@@ -91,13 +90,12 @@ pub(crate) struct AddRoleArgs {
 impl AddRoleArgs {
     pub(crate) fn run(&self, role: &str) -> Result<()> {
         // load the repo
-        let datastore = tempdir().context(error::TempDir)?;
         // We don't do anything with targets so we will use metadata url
         let settings = tough::Settings {
             root: File::open(&self.root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
-            targets_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         };

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -8,7 +8,6 @@ use std::io::{self};
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::http::HttpTransport;
 use tough::{ExpirationEnforcement, FilesystemTransport, Limits, Repository, Settings, Transport};
 use url::Url;
@@ -101,12 +100,11 @@ impl DownloadArgs {
         };
 
         // load repository
-        let repo_dir = tempdir().context(error::TempDir)?;
         let settings = Settings {
             root: File::open(&root_path).context(error::OpenRoot { path: &root_path })?,
-            datastore: repo_dir.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
-            targets_base_url: self.targets_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
+            targets_base_url: self.targets_base_url.to_string(),
             limits: Limits {
                 ..tough::Limits::default()
             },

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -10,7 +10,6 @@ use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::targets::TargetsEditor;
 use tough::http::HttpTransport;
 use tough::key_source::KeySource;
@@ -58,13 +57,12 @@ pub(crate) struct RemoveKeyArgs {
 impl RemoveKeyArgs {
     pub(crate) fn run(&self, role: &str) -> Result<()> {
         // load the repo
-        let datastore = tempdir().context(error::TempDir)?;
         // We don't do anything with targets so we will use metadata url
         let settings = tough::Settings {
             root: File::open(&self.root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
-            targets_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         };

--- a/tuftool/src/remove_role.rs
+++ b/tuftool/src/remove_role.rs
@@ -10,7 +10,6 @@ use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::targets::TargetsEditor;
 use tough::http::HttpTransport;
 use tough::key_source::KeySource;
@@ -56,13 +55,12 @@ pub(crate) struct RemoveRoleArgs {
 impl RemoveRoleArgs {
     pub(crate) fn run(&self, role: &str) -> Result<()> {
         // load the repo
-        let datastore = tempdir().context(error::TempDir)?;
         // We don't do anything with targets so we will use metadata url
         let settings = tough::Settings {
             root: File::open(&self.root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
-            targets_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         };

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -11,7 +11,6 @@ use std::fs::File;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::signed::PathExists;
 use tough::editor::RepositoryEditor;
 use tough::http::HttpTransport;
@@ -109,15 +108,14 @@ WARNING: `--allow-expired-repo` was passed; this is unsafe and will not establis
 impl UpdateArgs {
     pub(crate) fn run(&self) -> Result<()> {
         // Create a temporary directory where the TUF client can store metadata
-        let workdir = tempdir().context(error::TempDir)?;
         let settings = tough::Settings {
             root: File::open(&self.root).context(error::FileOpen { path: &self.root })?,
-            datastore: workdir.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
             // We never load any targets here so the real
             // `targets_base_url` isn't needed. `tough::Settings` requires
             // a value so we use `metadata_base_url` as a placeholder
-            targets_base_url: self.metadata_base_url.as_str(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: if self.allow_expired_repo {
                 expired_repo_warning(&self.outdir);

--- a/tuftool/src/update_targets.rs
+++ b/tuftool/src/update_targets.rs
@@ -12,7 +12,6 @@ use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use structopt::StructOpt;
-use tempfile::tempdir;
 use tough::editor::signed::PathExists;
 use tough::editor::targets::TargetsEditor;
 use tough::http::HttpTransport;
@@ -74,13 +73,12 @@ pub(crate) struct UpdateTargetsArgs {
 impl UpdateTargetsArgs {
     pub(crate) fn run(&self, role: &str) -> Result<()> {
         // load the repo
-        let datastore = tempdir().context(error::TempDir)?;
         let settings = tough::Settings {
             root: File::open(&self.root).unwrap(),
-            datastore: &datastore.path(),
-            metadata_base_url: self.metadata_base_url.as_str(),
+            datastore: None,
+            metadata_base_url: self.metadata_base_url.to_string(),
             // We don't do anything with targets so we will use metadata url
-            targets_base_url: self.metadata_base_url.as_str(),
+            targets_base_url: self.metadata_base_url.to_string(),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         };

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -7,6 +7,7 @@ use assert_cmd::Command;
 use chrono::{Duration, Utc};
 use std::fs::File;
 use tempfile::TempDir;
+use test_utils::dir_url;
 use tough::{ExpirationEnforcement, Limits, Repository, Settings};
 
 #[test]
@@ -24,7 +25,6 @@ fn create_command() {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let root_key = test_utils::test_data().join("snakeoil.pem");
     let repo_dir = TempDir::new().unwrap();
-    let load_dir = TempDir::new().unwrap();
 
     // Create a repo using tuftool and the reference tuf implementation targets
     Command::cargo_bin("tuftool")
@@ -56,15 +56,13 @@ fn create_command() {
         .success();
 
     // Load our newly created repo
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
-    let targets_base_url = &test_utils::dir_url(repo_dir.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
-            datastore: load_dir.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(repo_dir.path().join("metadata")),
+            targets_base_url: dir_url(repo_dir.path().join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tuftool/tests/create_repository_integration.rs
+++ b/tuftool/tests/create_repository_integration.rs
@@ -7,6 +7,7 @@ use chrono::{Duration, Utc};
 use std::env;
 use std::fs::File;
 use tempfile::TempDir;
+use test_utils::dir_url;
 use tough::{ExpirationEnforcement, Limits, Repository, Settings};
 
 // This file include integration tests for KeySources: tough-ssm, tough-kms and local file key.
@@ -125,7 +126,6 @@ fn create_repository(root_key: &str, auto_generate: bool) {
         .join("tuf-reference-impl")
         .join("targets");
     let repo_dir = TempDir::new().unwrap();
-    let load_dir = TempDir::new().unwrap();
     // Create a repo using tuftool and the reference tuf implementation targets
     Command::cargo_bin("tuftool")
         .unwrap()
@@ -156,15 +156,13 @@ fn create_repository(root_key: &str, auto_generate: bool) {
         .success();
 
     // Load our newly created repo
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
-    let targets_base_url = &test_utils::dir_url(repo_dir.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
-            datastore: load_dir.as_ref(),
-            metadata_base_url,
-            targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(repo_dir.path().join("metadata")),
+            targets_base_url: dir_url(repo_dir.path().join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Duration, Utc};
 use std::fs::File;
 use std::path::Path;
 use tempfile::TempDir;
+use test_utils::dir_url;
 use tough::{ExpirationEnforcement, Limits, Repository, Settings};
 
 fn create_repo<P: AsRef<Path>>(repo_dir: P) {
@@ -71,7 +72,7 @@ fn update_command_without_new_targets() {
     let new_snapshot_version: u64 = 250;
     let new_targets_expiration = Utc::now().checked_add_signed(Duration::days(6)).unwrap();
     let new_targets_version: u64 = 170;
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -104,16 +105,13 @@ fn update_command_without_new_targets() {
         .success();
 
     // Load the updated repo
-    let temp_datastore = TempDir::new().unwrap();
-    let updated_metadata_base_url = &test_utils::dir_url(update_out.path().join("metadata"));
-    let updated_targets_base_url = &test_utils::dir_url(update_out.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
-            datastore: temp_datastore.as_ref(),
-            metadata_base_url: updated_metadata_base_url,
-            targets_base_url: updated_targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(update_out.path().join("metadata")),
+            targets_base_url: dir_url(update_out.path().join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -151,7 +149,7 @@ fn update_command_with_new_targets() {
     let new_targets_expiration = Utc::now().checked_add_signed(Duration::days(6)).unwrap();
     let new_targets_version: u64 = 170;
     let new_targets_input_dir = test_utils::test_data().join("targets");
-    let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
+    let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let update_out = TempDir::new().unwrap();
 
     // Update the repo we just created
@@ -186,16 +184,13 @@ fn update_command_with_new_targets() {
         .success();
 
     // Load the updated repo.
-    let temp_datastore = TempDir::new().unwrap();
-    let updated_metadata_base_url = &test_utils::dir_url(update_out.path().join("metadata"));
-    let updated_targets_base_url = &test_utils::dir_url(update_out.path().join("targets"));
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
-            datastore: temp_datastore.as_ref(),
-            metadata_base_url: updated_metadata_base_url,
-            targets_base_url: updated_targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(update_out.path().join("metadata")),
+            targets_base_url: dir_url(update_out.path().join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },
@@ -380,17 +375,14 @@ fn update_command_expired_repo_allow() {
     // assert success for update command
     update_expected.0.success();
     // Load the updated repo
-    let temp_datastore = TempDir::new().unwrap();
-    let updated_metadata_base_url = &test_utils::dir_url(outdir.path().join("metadata"));
-    let updated_targets_base_url = &test_utils::dir_url(outdir.path().join("targets"));
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let repo = Repository::load(
         &tough::FilesystemTransport,
         Settings {
             root: File::open(root_json).unwrap(),
-            datastore: temp_datastore.as_ref(),
-            metadata_base_url: updated_metadata_base_url,
-            targets_base_url: updated_targets_base_url,
+            datastore: None,
+            metadata_base_url: dir_url(outdir.path().join("metadata")),
+            targets_base_url: dir_url(outdir.path().join("targets")),
             limits: Limits::default(),
             expiration_enforcement: ExpirationEnforcement::Safe,
         },


### PR DESCRIPTION
*Issue #, if available:*

Closes #249 

*Description of changes:*

```
Datastore: change the inner type from &'a Path to either PathBuf or
TempDir. This supports a common use case in which the user wants a
TempDir and does not want to own the lifetime of the Path.

Settings: change the datastore field to be an Option<PathBuf> instead of
&'a Path. This allows the user to specify None if they want a TempDir
to be created for them automatically, but retains the ability for the
user to specify the location of an existing directory. In the latter
case, it is often more convenient for the user to move ownership of the
Path-like object than to provide a reference.

Settings: change the two URL fields to owned Strings instead of &'a str.
This gives the user the flexibility to move temporary strings into the
Settings struct's ownership instead of creating local variables that the
user might not otherwise need.
```
*Testing*

For this one I am trusting the compiler and unit tests.

In the test case changes, we can see the improvement to the interface. Fewer lines of code are needed in the test cases for declaring variables that were only required for the sake of passing a ref. I believe most/all use cases in Bottlerocket will similarly benefit from the reduction of local variables that aren't otherwise needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
