### PR TITLE
Get rid of RUSTSEC-2020-0071

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "ring",
- "time 0.3.13",
+ "time",
  "tracing",
 ]
 
@@ -381,7 +381,7 @@ dependencies = [
  "itoa",
  "num-integer",
  "ryu",
- "time 0.3.13",
+ "time",
 ]
 
 [[package]]
@@ -483,17 +483,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1094,7 +1091,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1680,7 +1677,7 @@ checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
  "log",
  "termcolor",
- "time 0.3.13",
+ "time",
 ]
 
 [[package]]
@@ -1828,17 +1825,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2213,12 +2199,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/deny.toml
+++ b/deny.toml
@@ -61,8 +61,6 @@ skip-tree = [
     { name = "h2", version = "0.3.11" }, 
     # aws sdk depends on hyper, which pulls in an older version of itoa
     { name = "hyper", version = "0.14.16" },
-    # chrono pulls in an older version of time
-    { name = "chrono", version = "0.4.19" },
     # structopt is using an older heck
     { name = "heck", version="0.3.3"},
 ]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["tuf", "update", "repository"]
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4.20", features = ["serde"] }
+chrono = { version = "0.4.22", default-features = false, features = ["std", "alloc", "serde", "clock"] }
 dyn-clone = "1.0.9"
 globset = { version = "0.4.9" }
 hex = "0.4.2"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -16,7 +16,7 @@ aws-sdk-rust-native-tls = ["aws-config/native-tls", "aws-sdk-ssm/native-tls", "a
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-ssm/rustls", "aws-sdk-kms/rustls",]
 
 [dependencies]
-chrono = "0.4.20"
+chrono = { version = "0.4.22", default-features = false, features = ["alloc", "std", "clock"] }
 hex = "0.4.2"
 log = "0.4.8"
 maplit = "1.0.1"


### PR DESCRIPTION
*Issue #, if available:* none avaialable


*Description of changes:*

The `cargo audit` tool used to report this codebase to be affected by the [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071) security issue.

The vulnerability is brought by the `chrono` crate. Luckily, it's possible to disable the vulnerable code by enabling only the `chrono` features that are actually needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
