### PR TITLE
speed up ci with caching

### DIFF
--- a/.github/cache_bust
+++ b/.github/cache_bust
@@ -1,0 +1,4 @@
+# this file provides a manual way to clear out github actions caches. any change
+# to this file will cause all github action caches to miss. increment the number
+# below by 1 if you need to clear the caches.
+1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,11 +1,26 @@
 name: Rust
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
     branches: [develop]
 jobs:
   build:
+    strategy:
+      matrix:
+        make_target: ["build", "integ"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        # you can edit the .github/cache_bust file if you need to clear the cache
+        key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-
     - run: rustup update stable
-    - run: make ci
+    - run: make ${{ matrix.make_target }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+# the series of builds, tests and checks that runs for pull requests. requires docker.
 .PHONY: ci
-ci: ## The series of builds, tests and checks that runs for pull requests. Requires docker.
+ci: build integ
+
+# builds each crate, runs unit tests at the workspace level, and runs linting tools.
+.PHONY: build
+build:
 	set +e
 	cargo fmt -- --check
 	cargo clippy --locked -- -D warnings
@@ -9,5 +14,10 @@ ci: ## The series of builds, tests and checks that runs for pull requests. Requi
 	cargo build --locked -p tough-kms
 	cargo build --locked -p tuftool
 	cargo test --locked
+
+# checks tough tests with and without the http feature. http testing requires docker.
+.PHONY: integ
+integ:
+	set +e
 	cd tough && cargo test --features '' --locked
 	cd tough && cargo test --all-features --locked


### PR DESCRIPTION
*Issue #, if available:*

Closes #259

*Description of changes:*

- Cache build and certain CARGO_HOME directories for CI speedup.
- Split CI into two parts
  - one that does all of the crate builds, fmt, clippy and unit tests,
  - another that runs the docker/script-based HTTP integ test.

The cache behavior is such that, when Cargo.lock changes, a cache miss happens, but we restore the most recent cache and create a new cache after the build. There is a file named `cache_bust` that, if we make a change to it, we will start a fresh build with no cache restore.

One _could_ get the same `cache_bust` behavior by changing some prefix in the cache key in the `.gitignore` file, but the edit would need to be made in more than one place. I like the `cache_bust` file because it is a single edit that will discard all caches.

*Testing*

- `make ci` still works locally.
- GitHub actions run in about 4 minutes. Previously actions took about 11 or 12 minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
