### PR TITLE
Prepare crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "olpc-cjson"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aws-config",
  "aws-sdk-ssm",
@@ -2044,7 +2044,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tuftool"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "assert_cmd",
  "aws-config",

--- a/olpc-cjson/CHANGELOG.md
+++ b/olpc-cjson/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2022-10-03
+### Changed
+- Update dependencies.  [#491], [#502], [#514]
+- Fix clippy warnings.  [#455]
+
+[#455]: https://github.com/awslabs/tough/pull/455
+[#491]: https://github.com/awslabs/tough/pull/491
+[#502]: https://github.com/awslabs/tough/pull/502
+[#514]: https://github.com/awslabs/tough/pull/514
+
 ## [0.1.1] - 2021-07-30
 ### Changed
 - Update dependencies.  [#55], [#60], [#88], [#115], [#231], [#241], [#284], [#357], [#398]
@@ -29,5 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
+[Unreleased]: https://github.com/awslabs/tough/compare/olpc-cjson-v0.1.2...develop
+[0.1.2]: https://github.com/awslabs/tough/compare/olpc-cjson-v0.1.1...olpc-cjson-v0.1.2
 [0.1.1]: https://github.com/awslabs/tough/compare/olpc-cjson-v0.1.0...olpc-cjson-v0.1.1
 [0.1.0]: https://github.com/awslabs/tough/releases/tag/olpc-cjson-v0.1.0

--- a/olpc-cjson/Cargo.toml
+++ b/olpc-cjson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olpc-cjson"
-version = "0.1.1"
+version = "0.1.2"
 description = "serde_json Formatter to serialize as OLPC-style canonical JSON"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tough-kms/CHANGELOG.md
+++ b/tough-kms/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2022-10-03
+### Changes
+- Update dependencies [#501], [#502], [#514]
+
+[#501]: https://github.com/awslabs/tough/pull/501
+[#502]: https://github.com/awslabs/tough/pull/502
+[#514]: https://github.com/awslabs/tough/pull/514
+
 ## [0.4.1] - 2022-08-12
 ### Changes
 - Update dependencies
@@ -88,7 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-kms-v0.4.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-kms-v0.4.2...develop
+[0.4.2]: https://github.com/awslabs/tough/compare/tough-kms-v0.4.1...tough-kms-v0.4.2
+[0.4.1]: https://github.com/awslabs/tough/compare/tough-kms-v0.4.0...tough-kms-v0.4.1
 [0.4.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.6...tough-kms-v0.4.0
 [0.3.6]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.5...tough-kms-v0.3.6
 [0.3.5]: https://github.com/awslabs/tough/compare/tough-kms-v0.3.4...tough-kms-v0.3.5

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-kms"
-version = "0.4.1"
+version = "0.4.2"
 description = "Implements AWS KMS as a key source for TUF signing keys"
 authors = ["Shailesh Gothi <gothisg@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ aws-sdk-rust-tls = ["aws-config/native-tls", "aws-sdk-kms/native-tls"]
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-kms/rustls"]
 
 [dependencies]
-tough = { version = "0.12.4", path = "../tough", features = ["http"] }
+tough = { version = "0.12.5", path = "../tough", features = ["http"] }
 ring = { version = "0.16.16", features = ["std"] }
 aws-sdk-kms = "0.18.0"
 aws-config = "0.48.0"

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2022-10-03
+### Changes
+- Update dependencies [#501], [#502], [#514]
+
+[#501]: https://github.com/awslabs/tough/pull/501
+[#502]: https://github.com/awslabs/tough/pull/502
+[#514]: https://github.com/awslabs/tough/pull/514
+
 ## [0.7.1] - 2022-08-12
 ### Changes
 - Update dependencies
@@ -95,7 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-ssm-v0.7.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-ssm-v0.7.2...develop
+[0.7.2]: https://github.com/awslabs/tough/compare/tough-ssm-v0.7.1...tough-ssm-v0.7.2
+[0.7.1]: https://github.com/awslabs/tough/compare/tough-ssm-v0.7.0...tough-ssm-v0.7.1
 [0.7.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.6...tough-ssm-v0.7.0
 [0.6.6]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.5...tough-ssm-v0.6.6
 [0.6.5]: https://github.com/awslabs/tough/compare/tough-ssm-v0.6.4...tough-ssm-v0.6.5

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.7.1"
+version = "0.7.2"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ aws-sdk-rust-tls = ["aws-config/native-tls", "aws-sdk-ssm/native-tls"]
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.12.4", path = "../tough", features = ["http"] }
+tough = { version = "0.12.5", path = "../tough", features = ["http"] }
 aws-sdk-ssm = "0.18.0"
 aws-config = "0.48.0"
 serde = "1.0.144"

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.5] - 2022-10-03
+### Security Fixes
+- Update `chrono` and enable only necessary features to address RUSTSEC-2020-0071, thanks @flavio [#506]
+
+### Changes
+- Various dependency updates [#501], [#502], [#503], [#508], [#509], [#514]
+
+[#501]: https://github.com/awslabs/tough/pull/501
+[#502]: https://github.com/awslabs/tough/pull/502
+[#503]: https://github.com/awslabs/tough/pull/503
+[#506]: https://github.com/awslabs/tough/pull/506
+[#508]: https://github.com/awslabs/tough/pull/508
+[#509]: https://github.com/awslabs/tough/pull/509
+[#514]: https://github.com/awslabs/tough/pull/514
+
 ## [0.12.4] - 2022-08-12
 ### Changes
 - Various dependency updates
@@ -187,7 +202,9 @@ For changes that require modification of calling code see #120 and #121.
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.12.3...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.12.5...develop
+[0.12.5]: https://github.com/awslabs/tough/compare/tough-v0.12.4...tough-v0.12.5
+[0.12.4]: https://github.com/awslabs/tough/compare/tough-v0.12.3...tough-v0.12.4
 [0.12.3]: https://github.com/awslabs/tough/compare/tough-v0.12.2...tough-v0.12.3
 [0.12.2]: https://github.com/awslabs/tough/compare/tough-v0.12.1...tough-v0.12.2
 [0.12.1]: https://github.com/awslabs/tough/compare/tough-v0.12.0...tough-v0.12.1

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.12.4"
+version = "0.12.5"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ dyn-clone = "1.0.9"
 globset = { version = "0.4.9" }
 hex = "0.4.2"
 log = "0.4.8"
-olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
+olpc-cjson = { version = "0.1.2", path = "../olpc-cjson" }
 path-absolutize = "3"
 pem = "1.0.2"
 percent-encoding = "2"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2022-10-03
+### Security Fixes
+- Update `chrono` and enable only necessary features to address RUSTSEC-2020-0071, thanks @flavio [#506]
+
+### Changes
+- Various dependency updates [#501], [#502], [#503], [#508], [#514]
+
+[#501]: https://github.com/awslabs/tough/pull/501
+[#502]: https://github.com/awslabs/tough/pull/502
+[#503]: https://github.com/awslabs/tough/pull/503
+[#506]: https://github.com/awslabs/tough/pull/506
+[#508]: https://github.com/awslabs/tough/pull/508
+[#514]: https://github.com/awslabs/tough/pull/514
+
 ## [0.8.1] - 2022-08-12
 ### Changes
 - Update dependencies
@@ -176,7 +190,9 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.8.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.8.2...develop
+[0.8.2]: https://github.com/awslabs/tough/compare/tuftool-v0.8.1...tuftool-v0.8.2
+[0.8.1]: https://github.com/awslabs/tough/compare/tuftool-v0.8.0...tuftool-v0.8.1
 [0.8.0]: https://github.com/awslabs/tough/compare/tuftool-v0.7.2...tuftool-v0.8.0
 [0.7.2]: https://github.com/awslabs/tough/compare/tuftool-v0.7.1...tuftool-v0.7.2
 [0.7.1]: https://github.com/awslabs/tough/compare/tuftool-v0.7.0...tuftool-v0.7.1

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.8.1"
+version = "0.8.2"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -35,9 +35,9 @@ simplelog = "0.12"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 tempfile = "3.3.0"
 tokio = "~1.18"  # LTS
-tough = { version = "0.12.4", path = "../tough", features = ["http"] }
-tough-kms = { version = "0.4.1", path = "../tough-kms" }
-tough-ssm = { version = "0.7.1", path = "../tough-ssm" }
+tough = { version = "0.12.5", path = "../tough", features = ["http"] }
+tough-kms = { version = "0.4.2", path = "../tough-kms" }
+tough-ssm = { version = "0.7.2", path = "../tough-ssm" }
 url = "2.3.0"
 walkdir = "2.3.2"
 


### PR DESCRIPTION
*Description of changes:*

Prepare to release:
- olpc-cjson v0.1.2
- tough v0.12.5
- tuftool v0.8.2
- tough-ssm v0.7.2
- tough-kms v0.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
