### PR TITLE
Update license check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,12 @@ ci: check-licenses build integ
 # installs cargo-deny
 .PHONY: cargo-deny
 cargo-deny:
-	cargo install --version 0.6.2 cargo-deny --no-default-features
+	cargo install --version 0.9.1 cargo-deny --locked
 
 # checks each crate, and evaluates licenses. requires cargo-deny.
 .PHONY: check-licenses
 check-licenses: cargo-deny
-	cargo deny check --disable-fetch licenses
+	cargo deny --all-features check --disable-fetch licenses bans sources
 
 # builds each crate, runs unit tests at the workspace level, and runs linting tools.
 .PHONY: build

--- a/deny.toml
+++ b/deny.toml
@@ -35,3 +35,13 @@ expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
 ]
+
+[bans]
+# Deny multiple versions or wildcard dependencies.
+multiple-versions = "deny"
+wildcards = "deny"
+
+[sources]
+# Deny crates from unknown registries or git repositories.
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
*Description of changes:*

Bumps `cargo-deny` from 0.6.2 to 0.9.1 while also checking for:
- multiple versions
- wildcard dependencies
- unknown registries
- unknown git repositories

The license check was also tweaked to look at all features at once, and the `cargo-deny` install is now `--locked`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
