### PR TITLE
Dependabot tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # For AWS SDK for Rust, ignore all (but one) updates
+      # - dependency-name: "aws-config"
+      - dependency-name: "aws-endpoint"
+      - dependency-name: "aws-http"
+      - dependency-name: "aws-hyper"
+      - dependency-name: "aws-sig*"
+      - dependency-name: "aws-sdk*"
+      - dependency-name: "aws-smithy*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,46 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: tokio
-    versions:
-    - 1.0.3
-    - 1.2.0
-    - 1.3.0
-  - dependency-name: reqwest
-    versions:
-    - 0.11.1
-    - 0.11.2
-  - dependency-name: serde
-    versions:
-    - 1.0.124
-  - dependency-name: hex
-    versions:
-    - 0.4.3
-  - dependency-name: serde_json
-    versions:
-    - 1.0.62
-    - 1.0.64
-  - dependency-name: url
-    versions:
-    - 2.2.1
-  - dependency-name: pem
-    versions:
-    - 0.8.3
-  - dependency-name: unicode-normalization
-    versions:
-    - 0.1.17
-  - dependency-name: ring
-    versions:
-    - 0.16.20
-  - dependency-name: log
-    versions:
-    - 0.4.14
-  - dependency-name: assert_cmd
-    versions:
-    - 1.0.3
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+      - '.github/dependabot.yml'
     branches: [develop]
 jobs:
   build:


### PR DESCRIPTION
**Description of changes:**

This is to make our dependabot configuration more consistent with some of our other projects by removing extraneous settings and ignored versions, keeping actions up to date, limiting `aws-sdk-rust` to a single notification, and skipping actions workflows for dependabot changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
