### PR TITLE
do not pin tokio version in Cargo.toml

### DIFF
--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -21,7 +21,7 @@ rusoto_core = { version = "0.47", optional = true, default-features = false }
 rusoto_credential = { version = "0.47", optional = true }
 rusoto_kms = { version = "0.47", optional = true, default-features = false }
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
-tokio = "~1.8"  # LTS
+tokio = "1.8"
 pem = "1.0.2"
 
 [dev-dependencies]

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -22,4 +22,4 @@ rusoto_ssm = { version = "0.47", optional = true, default-features = false }
 serde = "1.0.125"
 serde_json = "1.0.63"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
-tokio = "~1.8"  # LTS
+tokio = "1.8"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I ran into some issues when attempting to update some Bottlerocket Rust dependencies (in the tools workspace). Generally speaking, we should not lock a dependency minor version in a library that is to be consumed by other projects. Doing so can cause unresolvable build issues if a customer's dependencies lock to a different minor version.

No versions were changed in Cargo.lock in this PR, we just changing Cargo.toml to allow cargo to do its thing when others are using the library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
