### PR TITLE
Fix clippy warnings

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -171,7 +171,7 @@ impl Repository {
             .context(error::CacheTargetMissing {
                 target_name: name.to_owned(),
             })?;
-        let (sha, filename) = self.target_digest_and_filename(&t, name);
+        let (sha, filename) = self.target_digest_and_filename(t, name);
         let mut reader = self.fetch_target(t, &sha, filename.as_str())?;
         let path = outdir.as_ref().join(filename);
         let mut f = OpenOptions::new()
@@ -223,7 +223,7 @@ impl Repository {
         fetch_sha256(
             self.transport.as_ref(),
             self.targets_base_url
-                .join(&filename)
+                .join(filename)
                 .context(error::JoinUrl {
                     path: filename,
                     url: self.targets_base_url.clone(),

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -177,7 +177,7 @@ impl RepositoryEditor {
             let mut roles = Vec::new();
             for role in delegated_targets {
                 // Create a `SignedRole<DelegatedTargets>` for each delegated targets
-                roles.push(SignedRole::from_signed(role)?)
+                roles.push(SignedRole::from_signed(role)?);
             }
             // SignedDelegatedTargets is a wrapper for a set of `SignedRole<DelegatedTargets>`
             Some(SignedDelegatedTargets {
@@ -257,7 +257,7 @@ impl RepositoryEditor {
 
     /// Add a `Target` to the repository
     pub fn add_target(&mut self, name: &str, target: Target) -> Result<&mut Self> {
-        self.targets_editor_mut()?.add_target(&name, target);
+        self.targets_editor_mut()?.add_target(name, target);
         Ok(self)
     }
 
@@ -578,7 +578,7 @@ impl RepositoryEditor {
         }
         // Add our new role in place of the old one
         if name == "targets" {
-            self.signed_targets = Some(role)
+            self.signed_targets = Some(role);
         } else {
             self.signed_targets
                 .as_mut()

--- a/tough/src/editor/signed.rs
+++ b/tough/src/editor/signed.rs
@@ -65,7 +65,7 @@ where
         // the keys provided.
         let valid_keys = root_keys
             .iter()
-            .filter(|(keyid, _signing_key)| role_keys.keyids.contains(&keyid));
+            .filter(|(keyid, _signing_key)| role_keys.keyids.contains(keyid));
 
         // Create the `Signed` struct for this role. This struct will be
         // mutated later to contain the signatures.

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -338,7 +338,7 @@ impl TargetsEditor {
     }
 
     /// Removes a role from delegations
-    /// If `recursive` is `false`, 'role` is only removed if it is directly delegated by this role
+    /// If `recursive` is `false`, `role` is only removed if it is directly delegated by this role
     /// If `true` removes whichever role eventually delegates 'role'
     pub fn remove_role(&mut self, role: &str, recursive: bool) -> Result<&mut Self> {
         let delegations = self.delegations.as_mut().context(error::NoDelegations)?;
@@ -543,7 +543,7 @@ impl TargetsEditor {
                         .targets
                         .context(error::NoTargets)?
                         .delegated_targets(&role.name),
-                )?)
+                )?);
             }
         }
 

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -261,7 +261,7 @@ fn fetch_with_retries(
     // retry loop
     loop {
         // build the request
-        let request = build_request(&client, r.next_byte, &url)?;
+        let request = build_request(&client, r.next_byte, url)?;
 
         // send the GET request, then categories the outcome by converting to an HttpResult.
         let http_result: HttpResult = client.execute(request).into();
@@ -293,7 +293,7 @@ fn fetch_with_retries(
             }
         }
 
-        r.increment(&cs);
+        r.increment(cs);
         std::thread::sleep(r.wait);
     }
 }

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -993,7 +993,7 @@ fn load_targets(
             metadata_base_url,
             max_targets_size,
             delegations,
-            &datastore,
+            datastore,
         )?;
     }
 
@@ -1060,7 +1060,7 @@ fn load_delegations(
         );
         {
             if let Some(delegations) = role.signed.delegations.as_ref() {
-                delegations.verify_paths().context(error::InvalidPath {})?
+                delegations.verify_paths().context(error::InvalidPath {})?;
             }
         }
 
@@ -1105,7 +1105,7 @@ mod tests {
         assert_eq!(
             parsed_url_without_trailing_slash,
             parsed_url_with_trailing_slash
-        )
+        );
     }
 
     // Ensure that the `ExpirationEnforcement` traits are not changed by mistake.

--- a/tough/src/schema/decoded.rs
+++ b/tough/src/schema/decoded.rs
@@ -213,6 +213,6 @@ impl<T> Ord for Decoded<T> {
 
 impl<T> Hash for Decoded<T> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
-        self.bytes.hash(hasher)
+        self.bytes.hash(hasher);
     }
 }

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -637,7 +637,7 @@ impl Targets {
             for role in &delelegations.roles {
                 roles.push(&role.name);
                 if let Some(targets) = &role.targets {
-                    roles.append(&mut targets.signed.role_names())
+                    roles.append(&mut targets.signed.role_names());
                 }
             }
         }
@@ -650,7 +650,7 @@ impl Targets {
         if let Some(delegations) = &self.delegations {
             for role in &delegations.roles {
                 if role.name == name {
-                    return Ok(&delegations);
+                    return Ok(delegations);
                 }
                 if let Some(targets) = &role.targets {
                     if let Ok(delegation) = targets.signed.parent_of(name) {
@@ -953,7 +953,7 @@ impl Delegations {
                 PathSet::Paths(paths) | PathSet::PathHashPrefixes(paths) => paths,
             };
             for path in pathset {
-                if !self.target_is_delegated(&path) {
+                if !self.target_is_delegated(path) {
                     return Err(Error::UnmatchedPath {
                         child: path.to_string(),
                     });
@@ -991,7 +991,7 @@ impl DelegatedRole {
             PathSet::Paths(x) | PathSet::PathHashPrefixes(x) => x,
         };
         for path in paths {
-            if !self.paths.matched_target(&path) {
+            if !self.paths.matched_target(path) {
                 return Err(Error::UnmatchedPath {
                     child: path.to_string(),
                 });

--- a/tough/tests/repo_cache.rs
+++ b/tough/tests/repo_cache.rs
@@ -46,8 +46,8 @@ fn load_tuf_reference_impl(paths: &RepoPaths) -> Repository {
 #[test]
 fn test_repo_cache_all_targets() {
     // load the reference_impl repo
-    let mut repo_paths = RepoPaths::new();
-    let repo = load_tuf_reference_impl(&mut repo_paths);
+    let repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&repo_paths);
 
     // cache the repo for future use
     let destination = TempDir::new().unwrap();
@@ -94,8 +94,8 @@ fn test_repo_cache_all_targets() {
 #[test]
 fn test_repo_cache_list_of_two_targets() {
     // load the reference_impl repo
-    let mut repo_paths = RepoPaths::new();
-    let repo = load_tuf_reference_impl(&mut repo_paths);
+    let repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&repo_paths);
 
     // cache the repo for future use
     let destination = TempDir::new().unwrap();
@@ -143,8 +143,8 @@ fn test_repo_cache_list_of_two_targets() {
 #[test]
 fn test_repo_cache_some() {
     // load the reference_impl repo
-    let mut repo_paths = RepoPaths::new();
-    let repo = load_tuf_reference_impl(&mut repo_paths);
+    let repo_paths = RepoPaths::new();
+    let repo = load_tuf_reference_impl(&repo_paths);
 
     // cache the repo for future use
     let destination = TempDir::new().unwrap();

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -164,11 +164,10 @@ impl UpdateArgs {
                 .sign_targets_editor(&self.keys)
                 .context(error::DelegationStructure)?
                 .update_delegated_targets(
-                    &self.role.as_ref().context(error::Missing {
+                    self.role.as_ref().context(error::Missing {
                         what: "delegated role",
                     })?,
-                    &self
-                        .indir
+                    self.indir
                         .as_ref()
                         .context(error::Missing {
                             what: "delegated role metadata url",


### PR DESCRIPTION
After the Rust 1.54 release, there are new clippy warnings to fix!

Unit tests still pass.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
