### PR TITLE
Fix new clippy lints

### DIFF
--- a/olpc-cjson/src/lib.rs
+++ b/olpc-cjson/src/lib.rs
@@ -269,8 +269,8 @@ impl Formatter for CanonicalFormatter {
 
     fn end_object_value<W: Write + ?Sized>(&mut self, _writer: &mut W) -> Result<()> {
         let object = self.obj_mut()?;
-        let key = std::mem::replace(&mut object.next_key, Vec::new());
-        let value = std::mem::replace(&mut object.next_value, Vec::new());
+        let key = std::mem::take(&mut object.next_key);
+        let value = std::mem::take(&mut object.next_value);
         object.obj.insert(key, value);
         Ok(())
     }

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -266,11 +266,10 @@ impl TargetsEditor {
         let mut keyids = Vec::new();
         for (keyid, key) in keys {
             // Check to see if the key is present
-            if delegations
+            if !delegations
                 .keys
-                .iter()
-                .find(|(_, candidate_key)| key.clone().eq(candidate_key))
-                .is_none()
+                .values()
+                .any(|candidate_key| key == *candidate_key)
             {
                 // Key isn't present yet, so we need to add it
                 delegations.keys.insert(keyid.clone(), key);


### PR DESCRIPTION
*Description of changes:*

This fixes two new clippy lints ([one](https://rust-lang.github.io/rust-clippy/master/index.html#search_is_some) [two](https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default)) that are blocking PRs.

*Testing done:*

`make ci` now passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
