### PR TITLE
feat: add workflow responsible for notifying of new TUF spec releases

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+    - cron: "0 13 * * *"
+  workflow_dispatch:
+name: Specification version check
+jobs:
+  # Get the latest TUF specification release and open an issue (if needed)
+  specification-bump-check:
+    permissions:
+      contents: read
+      issues: write
+    uses: theupdateframework/specification/.github/workflows/check-latest-spec-version.yml@master
+    with:
+      tuf-version: "v1.0.29" # Should be updated to the version the project supports either manually or extracted automatically. You can see how python-tuf did that as an example.


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

*Description of changes:*

The following PR adds a workflow that keeps track and creates an issue for notifying of new TUF specification releases.

The version (v1.0.29) of the spec which is currently used for the verification is added without verifying if this is indeed the version that the `tough` project is compliant with. In that sense, please advise which version to use and I'll update the PR accordingly.

**Note:** Dependent on - https://github.com/theupdateframework/specification/pull/224

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
