### PR TITLE
Format workflow and pin rust toolchain 1.64.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,8 +2,8 @@ name: Rust
 on:
   pull_request:
     paths-ignore:
-      - '**.md'
-      - '.github/dependabot.yml'
+      - "**.md"
+      - ".github/dependabot.yml"
     branches: [develop]
 jobs:
   build:
@@ -12,15 +12,17 @@ jobs:
         make_target: ["check-licenses", "build", "integ"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
-      with:
-        path: |
-          .cargo
-          target
-        # you can edit the .github/cache_bust file if you need to clear the cache
-        key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-
-    - run: rustup update stable
-    - run: make ${{ matrix.make_target }}
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .cargo
+            target
+          # you can edit the .github/cache_bust file if you need to clear the cache
+          key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-
+      - run: rustup default 1.64.0
+      - run: rustup component add rustfmt
+      - run: rustup component add clippy
+      - run: make ${{ matrix.make_target }}

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -26,8 +26,7 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::missing_errors_doc,
-    clippy::result_large_err
+    clippy::missing_errors_doc
 )]
 
 mod cache;

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -9,7 +9,6 @@
     clippy::use_self,
     // Caused by interacting with tough::schema::*._extra
     clippy::used_underscore_binding,
-    clippy::result_large_err,
 )]
 
 mod add_key_role;


### PR DESCRIPTION
**Description of changes:**

This commit pins a specific rust toolchain (1.64.0).

The yaml was also ran through a formatter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
