### PR TITLE
Fix clippy warning

### DIFF
--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -67,7 +67,7 @@ impl Delegations {
         role.signed
             .serialize(&mut ser)
             .context(error::JsonSerializationSnafu {
-                what: format!("{} role", name.to_string()),
+                what: format!("{} role", name),
             })?;
         for signature in &role.signatures {
             if role_keys.keyids.contains(&signature.keyid) {


### PR DESCRIPTION
**Description of changes:**

Fix clippy warning after Rust 1.58.0 release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
