### PR TITLE
tough: add tls features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,10 +785,26 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.17.0",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.13.1",
+ "webpki",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls 0.18.1",
+ "tokio",
+ "tokio-rustls 0.14.1",
  "webpki",
 ]
 
@@ -1437,6 +1453,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls 0.21.0",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1447,14 +1464,17 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.0",
+ "rustls 0.18.1",
  "serde",
  "serde_urlencoded 0.7.0",
  "tokio",
+ "tokio-rustls 0.14.1",
  "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1486,7 +1506,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-rustls",
+ "hyper-rustls 0.20.0",
  "hyper-tls",
  "lazy_static",
  "log",
@@ -1631,13 +1651,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+dependencies = [
+ "base64 0.12.3",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.17.0",
  "schannel",
  "security-framework 0.4.4",
 ]
@@ -2151,7 +2184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
- "rustls",
+ "rustls 0.17.0",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+dependencies = [
+ "futures-core",
+ "rustls 0.18.1",
  "tokio",
  "webpki",
 ]
@@ -2535,6 +2580,15 @@ checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -32,7 +32,11 @@ hex-literal = "0.3.1"
 mockito = "0.28"
 
 [features]
+# to use HTTP without TLS transport (no HTTPS), use the "http" feature. to enable TLS, enable either
+# "http-rustls-tls" or "http-native-tls".
 http = ["reqwest"]
+http-rustls-tls = ["http", "reqwest/rustls-tls"]
+http-native-tls = ["http", "reqwest/native-tls"]
 
 # The `integ` feature enables integration tests. These tests require docker to be running on the host.
 integ = []

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -1,4 +1,8 @@
-#[cfg(feature = "http")]
+#[cfg(any(
+    feature = "http",
+    feature = "http-rustls-tls",
+    feature = "http-native-tls"
+))]
 use crate::{HttpTransport, HttpTransportBuilder};
 use dyn_clone::DynClone;
 use std::error::Error;
@@ -165,7 +169,11 @@ impl Transport for FilesystemTransport {
 #[derive(Debug, Clone, Copy)]
 pub struct DefaultTransport {
     file: FilesystemTransport,
-    #[cfg(feature = "http")]
+    #[cfg(any(
+        feature = "http",
+        feature = "http-rustls-tls",
+        feature = "http-native-tls"
+    ))]
     http: HttpTransport,
 }
 
@@ -173,7 +181,11 @@ impl Default for DefaultTransport {
     fn default() -> Self {
         Self {
             file: FilesystemTransport,
-            #[cfg(feature = "http")]
+            #[cfg(any(
+                feature = "http",
+                feature = "http-rustls-tls",
+                feature = "http-native-tls"
+            ))]
             http: HttpTransport::default(),
         }
     }
@@ -186,7 +198,11 @@ impl DefaultTransport {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(any(
+    feature = "http",
+    feature = "http-rustls-tls",
+    feature = "http-native-tls"
+))]
 impl DefaultTransport {
     /// Create a new `DefaultTransport` with potentially customized settings.
     pub fn new_with_http_settings(builder: HttpTransportBuilder) -> Self {
@@ -211,7 +227,11 @@ impl Transport for DefaultTransport {
 }
 
 impl DefaultTransport {
-    #[cfg(not(feature = "http"))]
+    #[cfg(all(
+        not(feature = "http"),
+        not(feature = "http-rustls-tls"),
+        not(feature = "http-native-tls")
+    ))]
     #[allow(clippy::trivially_copy_pass_by_ref, clippy::unused_self)]
     fn handle_http(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError> {
         Err(TransportError::new_with_cause(
@@ -221,7 +241,11 @@ impl DefaultTransport {
         ))
     }
 
-    #[cfg(feature = "http")]
+    #[cfg(any(
+        feature = "http",
+        feature = "http-rustls-tls",
+        feature = "http-native-tls"
+    ))]
     fn handle_http(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError> {
         self.http.fetch(url)
     }

--- a/tough/tests/http.rs
+++ b/tough/tests/http.rs
@@ -1,7 +1,10 @@
 mod test_utils;
 
-/// Instead of guarding every individual thing with `#[cfg(feature = "http")]`, use a module.
-#[cfg(feature = "http")]
+#[cfg(any(
+    feature = "http",
+    feature = "http-rustls-tls",
+    feature = "http-native-tls"
+))]
 mod http_happy {
     use crate::test_utils::{read_to_end, test_data};
     use mockito::mock;
@@ -83,7 +86,11 @@ mod http_happy {
     }
 }
 
-#[cfg(feature = "http")]
+#[cfg(any(
+    feature = "http",
+    feature = "http-rustls-tls",
+    feature = "http-native-tls"
+))]
 #[cfg(feature = "integ")]
 mod http_integ {
     use crate::test_utils::test_data;

--- a/tough/tests/transport.rs
+++ b/tough/tests/transport.rs
@@ -9,7 +9,11 @@ mod test_utils;
 
 /// If the `http` feature is not enabled, we should get an error message indicating that the feature
 /// is not enabled.
-#[cfg(not(feature = "http"))]
+#[cfg(all(
+    not(feature = "http"),
+    not(feature = "http-rustls-tls"),
+    not(feature = "http-native-tls")
+))]
 #[test]
 fn default_transport_error_no_http() {
     let transport = DefaultTransport::new();


### PR DESCRIPTION

*Issue #, if available:*

Closes #271 
Does not address #13, I will work on that separately.

*Description of changes:*

```
Before this commit, there was no way to enable TLS for the HTTP
transport. The only way to do so was to manually include the same
version of reqwest and enable TLS on reqwest directly.

Here we keep the behavior we already had with the http feature (no TLS),
but we add two new features for the two TLS implementations.
```

**Testing**

I created a simple program referencing tough locally. The program loaded the Bottlerocket repo. With the `http` feature it failed (since the URL is https).  Both `http-rustls-tls` and `http-native-tls` worked.

I downloaded the repo with tuftool, and that was working regardless of whether tuftools Cargo.toml specifies tough with `features = ["http"]`, or `http-rustls-tls` or `http-native-tls`, so I left tuftool's Cargo.toml unchanged.

I also ran these:
```
    cd tough && cargo test --features 'integ,http' --locked
    cd tough && cargo test --features 'integ,http-rustls-tls' --locked
    cd tough && cargo test --features 'integ,http-native-tls' --locked
```
And all passed. I did not add these to the Makefile or CI yet because I don't want to make CI slower.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
