### PR TITLE
Fix parsing of `root.json` file when `ecdsa-sha2-nistp256` keys are used

### DIFF
--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -58,6 +58,7 @@ pub enum Key {
         _extra: HashMap<String, Value>,
     },
     /// An EcdsaKey
+    #[serde(rename = "ecdsa-sha2-nistp256")]
     Ecdsa {
         /// The Ecdsa key.
         keyval: EcdsaKey,


### PR DESCRIPTION
[According to the TUF spec](https://theupdateframework.github.io/specification/v1.0.25/index.html#keytype), the `key_type` value for  ECDSA-sha2-nistp256 keys is `ecdsa-sha2-nistp256`.
    
Prior to this commit, the expected `key_type` value for these keys was `ecdsa`.
    
That made impossible the parsing of `root.json` files using one or more of this type of keys.