### PR TITLE
Supported 'ExpirationEnforcement::Unsafe' when '--allow-expired-repo' is passed

### DIFF
--- a/tuftool/tests/test_utils.rs
+++ b/tuftool/tests/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use assert_cmd::Command;
+use chrono::{Duration, Utc};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use url::Url;
@@ -27,4 +29,48 @@ pub fn read_to_end<R: Read>(mut reader: R) -> Vec<u8> {
     let mut v = Vec::new();
     reader.read_to_end(&mut v).unwrap();
     v
+}
+
+/// Creates a repository with expired timestamp metadata.
+#[allow(unused)]
+pub fn create_expired_repo<P: AsRef<Path>>(repo_dir: P) {
+    // Expired time stamp
+    let timestamp_expiration = Utc::now().checked_add_signed(Duration::days(-1)).unwrap();
+    let timestamp_version: u64 = 31;
+    let snapshot_expiration = Utc::now().checked_add_signed(Duration::days(2)).unwrap();
+    let snapshot_version: u64 = 25;
+    let targets_expiration = Utc::now().checked_add_signed(Duration::days(3)).unwrap();
+    let targets_version: u64 = 17;
+    let targets_input_dir = test_data().join("tuf-reference-impl").join("targets");
+    let root_json = test_data().join("simple-rsa").join("root.json");
+    let root_key = test_data().join("snakeoil.pem");
+
+    // Create a repo using tuftool and the reference tuf implementation data
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args(&[
+            "create",
+            "-t",
+            targets_input_dir.to_str().unwrap(),
+            "-o",
+            repo_dir.as_ref().to_str().unwrap(),
+            "-k",
+            root_key.to_str().unwrap(),
+            "--root",
+            root_json.to_str().unwrap(),
+            "--targets-expires",
+            targets_expiration.to_rfc3339().as_str(),
+            "--targets-version",
+            format!("{}", targets_version).as_str(),
+            "--snapshot-expires",
+            snapshot_expiration.to_rfc3339().as_str(),
+            "--snapshot-version",
+            format!("{}", snapshot_version).as_str(),
+            "--timestamp-expires",
+            timestamp_expiration.to_rfc3339().as_str(),
+            "--timestamp-version",
+            format!("{}", timestamp_version).as_str(),
+        ])
+        .assert()
+        .success();
 }


### PR DESCRIPTION
*Issue #, if available:*
#224 
*Description of changes:*
* Allowed `ExpirationEnforcement::Unsafe` when '--allow-expired-repo' is passed.

*Testing*
* Added test cases to download and update expired repo with and without `--allow-expired-repo` and saw them passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
