### PR TITLE
tough: remove allow dead_code from transport

### DIFF
--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -135,7 +135,6 @@ impl DefaultTransport {
 #[cfg(feature = "http")]
 impl DefaultTransport {
     /// Create a new `DefaultTransport` using the given HTTP `ClientSettings`.
-    #[allow(dead_code)]
     pub fn from_http_settings(settings: ClientSettings) -> Self {
         Self {
             file: FilesystemTransport,


### PR DESCRIPTION
*Issue #, if available:*

Closes #293 

*Description of changes:*

```
It looks like #[allow(dead_code)] was vestigial from some in-between
state during the work on #256. This commit removes it.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
