### PR TITLE
tough: blanket impl sign for references

### DIFF
--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -665,7 +665,7 @@ impl RepositoryEditor {
         let expires = self.snapshot_expires.context(error::MissingSnafu {
             field: "snapshot expiration",
         })?;
-        let _extra = self.snapshot_extra.clone().unwrap_or_else(HashMap::new);
+        let _extra = self.snapshot_extra.clone().unwrap_or_default();
 
         let mut snapshot = Snapshot::new(SPEC_VERSION.to_string(), version, expires);
 
@@ -713,7 +713,7 @@ impl RepositoryEditor {
         let expires = self.timestamp_expires.context(error::MissingSnafu {
             field: "timestamp expiration",
         })?;
-        let _extra = self.timestamp_extra.clone().unwrap_or_else(HashMap::new);
+        let _extra = self.timestamp_extra.clone().unwrap_or_default();
         let mut timestamp = Timestamp::new(SPEC_VERSION.to_string(), version, expires);
 
         // Timestamp stores metadata about snapshot

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -474,7 +474,7 @@ impl TargetsEditor {
             }
         }
 
-        let _extra = self._extra.clone().unwrap_or_else(HashMap::new);
+        let _extra = self._extra.clone().unwrap_or_default();
         Ok(DelegatedTargets {
             name: self.name.clone(),
             targets: Targets {

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -57,12 +57,14 @@ impl HttpTransportBuilder {
     }
 
     /// Set a timeout for the complete fetch operation.
+    #[must_use]
     pub fn timeout(mut self, value: Duration) -> Self {
         self.timeout = value;
         self
     }
 
     /// Set a timeout for only the connect phase.
+    #[must_use]
     pub fn connect_timeout(mut self, value: Duration) -> Self {
         self.connect_timeout = value;
         self
@@ -70,18 +72,21 @@ impl HttpTransportBuilder {
 
     /// Set the total number of times we will try the fetch operation (in case of retryable
     /// failures).
+    #[must_use]
     pub fn tries(mut self, value: u32) -> Self {
         self.tries = value;
         self
     }
 
     /// Set the pause duration between the first and second try.
+    #[must_use]
     pub fn initial_backoff(mut self, value: Duration) -> Self {
         self.initial_backoff = value;
         self
     }
 
     /// Set the maximum duration of a pause between retries.
+    #[must_use]
     pub fn max_backoff(mut self, value: Duration) -> Self {
         self.max_backoff = value;
         self
@@ -89,6 +94,7 @@ impl HttpTransportBuilder {
 
     /// Set the exponential backoff factor, the factor by which the pause time will increase after
     /// each try until reaching `max_backoff`.
+    #[must_use]
     pub fn backoff_factor(mut self, value: f32) -> Self {
         self.backoff_factor = value;
         self

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -195,12 +195,14 @@ impl<R: Read> RepositoryLoader<R> {
     }
 
     /// Set the transport. If no transport has been set, [`DefaultTransport`] will be used.
+    #[must_use]
     pub fn transport<T: Transport + 'static>(mut self, transport: T) -> Self {
         self.transport = Some(Box::new(transport));
         self
     }
 
     /// Set a the repository [`Limits`].
+    #[must_use]
     pub fn limits(mut self, limits: Limits) -> Self {
         self.limits = Some(limits);
         self
@@ -213,6 +215,7 @@ impl<R: Read> RepositoryLoader<R> {
     /// You may chose to provide a [`PathBuf`] to a directory on a persistent filesystem, which must
     /// exist prior to calling [`RepositoryLoader::load`]. If no datastore is provided, a temporary
     /// directory will be created and cleaned up for for you.
+    #[must_use]
     pub fn datastore<P: Into<PathBuf>>(mut self, datastore: P) -> Self {
         self.datastore = Some(datastore.into());
         self
@@ -223,6 +226,7 @@ impl<R: Read> RepositoryLoader<R> {
     /// **CAUTION:** TUF metadata expiration dates, particularly `timestamp.json`, are designed to
     /// limit a replay attack window. By setting `expiration_enforcement` to `Unsafe`, you are
     /// disabling this feature of TUF. Use `Safe` unless you have a good reason to use `Unsafe`.
+    #[must_use]
     pub fn expiration_enforcement(mut self, exp: ExpirationEnforcement) -> Self {
         self.expiration_enforcement = Some(exp);
         self

--- a/tough/src/schema/spki.rs
+++ b/tough/src/schema/spki.rs
@@ -114,7 +114,7 @@ fn asn1_encode_len(n: usize) -> Vec<u8> {
         vec![n as u8]
     } else {
         let n = n.to_be_bytes();
-        let skip_bytes = n.iter().position(|b| *b != 0).unwrap_or_else(|| n.len());
+        let skip_bytes = n.iter().position(|b| *b != 0).unwrap_or(n.len());
         let mut v = vec![0_u8; n.len() - skip_bytes + 1];
         v[0] = 0x80 | (n.len() - skip_bytes) as u8;
         v[1..].copy_from_slice(&n[skip_bytes..]);

--- a/tough/src/sign.rs
+++ b/tough/src/sign.rs
@@ -12,6 +12,7 @@ use ring::rand::SecureRandom;
 use ring::signature::{EcdsaKeyPair, Ed25519KeyPair, KeyPair, RsaKeyPair};
 use snafu::ResultExt;
 use std::collections::HashMap;
+use std::error::Error;
 
 /// This trait must be implemented for each type of key with which you will
 /// sign things.
@@ -25,6 +26,21 @@ pub trait Sign: Sync + Send {
         msg: &[u8],
         rng: &dyn SecureRandom,
     ) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>>;
+}
+
+/// Implements `Sign` for a reference to any type that implements `Sign`.
+impl<'a, T: Sign> Sign for &'a T {
+    fn tuf_key(&self) -> Key {
+        (*self).tuf_key()
+    }
+
+    fn sign(
+        &self,
+        msg: &[u8],
+        rng: &dyn SecureRandom,
+    ) -> std::prelude::rust_2015::Result<Vec<u8>, Box<dyn Error + Send + Sync + 'static>> {
+        (*self).sign(msg, rng)
+    }
 }
 
 /// Implements the Sign trait for ED25519


### PR DESCRIPTION
*Issue #, if available:*

#446

*Description of changes:*

Implement `Sign` for references of types that implement `Sign`.
@iliana is this what's needed?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
