### PR TITLE
add makefile so local ci check is easy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,13 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: rustup update stable
-    - run: cargo fmt -- --check
-    - run: cargo clippy --locked -- -D warnings
-    - run: cargo build --locked -p olpc-cjson
-    - run: cargo build --locked -p tough
-    - run: cargo build --locked -p tough-ssm
-    - run: cargo build --locked -p tough-kms
-    - run: cargo build --locked -p tuftool
-    - run: cargo test --locked
-    - run: cd tough && cargo test --all-features --locked
-    - run: cd tough && cargo test --features '' --locked
+    - run: make ci

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: ci
+ci: ## The series of builds, tests and checks that runs for pull requests. Requires docker.
+	set +e
+	cargo fmt -- --check
+	cargo clippy --locked -- -D warnings
+	cargo build --locked -p olpc-cjson
+	cargo build --locked -p tough
+	cargo build --locked -p tough-ssm
+	cargo build --locked -p tough-kms
+	cargo build --locked -p tuftool
+	cargo test --locked
+	cd tough && cargo test --features '' --locked
+	cd tough && cargo test --all-features --locked


### PR DESCRIPTION

*Issue #, if available:*

Closes #266

*Description of changes:*

```
Add a Makefile that does all of the continuous integration builds and
checks. Then call that Makefile target in the actual ci run. This will
be helpful when developers want to check that ci will pass locally
before pushing changes to a pull request.
```

This will significantly improve my workflow experience!

*Testing*

It worked for me locally and we'll see if it works on the GitHub runner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
