### PR TITLE
Replace structopt with clap in tuftool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,15 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,17 +489,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -801,15 +816,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1213,6 +1219,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "output_vt100"
@@ -1700,7 +1712,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1724,33 +1736,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1794,12 +1782,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -2066,6 +2051,7 @@ dependencies = [
  "aws-sdk-kms",
  "aws-sdk-ssm",
  "chrono",
+ "clap",
  "hex",
  "httptest",
  "log",
@@ -2079,7 +2065,6 @@ dependencies = [
  "serde_json",
  "simplelog",
  "snafu",
- "structopt",
  "tempfile",
  "tokio",
  "tough",
@@ -2111,18 +2096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,12 +2123,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/deny.toml
+++ b/deny.toml
@@ -59,8 +59,6 @@ multiple-versions = "deny"
 wildcards = "deny"
 
 skip-tree = [
-    # structopt is using an older heck
-    { name = "structopt", version = "0.3.26" },
 ]
 
 [sources]

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -16,7 +16,11 @@ aws-sdk-rust-native-tls = ["aws-config/native-tls", "aws-sdk-ssm/native-tls", "a
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-ssm/rustls", "aws-sdk-kms/rustls",]
 
 [dependencies]
+aws-config = "0.48.0"
+aws-sdk-kms = "0.18.0"
+aws-sdk-ssm = "0.18.0"
 chrono = { version = "0.4.22", default-features = false, features = ["alloc", "std", "clock"] }
+clap = { version = "3.2.22", features = ["derive"] }
 hex = "0.4.2"
 log = "0.4.8"
 maplit = "1.0.1"
@@ -24,9 +28,6 @@ olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "1.0.2"
 rayon = "1.5"
 reqwest = { version = "0.11.1", features = ["blocking"] }
-aws-sdk-kms = "0.18.0"
-aws-sdk-ssm = "0.18.0"
-aws-config = "0.48.0"
 ring = { version = "0.16.16", features = ["std"] }
 serde = "1.0.144"
 serde_json = "1.0.85"
@@ -35,11 +36,10 @@ snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 tempfile = "3.3.0"
 tokio = "~1.18"  # LTS
 tough = { version = "0.12.4", path = "../tough", features = ["http"] }
-tough-ssm = { version = "0.7.1", path = "../tough-ssm" }
 tough-kms = { version = "0.4.1", path = "../tough-kms" }
+tough-ssm = { version = "0.7.1", path = "../tough-ssm" }
 url = "2.3.0"
 walkdir = "2.3.2"
-clap = { version = "3.2.22", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -32,7 +32,6 @@ serde = "1.0.144"
 serde_json = "1.0.85"
 simplelog = "0.12"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
-structopt = "0.3"
 tempfile = "3.3.0"
 tokio = "~1.18"  # LTS
 tough = { version = "0.12.4", path = "../tough", features = ["http"] }
@@ -40,6 +39,7 @@ tough-ssm = { version = "0.7.1", path = "../tough-ssm" }
 tough-kms = { version = "0.4.1", path = "../tough-kms" }
 url = "2.3.0"
 walkdir = "2.3.2"
+clap = { version = "3.2.22", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -6,48 +6,48 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct AddKeyArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// New keys to be used for role
-    #[structopt(long = "new-key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(long = "new-key", required = true, parse(try_from_str = parse_key_source))]
     new_keys: Vec<Box<dyn KeySource>>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of role file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// The role for the keys to be added to
-    #[structopt(long = "delegated-role")]
+    #[clap(long = "delegated-role")]
     delegated_role: Option<String>,
 }
 

--- a/tuftool/src/add_role.rs
+++ b/tuftool/src/add_role.rs
@@ -6,81 +6,81 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::{OptionExt, ResultExt};
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::{targets::TargetsEditor, RepositoryEditor};
 use tough::key_source::KeySource;
 use tough::schema::{PathHashPrefix, PathPattern, PathSet};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct AddRoleArgs {
     /// The role being delegated
-    #[structopt(short = "d", long = "delegated-role")]
+    #[clap(short = 'd', long = "delegated-role")]
     delegatee: String,
 
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of targets.json file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// Incoming metadata
-    #[structopt(short = "i", long = "incoming-metadata")]
+    #[clap(short = 'i', long = "incoming-metadata")]
     indir: Url,
 
     /// threshold of signatures to sign delegatee
-    #[structopt(short = "t", long = "threshold")]
+    #[clap(short = 't', long = "threshold")]
     threshold: NonZeroU64,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// The delegated paths
-    #[structopt(short = "p", long = "paths", conflicts_with = "path-hash-prefixes")]
+    #[clap(short = 'p', long = "paths", conflicts_with = "path-hash-prefixes")]
     paths: Option<Vec<PathPattern>>,
 
     /// The delegated paths hash prefixes
-    #[structopt(short = "hp", long = "path-hash-prefixes")]
+    #[clap(short = 'x', long = "path-hash-prefixes")]
     path_hash_prefixes: Option<Vec<PathHashPrefix>>,
 
     /// Determines if entire repo should be signed
-    #[structopt(long = "sign-all")]
+    #[clap(long = "sign-all")]
     sign_all: bool,
 
     /// Version of snapshot.json file
-    #[structopt(long = "snapshot-version")]
+    #[clap(long = "snapshot-version")]
     snapshot_version: Option<NonZeroU64>,
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
     snapshot_expires: Option<DateTime<Utc>>,
 
     /// Version of timestamp.json file
-    #[structopt(long = "timestamp-version")]
+    #[clap(long = "timestamp-version")]
     timestamp_version: Option<NonZeroU64>,
 
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
     timestamp_expires: Option<DateTime<Utc>>,
 }
 

--- a/tuftool/src/clone.rs
+++ b/tuftool/src/clone.rs
@@ -4,58 +4,58 @@
 use crate::common::UNUSED_URL;
 use crate::download_root::download_root;
 use crate::error::{self, Result};
+use clap::Parser;
 use snafu::ResultExt;
 use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct CloneArgs {
     /// Path to root.json file for the repository
-    #[structopt(
-        short = "r",
+    #[clap(
+        short = 'r',
         long = "root",
         required_if("allow-root-download", "false")
     )]
     root: Option<PathBuf>,
 
     /// Remote root.json version number
-    #[structopt(short = "v", long = "root-version", default_value = "1")]
+    #[clap(short = 'v', long = "root-version", default_value = "1")]
     root_version: NonZeroU64,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// TUF repository targets base URL
-    #[structopt(short = "t", long = "targets-url", required_unless = "metadata-only")]
+    #[clap(short = 't', long = "targets-url", required_unless = "metadata-only")]
     targets_base_url: Option<Url>,
 
     /// Allow downloading the root.json file (unsafe)
-    #[structopt(long)]
+    #[clap(long)]
     allow_root_download: bool,
 
     /// Allow repo download for expired metadata (unsafe)
-    #[structopt(long)]
+    #[clap(long)]
     allow_expired_repo: bool,
 
     /// Download only these targets, if specified
-    #[structopt(short = "n", long = "target-names", conflicts_with = "metadata-only")]
+    #[clap(short = 'n', long = "target-names", conflicts_with = "metadata-only")]
     target_names: Vec<String>,
 
     /// Output directory of targets
-    #[structopt(long, required_unless = "metadata-only")]
+    #[clap(long, required_unless = "metadata-only")]
     targets_dir: Option<PathBuf>,
 
     /// Output directory of metadata
-    #[structopt(long)]
+    #[clap(long)]
     metadata_dir: PathBuf,
 
     /// Only download the repository metadata, not the targets
-    #[structopt(long, conflicts_with_all(&["target-names", "targets-dir", "targets-base-url"]))]
+    #[clap(long, conflicts_with_all(&["target-names", "targets-dir", "targets-base-url"]))]
     metadata_only: bool,
 }
 
@@ -80,7 +80,7 @@ impl CloneArgs {
             std::process::exit(1);
         };
 
-        // Structopt won't allow `targets_base_url` to be None when it is required.  We require the
+        // Clap won't allow `targets_base_url` to be None when it is required.  We require the
         // user to supply `targets_base_url` in the case they actually plan to download targets.
         // When downloading metadata, we don't ever need to access the targets URL, so we use a
         // fake URL to satisfy the library.

--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -6,60 +6,60 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::signed::PathExists;
 use tough::editor::RepositoryEditor;
 use tough::key_source::KeySource;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct CreateArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Version of snapshot.json file
-    #[structopt(long = "snapshot-version")]
+    #[clap(long = "snapshot-version")]
     snapshot_version: NonZeroU64,
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
     snapshot_expires: DateTime<Utc>,
 
     /// Version of targets.json file
-    #[structopt(long = "targets-version")]
+    #[clap(long = "targets-version")]
     targets_version: NonZeroU64,
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "targets-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "targets-expires", parse(try_from_str = parse_datetime))]
     targets_expires: DateTime<Utc>,
 
     /// Version of timestamp.json file
-    #[structopt(long = "timestamp-version")]
+    #[clap(long = "timestamp-version")]
     timestamp_version: NonZeroU64,
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
     timestamp_expires: DateTime<Utc>,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// Directory of targets
-    #[structopt(short = "t", long = "add-targets")]
+    #[clap(short = 't', long = "add-targets")]
     targets_indir: PathBuf,
 
     /// Behavior when a target exists with the same name and hash in the targets directory,
     /// for example from another repository when they share a targets directory.
     /// Options are "replace", "fail", and "skip"
-    #[structopt(long = "target-path-exists", default_value = "skip")]
+    #[clap(long = "target-path-exists", default_value = "skip")]
     target_path_exists: PathExists,
 
     /// Follow symbolic links in the given directory when adding targets
-    #[structopt(short = "f", long = "follow")]
+    #[clap(short = 'f', long = "follow")]
     follow: bool,
 
     /// Number of target hashing threads to run when adding targets
@@ -67,11 +67,11 @@ pub(crate) struct CreateArgs {
     // No default is specified in structopt here. This is because rayon
     // automatically spawns the same number of threads as cores when any
     // of its parallel methods are called.
-    #[structopt(short = "j", long = "jobs")]
+    #[clap(short = 'j', long = "jobs")]
     jobs: Option<NonZeroUsize>,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 }
 

--- a/tuftool/src/create_role.rs
+++ b/tuftool/src/create_role.rs
@@ -5,34 +5,34 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
 use tough::schema::decoded::Decoded;
 use tough::schema::decoded::Hex;
 use tough::schema::key::Key;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct CreateRoleArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", required = true, parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", required = true, parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of targets.json file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 }
 

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -3,45 +3,45 @@
 
 use crate::download_root::download_root;
 use crate::error::{self, Result};
+use clap::Parser;
 use snafu::{ensure, ResultExt};
 use std::fs::File;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use tough::{ExpirationEnforcement, Prefix, Repository, RepositoryLoader, TargetName};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct DownloadArgs {
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: Option<PathBuf>,
 
     /// Remote root.json version number
-    #[structopt(short = "v", long = "root-version", default_value = "1")]
+    #[clap(short = 'v', long = "root-version", default_value = "1")]
     root_version: NonZeroU64,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// TUF repository targets base URL
-    #[structopt(short = "t", long = "targets-url")]
+    #[clap(short = 't', long = "targets-url")]
     targets_base_url: Url,
 
     /// Allow downloading the root.json file (unsafe)
-    #[structopt(long)]
+    #[clap(long)]
     allow_root_download: bool,
 
     /// Download only these targets, if specified
-    #[structopt(short = "n", long = "target-name")]
+    #[clap(short = 'n', long = "target-name")]
     target_names: Vec<String>,
 
     /// Output directory for targets (will be created and must not already exist)
     outdir: PathBuf,
 
     /// Allow repo download for expired metadata
-    #[structopt(long)]
+    #[clap(long)]
     allow_expired_repo: bool,
 }
 

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -29,6 +29,7 @@ mod update;
 mod update_targets;
 
 use crate::error::Result;
+use clap::Parser;
 use rayon::prelude::*;
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 use snafu::{ErrorCompat, OptionExt, ResultExt};
@@ -36,7 +37,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
-use structopt::StructOpt;
 use tempfile::NamedTempFile;
 use tough::schema::Target;
 use tough::TargetName;
@@ -45,17 +45,17 @@ use walkdir::WalkDir;
 static SPEC_VERSION: &str = "1.0.0";
 
 /// This wrapper enables global options and initializes the logger before running any subcommands.
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Program {
     /// Set logging verbosity [trace|debug|info|warn|error]
-    #[structopt(
+    #[clap(
         name = "log-level",
-        short = "l",
+        short = 'l',
         long = "log-level",
         default_value = "info"
     )]
     log_level: LevelFilter,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Command,
 }
 
@@ -75,7 +75,7 @@ impl Program {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Command {
     /// Create a TUF repository
     Create(create::CreateArgs),
@@ -84,6 +84,7 @@ enum Command {
     /// Update a TUF repository's metadata and optionally add targets
     Update(Box<update::UpdateArgs>),
     /// Manipulate a root.json metadata file
+    #[clap(subcommand)]
     Root(root::Command),
     /// Delegation Commands
     Delegation(Delegation),
@@ -187,13 +188,13 @@ fn main() -> ! {
     })
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 struct Delegation {
     /// The signing role
-    #[structopt(long = "signing-role", required = true)]
+    #[clap(long = "signing-role", required = true)]
     role: String,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: DelegationCommand,
 }
 
@@ -203,7 +204,7 @@ impl Delegation {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum DelegationCommand {
     /// Creates a delegated role
     CreateRole(Box<create_role::CreateRoleArgs>),

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -6,48 +6,48 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
 use tough::schema::decoded::{Decoded, Hex};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct RemoveKeyArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Key to be removed will look similar to `8ec3a843a0f9328c863cac4046ab1cacbbc67888476ac7acf73d9bcd9a223ada`
-    #[structopt(long = "keyid", required = true)]
+    #[clap(long = "keyid", required = true)]
     remove: Decoded<Hex>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of role file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// The role for the keys to be added to
-    #[structopt(long = "delegated-role")]
+    #[clap(long = "delegated-role")]
     delegated_role: Option<String>,
 }
 

--- a/tuftool/src/remove_role.rs
+++ b/tuftool/src/remove_role.rs
@@ -6,47 +6,47 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct RemoveRoleArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of role file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// The role to be removed
-    #[structopt(long = "delegated-role")]
+    #[clap(long = "delegated-role")]
     delegated_role: String,
 
     /// Determine if the role should be removed even if it's not a direct delegatee
-    #[structopt(long = "recursive")]
+    #[clap(long = "recursive")]
     recursive: bool,
 }
 

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -6,6 +6,7 @@ use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use crate::{load_file, write_file};
 use chrono::{DateTime, Timelike, Utc};
+use clap::Parser;
 use log::warn;
 use maplit::hashmap;
 use ring::rand::SystemRandom;
@@ -14,7 +15,6 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use tempfile::NamedTempFile;
 use tough::editor::signed::SignedRole;
 use tough::key_source::KeySource;
@@ -22,7 +22,7 @@ use tough::schema::decoded::{Decoded, Hex};
 use tough::schema::{key::Key, KeyHolder, RoleKeys, RoleType, Root, Signed};
 use tough::sign::{parse_keypair, Sign};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) enum Command {
     /// Create a new root.json metadata file
     Init {
@@ -40,7 +40,7 @@ pub(crate) enum Command {
         path: PathBuf,
         /// Expiration of root; can be in full RFC 3339 format, or something like 'in
         /// 7 days'
-        #[structopt(parse(try_from_str = parse_datetime))]
+        #[clap(parse(try_from_str = parse_datetime))]
         time: DateTime<Utc>,
     },
     /// Set the signature count threshold for a role
@@ -64,10 +64,10 @@ pub(crate) enum Command {
         /// Path to root.json
         path: PathBuf,
         /// The new key
-        #[structopt(parse(try_from_str = parse_key_source))]
+        #[clap(parse(try_from_str = parse_key_source))]
         key_source: Box<dyn KeySource>,
         /// The role to add the key to
-        #[structopt(short = "r", long = "role")]
+        #[clap(short = 'r', long = "role")]
         roles: Vec<RoleType>,
     },
     /// Remove a key ID, either entirely or from a single role
@@ -85,16 +85,16 @@ pub(crate) enum Command {
         /// Path to root.json
         path: PathBuf,
         /// Where to write the new key
-        #[structopt(parse(try_from_str = parse_key_source))]
+        #[clap(parse(try_from_str = parse_key_source))]
         key_source: Box<dyn KeySource>,
         /// Bit length of new key
-        #[structopt(short = "b", long = "bits", default_value = "2048")]
+        #[clap(short = 'b', long = "bits", default_value = "2048")]
         bits: u16,
         /// Public exponent of new key
-        #[structopt(short = "e", long = "exp", default_value = "65537")]
+        #[clap(short = 'e', long = "exp", default_value = "65537")]
         exponent: u32,
         /// The role to add the key to
-        #[structopt(short = "r", long = "role")]
+        #[clap(short = 'r', long = "role")]
         roles: Vec<RoleType>,
     },
     /// Sign the given root.json
@@ -102,13 +102,13 @@ pub(crate) enum Command {
         /// Path to root.json
         path: PathBuf,
         ///Key source(s) to sign the file with
-        #[structopt(short = "k", long = "key",parse(try_from_str = parse_key_source))]
+        #[clap(short = 'k', long = "key",parse(try_from_str = parse_key_source))]
         key_sources: Vec<Box<dyn KeySource>>,
         ///Optional - Path of older root.json that contains the key-id
-        #[structopt(short = "c", long = "cross-sign")]
+        #[clap(short = 'c', long = "cross-sign")]
         cross_sign: Option<PathBuf>,
         ///Ignore the threshold when signing with fewer keys
-        #[structopt(short = "i", long = "ignore-threshold")]
+        #[clap(short = 'i', long = "ignore-threshold")]
         ignore_threshold: bool,
     },
 }

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -7,67 +7,67 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::{OptionExt, ResultExt};
 use std::fs::File;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
-use structopt::StructOpt;
 use tough::editor::signed::PathExists;
 use tough::editor::RepositoryEditor;
 use tough::key_source::KeySource;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct UpdateArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Version of snapshot.json file
-    #[structopt(long = "snapshot-version")]
+    #[clap(long = "snapshot-version")]
     snapshot_version: NonZeroU64,
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
     snapshot_expires: DateTime<Utc>,
 
     /// Version of targets.json file
-    #[structopt(long = "targets-version")]
+    #[clap(long = "targets-version")]
     targets_version: NonZeroU64,
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "targets-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "targets-expires", parse(try_from_str = parse_datetime))]
     targets_expires: DateTime<Utc>,
 
     /// Version of timestamp.json file
-    #[structopt(long = "timestamp-version")]
+    #[clap(long = "timestamp-version")]
     timestamp_version: NonZeroU64,
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
+    #[clap(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
     timestamp_expires: DateTime<Utc>,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// Directory of targets
-    #[structopt(short = "t", long = "add-targets")]
+    #[clap(short = 't', long = "add-targets")]
     targets_indir: Option<PathBuf>,
 
     /// Behavior when a target exists with the same name and hash in the desired repository
     /// directory, for example from another repository when you're sharing target directories.
     /// Options are "replace", "fail", and "skip"
-    #[structopt(long = "target-path-exists", default_value = "skip")]
+    #[clap(long = "target-path-exists", default_value = "skip")]
     target_path_exists: PathExists,
 
     /// Follow symbolic links in the given directory when adding targets
-    #[structopt(short = "f", long = "follow")]
+    #[clap(short = 'f', long = "follow")]
     follow: bool,
 
     /// Number of target hashing threads to run when adding targets
@@ -75,23 +75,23 @@ pub(crate) struct UpdateArgs {
     // No default is specified in structopt here. This is because rayon
     // automatically spawns the same number of threads as cores when any
     // of its parallel methods are called.
-    #[structopt(short = "j", long = "jobs")]
+    #[clap(short = 'j', long = "jobs")]
     jobs: Option<NonZeroUsize>,
 
     /// The directory where the updated repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// Incoming metadata from delegatee
-    #[structopt(short = "i", long = "incoming-metadata")]
+    #[clap(short = 'i', long = "incoming-metadata")]
     indir: Option<Url>,
 
     /// Role of incoming metadata
-    #[structopt(long = "role")]
+    #[clap(long = "role")]
     role: Option<String>,
 
     /// Allow repo download for expired metadata
-    #[structopt(long)]
+    #[clap(long)]
     allow_expired_repo: bool,
 }
 

--- a/tuftool/src/update_targets.rs
+++ b/tuftool/src/update_targets.rs
@@ -7,49 +7,49 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use chrono::{DateTime, Utc};
+use clap::Parser;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use tough::editor::signed::PathExists;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub(crate) struct UpdateTargetsArgs {
     /// Key files to sign with
-    #[structopt(short = "k", long = "key", required = true, parse(try_from_str = parse_key_source))]
+    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
     keys: Vec<Box<dyn KeySource>>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[structopt(short = "e", long = "expires", parse(try_from_str = parse_datetime))]
+    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
     expires: DateTime<Utc>,
 
     /// Version of targets.json file
-    #[structopt(short = "v", long = "version")]
+    #[clap(short = 'v', long = "version")]
     version: NonZeroU64,
 
     /// Path to root.json file for the repository
-    #[structopt(short = "r", long = "root")]
+    #[clap(short = 'r', long = "root")]
     root: PathBuf,
 
     /// TUF repository metadata base URL
-    #[structopt(short = "m", long = "metadata-url")]
+    #[clap(short = 'm', long = "metadata-url")]
     metadata_base_url: Url,
 
     /// Directory of targets
-    #[structopt(short = "t", long = "add-targets")]
+    #[clap(short = 't', long = "add-targets")]
     targets_indir: Option<PathBuf>,
 
     /// The directory where the repository will be written
-    #[structopt(short = "o", long = "outdir")]
+    #[clap(short = 'o', long = "outdir")]
     outdir: PathBuf,
 
     /// Follow symbolic links in the given directory when adding targets
-    #[structopt(short = "f", long = "follow")]
+    #[clap(short = 'f', long = "follow")]
     follow: bool,
 
     /// Number of target hashing threads to run when adding targets
@@ -57,13 +57,13 @@ pub(crate) struct UpdateTargetsArgs {
     // No default is specified in structopt here. This is because rayon
     // automatically spawns the same number of threads as cores when any
     // of its parallel methods are called.
-    #[structopt(short = "j", long = "jobs")]
+    #[clap(short = 'j', long = "jobs")]
     jobs: Option<NonZeroUsize>,
 
     /// Behavior when a target exists with the same name and hash in the desired repository
     /// directory, for example from another repository when you're sharing target directories.
     /// Options are "replace", "fail", and "skip"
-    #[structopt(long = "target-path-exists", default_value = "skip")]
+    #[clap(long = "target-path-exists", default_value = "skip")]
     target_path_exists: PathExists,
 }
 


### PR DESCRIPTION
*Description of changes:*

`structopt` has been superseded by `clap`, which is more or less a drop-in replacement.

The only functional change is that the short arg for delegated **path-hash-prefixes** (previously 'hp') is now 'x'.

*Testing done:*

Downloaded a Bottlerocket OVA with `tuftool`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
