### PR TITLE
[tough]: Add the ability to cache only a repository's metadata

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -57,6 +57,28 @@ impl Repository {
         Ok(())
     }
 
+    /// Cache only a repository's metadata files (snapshot, targets, timestamp), including any
+    /// delegated targets metadata.  The cached files will be saved to the local filesystem.
+    ///
+    /// * `metadata_outdir` is the directory where cached metadata files will be saved.
+    /// * `cache_root_chain` specifies whether or not we will cache all versions of `root.json`.
+    pub fn cache_metadata<P>(&self, metadata_outdir: P, cache_root_chain: bool) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        // Create the output directory if it does not exist.
+        std::fs::create_dir_all(metadata_outdir.as_ref()).context(error::CacheDirectoryCreate {
+            path: metadata_outdir.as_ref(),
+        })?;
+
+        self.cache_metadata_impl(&metadata_outdir)?;
+
+        if cache_root_chain {
+            self.cache_root_chain(metadata_outdir)?;
+        }
+        Ok(())
+    }
+
     /// Cache repository metadata files, including delegated targets metadata
     fn cache_metadata_impl<P>(&self, metadata_outdir: P) -> Result<()>
     where


### PR DESCRIPTION
*Issue #, if available:*
Related to #401 

*Description of changes:*
```
    tough: factor out metadata and root caching
    
    This change moves the metadata and root chain caching into their own
    (private) functions. This allows us to create additional public
    functions that make use of them.  The functionality of `cache()` is
    unchanged.
```
```
    tough: Add `Repository.cache_metadata()` method
    
    This change adds an additional method to `Repository`,
    `cache_metadata()`.  This method allows a user to download just the
    metadata of a repository (including delegated targets metadata), and
    optionally cache the root chain as well.
```

*Testing done:*
* All (new/old) unit tests pass
* The library will be further exercised/tested with the `tuftool` functionality added in #401 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
