### PR TITLE
Fixed cargo clippy check of lazy evaluation for or_ok_else

### DIFF
--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -252,9 +252,7 @@ impl<'a, T: Transport> RepositoryEditor<'a, T> {
 
     /// Returns a mutable reference to the targets editor if it exists
     fn targets_editor_mut(&mut self) -> Result<&mut TargetsEditor<'a, T>> {
-        self.targets_editor
-            .as_mut()
-            .ok_or_else(|| error::Error::NoTargets)
+        self.targets_editor.as_mut().ok_or(error::Error::NoTargets)
     }
 
     /// Add a `Target` to the repository

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -569,7 +569,7 @@ impl Targets {
         self.delegated_role(name)?
             .targets
             .as_ref()
-            .ok_or_else(|| error::Error::NoTargets)
+            .ok_or(error::Error::NoTargets)
     }
 
     /// Returns a mutable `Signed<Targets>` for `name`
@@ -577,7 +577,7 @@ impl Targets {
         self.delegated_role_mut(name)?
             .targets
             .as_mut()
-            .ok_or_else(|| error::Error::NoTargets)
+            .ok_or(error::Error::NoTargets)
     }
 
     /// Returns the `&DelegatedRole` for `name`
@@ -585,7 +585,7 @@ impl Targets {
         for role in &self
             .delegations
             .as_ref()
-            .ok_or_else(|| error::Error::NoDelegations)?
+            .ok_or(error::Error::NoDelegations)?
             .roles
         {
             if role.name == name {
@@ -593,7 +593,7 @@ impl Targets {
             } else if let Ok(role) = role
                 .targets
                 .as_ref()
-                .ok_or_else(|| error::Error::NoTargets)?
+                .ok_or(error::Error::NoTargets)?
                 .signed
                 .delegated_role(name)
             {
@@ -610,7 +610,7 @@ impl Targets {
         for role in &mut self
             .delegations
             .as_mut()
-            .ok_or_else(|| error::Error::NoDelegations)?
+            .ok_or(error::Error::NoDelegations)?
             .roles
         {
             if role.name == name {
@@ -618,7 +618,7 @@ impl Targets {
             } else if let Ok(role) = role
                 .targets
                 .as_mut()
-                .ok_or_else(|| error::Error::NoTargets)?
+                .ok_or(error::Error::NoTargets)?
                 .signed
                 .delegated_role_mut(name)
             {

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -342,7 +342,7 @@ impl Command {
             .signed
             .roles
             .get(&RoleType::Root)
-            .ok_or_else(|| error::Error::UnstableRoot {
+            .ok_or(error::Error::UnstableRoot {
                 // The code should never reach this point
                 role: RoleType::Root,
                 threshold: 0,


### PR DESCRIPTION
*Issue #, if available:*
Fixed the dependabot failing [PR](https://github.com/awslabs/tough/pull/276) 

*Description of changes:*
cargo clippy from  rust 1.48 checks on lazy evaluations for `or_ok_else` and prints warning. [Here's](https://rust-lang.github.io/rust-clippy/rust-1.48.0/index.html#unnecessary_lazy_evaluations) the clippy lint  for the same.
Fixed it by using `or_ok`instead of `or_ok_else` which uses eager evalution

*Test*
cargo test passes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
