### PR TITLE
Update rusoto to 0.48.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,15 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,19 +644,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "ct-logs",
- "futures-util",
+ "http",
  "hyper",
  "log",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -1211,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4f000e8934c1b4f70adde180056812e7ea6b1a247952db8ee98c94cd3116cc"
+checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1237,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46b67db7bb66f5541e44db22b0a02fed59c9603e146db3a9e633272d3bac2f"
+checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1255,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_kms"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7892cd2cca7644d33bd6fafdb2236efd3659162fd7b73ca68d3877f0528399c"
+checksum = "3e1fc19cfcfd9f6b2f96e36d5b0dddda9004d2cbfc2d17543e3b9f10cc38fce8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1269,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_mock"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b3ad822f9ff58043dc81172a27f392e2f2aedebd8566c5f4bee4bfd2be021a"
+checksum = "5a384880f3c6d514e9499e6df75490bef5f6f39237bc24844e3933dfc09e9e55"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1284,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6264e93384b90a747758bcc82079711eacf2e755c3a8b5091687b5349d870bcc"
+checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
 dependencies = [
  "base64",
  "bytes",
@@ -1310,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_ssm"
-version = "0.47.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050304a18997ab01994d4a452472199088dc0376e61d1f50e2d9675227a0fe0c"
+checksum = "166034bb4835e1e6a7ac1cc659c9798e751cd75d7244f37beeaa12f2bbdda30b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1339,11 +1328,10 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
- "base64",
  "log",
  "ring",
  "sct",
@@ -1352,14 +1340,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.5.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1395,9 +1392,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1720,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
  "rustls",
  "tokio",
@@ -2058,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",

--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,7 @@ wildcards = "deny"
 
 skip-tree = [
     # rusoto_signature uses an older version of itoa
-    { name = "rusoto_signature", version = "0.47.0" },
+    { name = "rusoto_signature" },
 ]
 
 [sources]

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -17,9 +17,9 @@ rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_kms/rustls"]
 [dependencies]
 tough = { version = "0.12.0", path = "../tough", features = ["http"] }
 ring = { version = "0.16.16", features = ["std"] }
-rusoto_core = { version = "0.47", optional = true, default-features = false }
-rusoto_credential = { version = "0.47", optional = true }
-rusoto_kms = { version = "0.47", optional = true, default-features = false }
+rusoto_core = { version = "0.48", optional = true, default-features = false }
+rusoto_credential = { version = "0.48", optional = true }
+rusoto_kms = { version = "0.48", optional = true, default-features = false }
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 tokio = "1.8"
 pem = "1.0.2"
@@ -27,6 +27,6 @@ pem = "1.0.2"
 [dev-dependencies]
 base64 = "0.13"
 bytes = "1"
-rusoto_mock = { version = "0.47", default-features = false }
+rusoto_mock = { version = "0.48", default-features = false }
 serde = "1.0.125"
 serde_json = "1.0.63"

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -16,9 +16,9 @@ rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 
 [dependencies]
 tough = { version = "0.12.0", path = "../tough", features = ["http"] }
-rusoto_core = { version = "0.47", optional = true, default-features = false }
-rusoto_credential = { version = "0.47", optional = true }
-rusoto_ssm = { version = "0.47", optional = true, default-features = false }
+rusoto_core = { version = "0.48", optional = true, default-features = false }
+rusoto_credential = { version = "0.48", optional = true }
+rusoto_ssm = { version = "0.48", optional = true, default-features = false }
 serde = "1.0.125"
 serde_json = "1.0.63"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -25,10 +25,10 @@ pem = "1.0.2"
 rayon = "1.5"
 reqwest = { version = "0.11.1", features = ["blocking"] }
 ring = { version = "0.16.16", features = ["std"] }
-rusoto_core = { version = "0.47", optional = true, default-features = false }
-rusoto_credential = { version = "0.47", optional = true }
-rusoto_ssm = { version = "0.47", optional = true, default-features = false }
-rusoto_kms = { version = "0.47", optional = true, default-features = false }
+rusoto_core = { version = "0.48", optional = true, default-features = false }
+rusoto_credential = { version = "0.48", optional = true }
+rusoto_ssm = { version = "0.48", optional = true, default-features = false }
+rusoto_kms = { version = "0.48", optional = true, default-features = false }
 serde = "1.0.125"
 serde_json = "1.0.63"
 simplelog = "0.11"


### PR DESCRIPTION
**Description of changes:**

rusoto: **0.47.0 → [0.48.0](https://github.com/rusoto/rusoto/releases/tag/rusoto-v0.48.0)**

This PR combines #456, #457, #458, #459, and #460, into a single commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
