### PR TITLE
Windows fix [ Partial / 'tough' crate only ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 **tuftool** is a Rust command-line utility for generating and signing TUF repositories.
 
+## Integration Testing
+Integration tests require `docker`.
+
+### Windows❗ Warnings
+- Tests can break on Windows if Git's `autocrlf` feature changes line endings.
+  This is due to the fact that some tests require files to have a *precise* byte size and hash signature.
+  *We have mitigated this with a `.gitattributes` file in the test data directory*.
+
+- Cygwin **must** be installed at `C:\cygwin64\` and have the `make` package installed for integration tests to work properly. 
+
 ## Documentation
 See [tough - Rust](https://docs.rs/tough/) for the latest `tough` library documentation.
 

--- a/integ/failure-server/.gitattributes
+++ b/integ/failure-server/.gitattributes
@@ -1,0 +1,4 @@
+# Denote bash scripts as binary so they will not be modified by autocrlf.
+# (Bash doens't seem to like CRLF-encoded scripts | Just to be sure)
+run.sh binary
+teardown.sh binary

--- a/integ/failure-server/run.sh
+++ b/integ/failure-server/run.sh
@@ -14,6 +14,14 @@ set -eo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TUF_REFERENCE_REPO="${DIR}/../../tough/tests/data/tuf-reference-impl"
 
+# if we are under cygwin , set a windows style path
+# (docker for windows requires windows style paths to work ,it doesn't understand cygwin-style paths)
+if [[ "$OSTYPE" == "cygwin" ]]; then
+  DIR="$(cygpath --windows ${DIR})"
+  TUF_REFERENCE_REPO="$(cygpath --windows ${TUF_REFERENCE_REPO})"
+fi
+
+
 function waitforit() {
   echo "waiting $1 seconds for $2 to start"
   sleep $1

--- a/tough/src/editor/signed.rs
+++ b/tough/src/editor/signed.rs
@@ -21,7 +21,12 @@ use serde_plain::forward_from_str_to_serde;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs;
+
+#[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::symlink;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::symlink_file as symlink;
+
 use std::path::{Path, PathBuf};
 use url::Url;
 use walkdir::WalkDir;

--- a/tough/tests/data/.gitattributes
+++ b/tough/tests/data/.gitattributes
@@ -1,0 +1,2 @@
+# Denote all files as binary so they will not be modified by autocrlf.
+* binary


### PR DESCRIPTION
*Issue #, if available:*
"tough" crate doesn't compile on Windows

*Description of changes:*
 - Replaces the `symlink` function with the `symlink_file` when needed
 - Patches the FileSystemTransport to patch a bug with 'url.path()' that returned an invalid path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
