### PR TITLE
Tuftool 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,9 +506,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fa4cc29d25b0687b8570b0da86eac698dcb525110ad8b938fe6712baa711ec"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ebc390c6913de330e418add60e1a7e5af4cb5ec600d19111b339cafcdcc027"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -531,15 +531,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089bd0baf024d3216916546338fffe4fc8dfffdd901e33c278abb091e0d52111"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cb59f15119671c94cd9cc543dc9a50b8d5edc468b4ff5f0bb8567f66c6b48a"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -548,15 +548,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3868967e4e5ab86614e2176c99949eeef6cbcacaee737765f6ae693988273997"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95778720c3ee3c179cd0d8fd5a0f9b40aa7d745c080f86a8f8bed33c4fd89758"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -566,24 +566,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e0f6be0ec0357772fd58fb751958dd600bd0b3edfd429e77793e4282831360"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868090f28a925db6cb7462938c51d807546e298fb314088239f0e52fb4338b96"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad5e82786df758d407932aded1235e24d8e2eb438b6adafd37930c2462fb5d1"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -2272,7 +2272,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rusoto_core",
  "rusoto_credential",

--- a/tough-kms/CHANGELOG.md
+++ b/tough-kms/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2021-01-19
+### Changes
+- Update `tough` dependency to 0.10.0.
+
 ## [0.1.1] - 2020-11-10
 ### Changes
 - We now pad signatures shorter than the RSA modulus to ensure compatibility with other implementations of RSA PSS ([#263]).
+- Update `rusoto` dependency to 0.45.0.
 
 [#263]: https://github.com/awslabs/tough/pull/263
 
@@ -14,5 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[0.2.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.1.1...tough-kms-v0.2.0
 [0.1.1]: https://github.com/awslabs/tough/compare/tough-kms-v0.1.0...tough-kms-v0.1.1
 [0.1.0]: https://github.com/awslabs/tough/releases/tag/tough-kms-v0.1.0

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-kms"
-version = "0.1.1"
+version = "0.2.0"
 description = "Implements AWS KMS as a key source for TUF signing keys"
 authors = ["Shailesh Gothi <gothisg@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2021-01-19
+### Changed
+- Update `tough` dependency to 0.10.0.
+- Update `rusoto` dependency to 0.45.0.
+
 ## [0.4.0] - 2020-09-17
 ### Changed
 - Update `tough` dependency to 0.9.0.
@@ -23,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[0.5.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.4.0...tough-ssm-v0.5.0
 [0.4.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.3.0...tough-ssm-v0.4.0
 [0.3.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.2.0...tough-ssm-v0.3.0
 [0.2.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.1.0...tough-ssm-v0.2.0

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.4.0"
+version = "0.5.0"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,20 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.0] - 2021-01-19
+### Breaking Changes
+- Correct spelling of `tuftool download` argument from `--target-url` to `--targets-url` [#309]
+
 ### Added
 - Support `file://` URLs with the download command [#222]
 - Support download and update of expired repos [#224]
 - Set version command for specifying the `root.json` version. [#236]
 
 ### Changed
-- `tough-kms` fix to prevent occasional bad repo signing with KMS [#263]
+- Updated `tough` dependency to 0.10.0.
+- Updated `tough-kms` dependency to 0.2.0 (which includes fix for [#263]).
+- Updated `tough-ssm` to 0.5.0. 
 - Other dependency updates.
 
 [#222]: https://github.com/awslabs/tough/pull/222
 [#224]: https://github.com/awslabs/tough/pull/224
 [#236]: https://github.com/awslabs/tough/pull/236
 [#263]: https://github.com/awslabs/tough/issues/263
+[#309]: https://github.com/awslabs/tough/pull/309
 
 ## [0.5.0] - 2020-09-14
 ### Added
@@ -93,7 +99,8 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.5.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.6.0...develop
+[0.6.0]: https://github.com/awslabs/tough/compare/tuftool-v0.5.0...tuftool-v0.6.0
 [0.5.0]: https://github.com/awslabs/tough/compare/tuftool-v0.4.1...tuftool-v0.5.0
 [0.4.1]: https://github.com/awslabs/tough/compare/tuftool-v0.4.0...tuftool-v0.4.1
 [0.4.0]: https://github.com/awslabs/tough/compare/tuftool-v0.3.1...tuftool-v0.4.0

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -37,8 +37,8 @@ structopt = "0.3"
 tempfile = "3.1.0"
 tokio = "0.2.21"
 tough = { version = "0.10.0", path = "../tough", features = ["http"] }
-tough-ssm = { version = "0.4.0", path = "../tough-ssm" }
-tough-kms = { version = "0.1.1", path = "../tough-kms" }
+tough-ssm = { version = "0.5.0", path = "../tough-ssm" }
+tough-kms = { version = "0.2.0", path = "../tough-kms" }
 url = "2.1.0"
 walkdir = "2.2.9"
 


### PR DESCRIPTION

Prep releases of tough-kms, tough-ssm and tuftool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
