### PR TITLE
tuftool: update simplelog to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc0ffd69814a9b251d43afcabf96dad1b29f5028378056257be9e3fecc9f720"
+checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
 dependencies = [
  "chrono",
  "log",

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -31,7 +31,7 @@ rusoto_ssm = { version = "0.46", optional = true, default-features = false }
 rusoto_kms = { version = "0.46", optional = true, default-features = false }
 serde = "1.0.125"
 serde_json = "1.0.63"
-simplelog = "0.9.0"
+simplelog = "0.10"
 snafu = { version = "0.6.10", features = ["backtraces-impl-backtrace-crate"] }
 structopt = "0.3"
 tempfile = "3.1.0"

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -28,7 +28,7 @@ mod update_targets;
 
 use crate::error::Result;
 use rayon::prelude::*;
-use simplelog::{ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
+use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 use snafu::{ErrorCompat, OptionExt, ResultExt};
 use std::collections::HashMap;
 use std::fs::File;
@@ -65,6 +65,7 @@ impl Program {
                 .add_filter_allow_str("tough")
                 .build(),
             TerminalMode::Mixed,
+            ColorChoice::Auto,
         )
         .context(error::Logger)?;
         self.cmd.run()


### PR DESCRIPTION
*Description of changes:*

Replaces dependabot's #368, with the syntax changes needed for simplelog 0.10.

*Testing done:*

Unit tests pass.  Used tuftool to download from a repo OK, and confirmed with `--log-level trace` I still see log output, with color where appropriate.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
