### PR TITLE
tough: hide snafu context selectors for transport

### DIFF
--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -343,7 +343,6 @@ fn build_request(client: &Client, next_byte: usize, url: &Url) -> Result<Request
 
 /// The error type for the HTTP transport module.
 #[derive(Debug, Snafu)]
-#[snafu(visibility = "pub(super)")]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum HttpError {

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -46,7 +46,6 @@ pub enum TransportErrorKind {
 
 /// The error type that [`Transport`] `fetch` returns.
 #[derive(Debug, Snafu)]
-#[snafu(visibility = "pub")]
 #[snafu(display("{:?} error fetching '{}': {}", kind, url, source))]
 pub struct TransportError {
     /// The kind of error that occurred.


### PR DESCRIPTION
*Issue #, if available:*

Closes #295 

*Description of changes:*

```
In #256 the TransportError incorrectly set snafu visibility to pub. This
was not necessary as clients of tough would have no use for snafu's
context selectors.
```

`visibility = pub` was not necessary for snafu's macros on `TransportError`. I didn't understand what this was doing at first, but now I see that it exposes snafu's "context selectors and their inherent methods" beyond the scope of the module. This is not needed for TransportError (or HttpError), so these are now properly privatized.

This should address @iliana's concern here: https://github.com/awslabs/tough/pull/256#discussion_r545459335


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
