### PR TITLE
tough: improve transport error

### DIFF
--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -12,25 +12,29 @@ use std::io::Read;
 use std::time::Duration;
 use url::Url;
 
-/// Settings for the HTTP client including retry strategy and timeouts.
+/// A builder for [`HttpTransport`] which allows settings customization.
+///
+/// # Example
+///
+/// ```
+/// # use tough::HttpTransportBuilder;
+/// let http_transport = HttpTransportBuilder::new()
+/// .tries(3)
+/// .backoff_factor(1.5)
+/// .build();
+/// ```
+///
 #[derive(Clone, Copy, Debug)]
-pub struct ClientSettings {
-    /// Set a timeout for connect, read and write operations.
-    pub timeout: Duration,
-    /// Set a timeout for only the connect phase.
-    pub connect_timeout: Duration,
-    /// The total number of times we will try to get the response.
-    pub tries: u32,
-    /// The pause between the first and second try.
-    pub initial_backoff: Duration,
-    /// The maximum length of a pause between retries.
-    pub max_backoff: Duration,
-    /// The exponential backoff factor, the factor by which the pause time will increase after each
-    /// try until reaching `max_backoff`.
-    pub backoff_factor: f32,
+pub struct HttpTransportBuilder {
+    timeout: Duration,
+    connect_timeout: Duration,
+    tries: u32,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    backoff_factor: f32,
 }
 
-impl Default for ClientSettings {
+impl Default for HttpTransportBuilder {
     fn default() -> Self {
         Self {
             timeout: std::time::Duration::from_secs(30),
@@ -44,7 +48,58 @@ impl Default for ClientSettings {
     }
 }
 
-/// An HTTP `Transport` with retry logic.
+impl HttpTransportBuilder {
+    /// Create a new `HttpTransportBuilder` with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a timeout for the complete fetch operation.
+    pub fn timeout(mut self, value: Duration) -> Self {
+        self.timeout = value;
+        self
+    }
+
+    /// Set a timeout for only the connect phase.
+    pub fn connect_timeout(mut self, value: Duration) -> Self {
+        self.connect_timeout = value;
+        self
+    }
+
+    /// Set the total number of times we will try the fetch operation (in case of retryable
+    /// failures).
+    pub fn tries(mut self, value: u32) -> Self {
+        self.tries = value;
+        self
+    }
+
+    /// Set the pause duration between the first and second try.
+    pub fn initial_backoff(mut self, value: Duration) -> Self {
+        self.initial_backoff = value;
+        self
+    }
+
+    /// Set the maximum duration of a pause between retries.
+    pub fn max_backoff(mut self, value: Duration) -> Self {
+        self.max_backoff = value;
+        self
+    }
+
+    /// Set the exponential backoff factor, the factor by which the pause time will increase after
+    /// each try until reaching `max_backoff`.
+    pub fn backoff_factor(mut self, value: f32) -> Self {
+        self.backoff_factor = value;
+        self
+    }
+
+    /// Construct an [`HttpTransport`] transport from this builder's settings.
+    pub fn build(self) -> HttpTransport {
+        HttpTransport { settings: self }
+    }
+}
+
+/// A [`Transport`] over HTTP with retry logic. Use the [`HttpTransportBuilder`] to construct a
+/// custom `HttpTransport`, or use `HttpTransport::default()`.
 ///
 /// This transport returns `FileNotFound` for the following HTTP response codes:
 /// - 403: Forbidden. (Some services return this code when a file does not exist.)
@@ -52,19 +107,7 @@ impl Default for ClientSettings {
 /// - 410: Gone.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HttpTransport {
-    settings: ClientSettings,
-}
-
-impl HttpTransport {
-    /// Create a new `HttpRetryTransport` with default settings.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Create a new `HttpRetryTransport` with specific settings.
-    pub fn from_settings(settings: ClientSettings) -> Self {
-        Self { settings }
-    }
+    settings: HttpTransportBuilder,
 }
 
 /// Implement the `tough` `Transport` trait for `HttpRetryTransport`
@@ -84,7 +127,7 @@ impl Transport for HttpTransport {
 #[derive(Debug)]
 pub struct RetryRead {
     retry_state: RetryState,
-    settings: ClientSettings,
+    settings: HttpTransportBuilder,
     response: Response,
     url: Url,
 }
@@ -176,7 +219,7 @@ impl RetryState {
 
 impl RetryState {
     /// Increments the count and the wait duration.
-    fn increment(&mut self, settings: &ClientSettings) {
+    fn increment(&mut self, settings: &HttpTransportBuilder) {
         if self.current_try > 0 {
             let new_wait = self.wait.mul_f32(settings.backoff_factor);
             match new_wait.cmp(&settings.max_backoff) {
@@ -196,7 +239,7 @@ impl RetryState {
 /// Sends a `GET` request to the `url`. Retries the request as necessary per the `ClientSettings`.
 fn fetch_with_retries(
     r: &mut RetryState,
-    cs: &ClientSettings,
+    cs: &HttpTransportBuilder,
     url: &Url,
 ) -> Result<RetryRead, HttpError> {
     trace!("beginning fetch for '{}'", url);

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -373,9 +373,9 @@ impl From<(Url, HttpError)> for TransportError {
     fn from((url, e): (Url, HttpError)) -> Self {
         match e {
             HttpError::FetchFileNotFound { .. } => {
-                TransportError::new(TransportErrorKind::FileNotFound, url, e)
+                TransportError::new_with_cause(TransportErrorKind::FileNotFound, url, e)
             }
-            _ => TransportError::new(TransportErrorKind::Other, url, e),
+            _ => TransportError::new_with_cause(TransportErrorKind::Other, url, e),
         }
     }
 }

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -389,7 +389,7 @@ impl Repository {
     }
 
     ///return a vec of all targets including all target files delegated by targets
-    pub fn all_targets<'b>(&'b self) -> impl Iterator + 'b {
+    pub fn all_targets(&self) -> impl Iterator + '_ {
         self.targets.signed.targets_iter()
     }
 

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -47,7 +47,7 @@ use crate::error::Result;
 use crate::fetch::{fetch_max_size, fetch_sha256};
 /// An HTTP transport that includes retries.
 #[cfg(feature = "http")]
-pub use crate::http::{ClientSettings, HttpTransport, RetryRead};
+pub use crate::http::{HttpTransport, HttpTransportBuilder, RetryRead};
 use crate::schema::{DelegatedRole, Delegations};
 use crate::schema::{Role, RoleType, Root, Signed, Snapshot, Timestamp};
 pub use crate::transport::{

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -538,7 +538,7 @@ impl Targets {
     }
 
     /// Returns an iterator of all targets delegated
-    pub fn targets_iter<'a>(&'a self) -> impl Iterator + 'a {
+    pub fn targets_iter(&self) -> impl Iterator + '_ {
         self.targets_map().into_iter()
     }
 

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "http")]
-use crate::{ClientSettings, HttpTransport};
+use crate::{HttpTransport, HttpTransportBuilder};
 use dyn_clone::DynClone;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -188,11 +188,11 @@ impl DefaultTransport {
 
 #[cfg(feature = "http")]
 impl DefaultTransport {
-    /// Create a new `DefaultTransport` using the given HTTP `ClientSettings`.
-    pub fn from_http_settings(settings: ClientSettings) -> Self {
+    /// Create a new `DefaultTransport` with potentially customized settings.
+    pub fn new_with_http_settings(builder: HttpTransportBuilder) -> Self {
         Self {
             file: FilesystemTransport,
-            http: HttpTransport::from_settings(settings),
+            http: builder.build(),
         }
     }
 }

--- a/tough/tests/transport.rs
+++ b/tough/tests/transport.rs
@@ -15,7 +15,7 @@ fn default_transport_error_no_http() {
     let transport = DefaultTransport::new();
     let url = Url::from_str("http://example.com").unwrap();
     let error = transport.fetch(url).err().unwrap();
-    match &error.kind {
+    match error.kind() {
         TransportErrorKind::UnsupportedUrlScheme => {
             let message = format!("{}", error);
             assert!(message.contains("http feature"))
@@ -29,8 +29,8 @@ fn default_transport_error_ftp() {
     let transport = DefaultTransport::new();
     let url = Url::from_str("ftp://example.com").unwrap();
     let error = transport.fetch(url.clone()).err().unwrap();
-    match &error.kind {
-        TransportErrorKind::UnsupportedUrlScheme => assert_eq!(error.url.as_str(), url.as_str()),
+    match error.kind() {
+        TransportErrorKind::UnsupportedUrlScheme => assert_eq!(error.url(), url.as_str()),
         _ => panic!("incorrect error kind, expected UnsupportedUrlScheme"),
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Closes #294
Closes #303

*Description of changes:*

The first commit: 

```
Make the inner error of the TransportError optional. Two public
functions are provided for constructing a TransportError. This is better
than a function that takes an Option<E> for the optional inner error
because the user would need to specify a type when trying to pass None.

Expand documentation of the TransportErrorKind::FileNotFound variant to
better explain the intent.

Hide the members of the TransportError struct to make breaking changes
less likely. Instead make them accessible by getter functions.

Changing the inner error to an Option made Snafu's macros less useful
because it gives special meaning to a struct member named 'source', and
would not compile when this became an Option. I wanted to keep the
member name because it seems to be canonical in Rust. Additionally, the
display macro became difficult to use to produce a clean error message.
It seemed easier to implement Error and Display myself.
```

The second commit

```
Provide documentation about what HTTP codes constitute FileNotFound for
the HTTP transport and add 410 to the list.
```

The third commit:

I briefly considered making the `FileNotFound` codes configurable for the `HttpTransport`, but I think YAGNI. Also, after a bit of searching, I think it is a best practice for HTTP servers to obscure the difference between 404 and 403, so I think it is correct for the transport to treat them as equivalent.

However, the idea of adding a setting got me thinking about breaking changes. If we use a builder instead of a settings struct, we set ourselves up better for preventing future breaking changes when a new setting is introduced.

```
Replaces the http ClientSettings struct with a builder,
HttpTransportBuilder. By introducing a builder we can hide settings
details and prevent future breaking changes (e.g. if we need to add a
setting).
```

*Testing*

I didn't do any testing beyond running tests locally and in CI. No algorithms were harmed during the making of this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
