### PR TITLE
update reqwest for better proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+checksum = "0460542b551950620a3648c6aa23318ac6b3cd779114bd873209e6e8b5eb1c34"
 dependencies = [
  "base64",
  "bytes",

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.2"
 log = "0.4.8"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.8.1"
-reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking"] }
+reqwest = { version = "0.11.1", optional = true, default-features = false, features = ["blocking"] }
 ring = { version = "0.16.16", features = ["std"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.60"

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -24,6 +24,8 @@ use url::Url;
 /// .build();
 /// ```
 ///
+/// See [`HttpTransport`] for proxy support and other behavior details.
+///
 #[derive(Clone, Copy, Debug)]
 pub struct HttpTransportBuilder {
     timeout: Duration,
@@ -105,6 +107,12 @@ impl HttpTransportBuilder {
 /// - 403: Forbidden. (Some services return this code when a file does not exist.)
 /// - 404: Not Found.
 /// - 410: Gone.
+///
+/// # Proxy Support
+///
+/// To use the `HttpTransport` with a proxy, specify the `HTTPS_PROXY` environment variable.
+/// The transport will also respect the `NO_PROXY` environment variable.
+///
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HttpTransport {
     settings: HttpTransportBuilder,

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -23,7 +23,7 @@ maplit = "1.0.1"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "0.8.1"
 rayon = "1.2"
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11.1", features = ["blocking"] }
 ring = { version = "0.16.16", features = ["std"] }
 rusoto_core = { version = "0.46", optional = true, default-features = false }
 rusoto_credential = { version = "0.46", optional = true }

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -125,6 +125,10 @@ tuftool download \
    "${WRK}/tuf-downlaod"
 ```
 
+## HTTP Proxy Support
+
+`tuftool` respects the `HTTPS_PROXY` and `NO_PROXY` environment variables.
+
 ## Testing
 
 Unit tests are run in the usual manner: `cargo test`.


### PR DESCRIPTION
*Issue #, if available:*

Closes #339

*Description of changes:*

```
In both tough and tuftool we set the reqwest version to 0.11.1 or higher
to ensure that we have the changes from the following PR:
https://github.com/seanmonstar/reqwest/pull/1178

This ensures that the HTTPS_PROXY environment variable will work as
expected such that a proxy given without a protocol scheme will be
treated as http://.
```

*Testing*

I ran tinyproxy and exported `HTTPS_PROXY=localhost:8888`, I then ran

```sh
cargo run -- download \
    --allow-root-download \
    --targets-url https://updates.bottlerocket.aws/targets/ \
    --metadata-url https://updates.bottlerocket.aws/2020-07-07/aws-k8s-1.17/x86_64/ \
    /tmp/foobar
```

I have also verified reqwest's `NO_PROXY` behavior in other contexts/PRs.

The download worked and I observed the traffic going through my tinyproxy.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
