### PR TITLE
Fix new clippy lints in Rust 1.52

### DIFF
--- a/tough-kms/src/lib.rs
+++ b/tough-kms/src/lib.rs
@@ -78,7 +78,7 @@ impl KeySource for KmsKeySource {
         &self,
     ) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync + 'static>>
     {
-        let kms_client = match self.client.to_owned() {
+        let kms_client = match self.client.clone() {
             Some(value) => value,
             None => client::build_client_kms(self.profile.as_deref())?,
         };
@@ -165,7 +165,7 @@ impl Sign for KmsRsaKey {
         // Create a Key struct for the public key
         Key::Rsa {
             keyval: RsaKey {
-                public: self.public_key.to_owned(),
+                public: self.public_key.clone(),
                 _extra: HashMap::new(),
             },
             scheme: RsaScheme::RsassaPssSha256,
@@ -178,7 +178,7 @@ impl Sign for KmsRsaKey {
         msg: &[u8],
         _rng: &dyn SecureRandom,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        let kms_client = match self.client.to_owned() {
+        let kms_client = match self.client.clone() {
             Some(value) => value,
             None => client::build_client_kms(self.profile.as_deref())?,
         };

--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -143,7 +143,7 @@ impl Repository {
                 .join(filename)
                 .context(error::JoinUrl {
                     path: filename,
-                    url: self.metadata_base_url.to_owned(),
+                    url: self.metadata_base_url.clone(),
                 })?,
             max_size,
             max_size_specifier,
@@ -155,7 +155,7 @@ impl Repository {
         let mut root_file_data = Vec::new();
         read.read_to_end(&mut root_file_data)
             .context(error::CacheFileRead {
-                url: self.metadata_base_url.to_owned(),
+                url: self.metadata_base_url.clone(),
             })?;
         file.write_all(&root_file_data)
             .context(error::CacheFileWrite { path: outpath })
@@ -226,7 +226,7 @@ impl Repository {
                 .join(&filename)
                 .context(error::JoinUrl {
                     path: filename,
-                    url: self.targets_base_url.to_owned(),
+                    url: self.targets_base_url.clone(),
                 })?,
             target.length,
             "targets.json",

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -492,7 +492,7 @@ impl RepositoryEditor {
                 .join(&format!("{}.json", name))
                 .context(error::JoinUrl {
                     path: name.to_string(),
-                    url: metadata_base_url.to_owned(),
+                    url: metadata_base_url.clone(),
                 })?;
         let reader = Box::new(fetch_max_size(
             transport.as_ref(),
@@ -553,7 +553,7 @@ impl RepositoryEditor {
                     .join(&format!("{}.json", name))
                     .context(error::JoinUrl {
                         path: name.to_string(),
-                        url: metadata_base_url.to_owned(),
+                        url: metadata_base_url.clone(),
                     })?;
             let reader = Box::new(fetch_max_size(
                 transport.as_ref(),

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -355,7 +355,7 @@ impl Repository {
             transport,
             consistent_snapshot: root.signed.consistent_snapshot,
             datastore,
-            earliest_expiration: earliest_expiration.to_owned(),
+            earliest_expiration: *earliest_expiration,
             earliest_expiration_role: *earliest_expiration_role,
             root,
             snapshot,
@@ -555,7 +555,7 @@ fn load_root<R: Read>(
             transport,
             metadata_base_url.join(&path).context(error::JoinUrl {
                 path,
-                url: metadata_base_url.to_owned(),
+                url: metadata_base_url.clone(),
             })?,
             max_root_size,
             "max_root_size argument",
@@ -679,7 +679,7 @@ fn load_timestamp(
         transport,
         metadata_base_url.join(path).context(error::JoinUrl {
             path,
-            url: metadata_base_url.to_owned(),
+            url: metadata_base_url.clone(),
         })?,
         max_timestamp_size,
         "max_timestamp_size argument",
@@ -765,7 +765,7 @@ fn load_snapshot(
         transport,
         metadata_base_url.join(&path).context(error::JoinUrl {
             path,
-            url: metadata_base_url.to_owned(),
+            url: metadata_base_url.clone(),
         })?,
         snapshot_meta.length,
         "timestamp.json",
@@ -900,7 +900,7 @@ fn load_targets(
     };
     let targets_url = metadata_base_url.join(&path).context(error::JoinUrl {
         path,
-        url: metadata_base_url.to_owned(),
+        url: metadata_base_url.clone(),
     })?;
     let (max_targets_size, specifier) = match targets_meta.length {
         Some(length) => (length, "snapshot.json"),
@@ -1029,7 +1029,7 @@ fn load_delegations(
         };
         let role_url = metadata_base_url.join(&path).context(error::JoinUrl {
             path: path.clone(),
-            url: metadata_base_url.to_owned(),
+            url: metadata_base_url.clone(),
         })?;
         let specifier = "max_targets_size parameter";
         // load the role json file

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -80,13 +80,7 @@ impl AddKeyArgs {
             );
         }
         let updated_role = editor
-            .add_key(
-                key_pairs,
-                match &self.delegated_role {
-                    Some(role) => Some(role.as_str()),
-                    None => None,
-                },
-            )
+            .add_key(key_pairs, self.delegated_role.as_deref())
             .context(error::LoadMetadata)?
             .version(self.version)
             .expires(self.expires)

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -64,13 +64,7 @@ impl RemoveKeyArgs {
     /// Removes keys from a delegated role using targets Editor
     fn remove_key(&self, role: &str, mut editor: TargetsEditor) -> Result<()> {
         let updated_role = editor
-            .remove_key(
-                &self.remove,
-                match &self.delegated_role {
-                    Some(role) => Some(role.as_str()),
-                    None => None,
-                },
-            )
+            .remove_key(&self.remove, self.delegated_role.as_deref())
             .context(error::LoadMetadata)?
             .version(self.version)
             .expires(self.expires)


### PR DESCRIPTION
*Description of changes:*

Fixes the clippy warnings that are causing failed Checks in other PRs.  The `as_deref` suggestion is pretty great.  The other nice one is using `earliest_expiration`'s `Copy` status rather than cloning it.  (I was a bit surprised that `chrono::DateTime<Utc>` is Copy, but yay!)

Clippy is clean after, unit tests pass, and a `tuftool download` worked OK.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
