### PR TITLE
Update `crossbeam-utils` to `0.8.8`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated `crossbeam-utils` to `0.8.8` to silence dependabot warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
