### PR TITLE
tough: document transport dynclone requirement

### DIFF
--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -11,12 +11,15 @@ use url::Url;
 /// The trait hides the underlying types involved by returning the `Read` object as a
 /// `Box<dyn Read + Send>` and by requiring concrete type [`TransportError`] as the error type.
 ///
+/// Inclusion of the `DynClone` trait means that you will need to implement `Clone` when
+/// implementing a `Transport`.
 pub trait Transport: Debug + DynClone {
     /// Opens a `Read` object for the file specified by `url`.
     fn fetch(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError>;
 }
 
-// Implement `Clone` for `Transport` trait objects.
+// Implements `Clone` for `Transport` trait objects (i.e. on `Box::<dyn Clone>`). To facilitate
+// this, `Clone` needs to be implemented for any `Transport`s. The compiler will enforce this.
 dyn_clone::clone_trait_object!(Transport);
 
 // =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=   =^..^=


### PR DESCRIPTION


*Issue #, if available:*

Closes #292 

*Description of changes:*

```
Document that implementers of Transport need to implement Clone to
enable dyn_clone to do its magic.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
