### PR TITLE
Prepare crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64",
  "bytes",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "rusoto_core",
  "rusoto_credential",
@@ -1835,7 +1835,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuftool"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/tough-kms/CHANGELOG.md
+++ b/tough-kms/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2022-04-26
+### Changes
+- Do not pin tokio version in Cargo.toml. [#451]
+- Fix clippy warnings. [#455]
+- Update dependencies.
+
+[#451]: https://github.com/awslabs/tough/pull/451
+[#455]: https://github.com/awslabs/tough/pull/455
+
 ## [0.3.5] - 2022-01-28
 ### Changes
 - Update dependencies.
@@ -68,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.6...develop
+[0.3.6]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.5...tough-kms-v0.3.6
 [0.3.5]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.4...tough-kms-v0.3.5
 [0.3.4]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.3...tough-kms-v0.3.4
 [0.3.3]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.2...tough-kms-v0.3.3

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-kms"
-version = "0.3.5"
+version = "0.3.6"
 description = "Implements AWS KMS as a key source for TUF signing keys"
 authors = ["Shailesh Gothi <gothisg@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rusoto-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_kms/
 rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_kms/rustls"]
 
 [dependencies]
-tough = { version = "0.12.0", path = "../tough", features = ["http"] }
+tough = { version = "0.12.2", path = "../tough", features = ["http"] }
 ring = { version = "0.16.16", features = ["std"] }
 rusoto_core = { version = "0.48", optional = true, default-features = false }
 rusoto_credential = { version = "0.48", optional = true }

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6] - 2022-04-26
+### Changes
+- Do not pin tokio version in Cargo.toml. [#451]
+- Update dependencies.
+
+[#451]: https://github.com/awslabs/tough/pull/451
+
 ## [0.6.5] - 2022-01-28
 ### Changes
 - Update dependencies.
@@ -77,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.6...develop
+[0.6.6]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.5...tough-ssm-v0.6.6
 [0.6.5]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.4...tough-ssm-v0.6.5
 [0.6.4]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.3...tough-ssm-v0.6.4
 [0.6.3]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.2...tough-ssm-v0.6.3

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.6.5"
+version = "0.6.6"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ rusoto-native-tls = ["rusoto_core/native-tls", "rusoto_credential", "rusoto_ssm/
 rusoto-rustls = ["rusoto_core/rustls", "rusoto_credential", "rusoto_ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.12.0", path = "../tough", features = ["http"] }
+tough = { version = "0.12.2", path = "../tough", features = ["http"] }
 rusoto_core = { version = "0.48", optional = true, default-features = false }
 rusoto_credential = { version = "0.48", optional = true }
 rusoto_ssm = { version = "0.48", optional = true, default-features = false }

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2022-04-26
+### Changes
+- Blanket impl sign for references [#448]
+- Fix clippy warnings [#455]
+- Various other dependency updates
+
+[#448]: https://github.com/awslabs/tough/pull/448
+[#455]: https://github.com/awslabs/tough/pull/455
+
 ## [0.12.1] - 2022-01-28
 ### Fixes
 - ECDSA keys now use the correct keytype name, thanks @flavio [#425]
@@ -12,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for hex-encoded ECDSA keys, thanks @flavio [#426]
 - Updated to snafu 0.7, thanks @shepmaster [#435]
 - Various other dependency updates
+
+[#425]: https://github.com/awslabs/tough/pull/425
+[#426]: https://github.com/awslabs/tough/pull/426
+[#435]: https://github.com/awslabs/tough/pull/435
 
 ## [0.12.0] - 2021-10-19
 ### Breaking Changes
@@ -96,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.0] - 2020-07-20
 ### Breaking Changes
 - The `HttpTransport` type and the `Read` and `Error` types that it uses have changed.
-- Remove `root.json` from Snapshot metadata per [theupdateframework/specification#40](https://github.com/theupdateframework/specification/pull/40) 
+- Remove `root.json` from Snapshot metadata per [theupdateframework/specification#40](https://github.com/theupdateframework/specification/pull/40)
 
 ### Added
 - Added HTTP retry logic.
@@ -167,7 +180,8 @@ For changes that require modification of calling code see #120 and #121.
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.12.1...HEAD
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.12.2...develop
+[0.12.2]: https://github.com/awslabs/tough/compare/tough-v0.12.1...tough-v0.12.2
 [0.12.1]: https://github.com/awslabs/tough/compare/tough-v0.12.0...tough-v0.12.1
 [0.12.0]: https://github.com/awslabs/tough/compare/tough-v0.11.3...tough-v0.12.0
 [0.11.3]: https://github.com/awslabs/tough/compare/tough-v0.11.2...tough-v0.11.3

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.12.1"
+version = "0.12.2"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2022-04-26
+### Changes
+- Fix clippy warnings. [#455]
+- Update dependencies.
+
+[#455]: https://github.com/awslabs/tough/pull/455
+
 ## [0.7.1] - 2022-01-28
 ### Changes
 - Dependency updates.
@@ -75,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `tough` dependency to 0.10.0.
 - Updated `tough-kms` dependency to 0.2.0 (which includes fix for [#263]).
-- Updated `tough-ssm` to 0.5.0. 
+- Updated `tough-ssm` to 0.5.0.
 - Other dependency updates.
 
 [#222]: https://github.com/awslabs/tough/pull/222
@@ -158,7 +165,8 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.7.1...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.7.2...develop
+[0.7.2]: https://github.com/awslabs/tough/compare/tuftool-v0.7.1...tuftool-v0.7.2
 [0.7.1]: https://github.com/awslabs/tough/compare/tuftool-v0.7.0...tuftool-v0.7.1
 [0.7.0]: https://github.com/awslabs/tough/compare/tuftool-v0.6.4...tuftool-v0.7.0
 [0.6.4]: https://github.com/awslabs/tough/compare/tuftool-v0.6.3...tuftool-v0.6.4

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.7.1"
+version = "0.7.2"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -36,9 +36,9 @@ snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 structopt = "0.3"
 tempfile = "3.3.0"
 tokio = "~1.8"  # LTS
-tough = { version = "0.12.1", path = "../tough", features = ["http"] }
-tough-ssm = { version = "0.6.5", path = "../tough-ssm" }
-tough-kms = { version = "0.3.5", path = "../tough-kms" }
+tough = { version = "0.12.2", path = "../tough", features = ["http"] }
+tough-ssm = { version = "0.6.6", path = "../tough-ssm" }
+tough-kms = { version = "0.3.6", path = "../tough-kms" }
 url = "2.1.0"
 walkdir = "2.3.2"
 


### PR DESCRIPTION
*Description of changes:*

Prepare to release:
- tough v0.12.2
- tuftool v0.7.2
- tough-ssm v0.6.6
- tough-kms v0.3.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
