### PR TITLE
tuftool: prepare release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuftool"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2022-01-28
+### Changes
+- Dependency updates.
+
 ## [0.7.0] - 2021-10-19
 ### Breaking Changes
 - `tuftool download` now requires `outdir` to not exist.
@@ -154,7 +158,8 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.7.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.7.1...develop
+[0.7.1]: https://github.com/awslabs/tough/compare/tuftool-v0.7.0...tuftool-v0.7.1
 [0.7.0]: https://github.com/awslabs/tough/compare/tuftool-v0.6.4...tuftool-v0.7.0
 [0.6.4]: https://github.com/awslabs/tough/compare/tuftool-v0.6.3...tuftool-v0.6.4
 [0.6.3]: https://github.com/awslabs/tough/compare/tuftool-v0.6.2...tuftool-v0.6.3

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.7.0"
+version = "0.7.1"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Oops, we discovered that it *is* necessary to release tuftool when doing minor version bumps. We had a version mismatch error when we double checked cargo install tuftool, and releasing this update should fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
