### PR TITLE
Bump rust to 1.66.1 and cargo-deny to 0.13.5 in actions runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-
-      - run: rustup default 1.64.0
+      - run: rustup default 1.66.1
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: make ${{ matrix.make_target }}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ci: check-licenses build integ
 # installs cargo-deny
 .PHONY: cargo-deny
 cargo-deny:
-	cargo install --version 0.12.2 cargo-deny --locked
+	cargo install --version 0.13.5 cargo-deny --locked
 
 # checks each crate, and evaluates licenses. requires cargo-deny.
 .PHONY: check-licenses

--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -129,7 +129,7 @@ impl Repository {
         P: AsRef<Path>,
     {
         for ver in (1..=self.root.signed.version.get()).rev() {
-            let root_json_filename = format!("{}.root.json", ver);
+            let root_json_filename = format!("{ver}.root.json");
             self.cache_file_from_transport(
                 root_json_filename.as_str(),
                 self.limits.max_root_size,
@@ -166,7 +166,7 @@ impl Repository {
                 self.snapshot
                     .signed
                     .meta
-                    .get(&format!("{}.json", name))?
+                    .get(&format!("{name}.json"))?
                     .version,
                 encode_filename(name)
             ))

--- a/tough/src/datastore.rs
+++ b/tough/src/datastore.rs
@@ -52,7 +52,7 @@ impl Datastore {
             value,
         )
         .context(error::DatastoreSerializeSnafu {
-            what: format!("{} in datastore", file),
+            what: format!("{file} in datastore"),
             path,
         })
     }

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -513,7 +513,7 @@ impl RepositoryEditor {
         let metadata_base_url = parse_url(metadata_url)?;
         // path to updated metadata
         let encoded_name = encode_filename(name);
-        let encoded_filename = format!("{}.json", encoded_name);
+        let encoded_filename = format!("{encoded_name}.json");
         let role_url = metadata_base_url
             .join(&encoded_filename)
             .with_context(|_| error::JoinUrlEncodedSnafu {
@@ -578,7 +578,7 @@ impl RepositoryEditor {
         for name in new_roles {
             // path to new metadata
             let encoded_name = encode_filename(&name);
-            let encoded_filename = format!("{}.json", encoded_name);
+            let encoded_filename = format!("{encoded_name}.json");
             let role_url = metadata_base_url
                 .join(&encoded_filename)
                 .with_context(|_| error::JoinUrlEncodedSnafu {

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -400,7 +400,7 @@ impl TargetsEditor {
         let metadata_base_url = parse_url(metadata_url)?;
         // path to updated metadata
         let encoded_name = encode_filename(name);
-        let encoded_filename = format!("{}.json", encoded_name);
+        let encoded_filename = format!("{encoded_name}.json");
         let role_url = metadata_base_url
             .join(&encoded_filename)
             .with_context(|_| error::JoinUrlEncodedSnafu {

--- a/tough/src/editor/test.rs
+++ b/tough/src/editor/test.rs
@@ -53,7 +53,7 @@ mod tests {
         let key_source = LocalKeySource { path: root_key };
         let root_path = root_path();
 
-        let editor = RepositoryEditor::new(&root_path).unwrap();
+        let editor = RepositoryEditor::new(root_path).unwrap();
         assert!(editor.sign(&[Box::new(key_source)]).is_err());
     }
 
@@ -71,7 +71,7 @@ mod tests {
         let target4 = Target::from_path(target2_path).unwrap();
         let root_path = tuf_root_path();
 
-        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        let mut editor = RepositoryEditor::new(root_path).unwrap();
         editor
             .targets(targets)
             .unwrap()
@@ -91,7 +91,7 @@ mod tests {
         let target3 = targets_path().join("file3.txt");
         let root_path = tuf_root_path();
 
-        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        let mut editor = RepositoryEditor::new(root_path).unwrap();
         editor
             .targets(targets)
             .unwrap()
@@ -118,7 +118,7 @@ mod tests {
         let target3 = targets_path().join("file3.txt");
         let target_list = vec![target1, target2, target3];
 
-        let mut editor = RepositoryEditor::new(&root).unwrap();
+        let mut editor = RepositoryEditor::new(root).unwrap();
         editor
             .targets_expires(targets_expiration)
             .unwrap()
@@ -150,7 +150,7 @@ mod tests {
         .unwrap();
         let root_path = tuf_root_path();
 
-        let mut editor = RepositoryEditor::new(&root_path).unwrap();
+        let mut editor = RepositoryEditor::new(root_path).unwrap();
         editor
             .targets(targets)
             .unwrap()

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -389,7 +389,7 @@ fn build_request(client: &Client, next_byte: usize, url: &Url) -> Result<Request
             .context(RequestBuildSnafu)?;
         Ok(request)
     } else {
-        let header_value_string = format!("bytes={}-", next_byte);
+        let header_value_string = format!("bytes={next_byte}-");
         let header_value =
             HeaderValue::from_str(header_value_string.as_str()).context(InvalidHeaderSnafu {
                 header_value: &header_value_string,

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -26,7 +26,8 @@
 #![allow(
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::missing_errors_doc
+    clippy::missing_errors_doc,
+    clippy::result_large_err
 )]
 
 mod cache;

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -978,7 +978,7 @@ impl<'de> Deserialize<'de> for PathPattern {
         D: Deserializer<'de>,
     {
         let s = <String>::deserialize(deserializer)?;
-        PathPattern::new(s).map_err(|e| D::Error::custom(format!("{}", e)))
+        PathPattern::new(s).map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 
@@ -1194,7 +1194,7 @@ fn targets_iter_and_map_test() {
         terminating: false,
         targets: Some(Signed {
             signed: Targets {
-                spec_version: "".to_string(),
+                spec_version: String::new(),
                 version: NonZeroU64::new(1).unwrap(),
                 expires: Utc::now(),
                 targets: hashmap! {
@@ -1218,7 +1218,7 @@ fn targets_iter_and_map_test() {
         terminating: false,
         targets: Some(Signed {
             signed: Targets {
-                spec_version: "".to_string(),
+                spec_version: String::new(),
                 version: NonZeroU64::new(1).unwrap(),
                 expires: Utc::now(),
                 targets: hashmap! {
@@ -1235,7 +1235,7 @@ fn targets_iter_and_map_test() {
         roles: vec![b_role],
     };
     let a = Targets {
-        spec_version: "".to_string(),
+        spec_version: String::new(),
         version: NonZeroU64::new(1).unwrap(),
         expires: Utc::now(),
         targets: hashmap! {

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -67,7 +67,7 @@ impl Delegations {
         role.signed
             .serialize(&mut ser)
             .context(error::JsonSerializationSnafu {
-                what: format!("{} role", name),
+                what: format!("{name} role"),
             })?;
         for signature in &role.signatures {
             if role_keys.keyids.contains(&signature.keyid) {

--- a/tough/src/target_name.rs
+++ b/tough/src/target_name.rs
@@ -100,7 +100,7 @@ impl<'de> Deserialize<'de> for TargetName {
         D: Deserializer<'de>,
     {
         let s = <String>::deserialize(deserializer)?;
-        TargetName::new(s).map_err(|e| D::Error::custom(format!("{}", e)))
+        TargetName::new(s).map_err(|e| D::Error::custom(format!("{e}")))
     }
 }
 

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -118,8 +118,8 @@ impl Display for TransportError {
         if let Some(e) = self.source.as_ref() {
             write!(
                 f,
-                "Transport '{}' error fetching '{}': {}",
-                self.kind, self.url, e
+                "Transport '{}' error fetching '{}': {e}",
+                self.kind, self.url
             )
         } else {
             write!(f, "Transport '{}' error fetching '{}'", self.kind, self.url)

--- a/tough/tests/http.rs
+++ b/tough/tests/http.rs
@@ -13,7 +13,7 @@ mod http_happy {
     /// Set an expectation in a test HTTP server which serves a file from `tuf-reference-impl`.
     fn create_successful_get(relative_path: &str) -> httptest::Expectation {
         let repo_dir = test_data().join("tuf-reference-impl");
-        let file_bytes = std::fs::read(&repo_dir.join(relative_path)).unwrap();
+        let file_bytes = std::fs::read(repo_dir.join(relative_path)).unwrap();
         Expectation::matching(request::method_path("GET", format!("/{}", relative_path)))
             .times(1)
             .respond_with(

--- a/tough/tests/repo_cache.rs
+++ b/tough/tests/repo_cache.rs
@@ -205,7 +205,7 @@ fn test_repo_cache_metadata() {
     let copied_repo = RepositoryLoader::new(
         repo_paths.root(),
         dir_url(&metadata_destination),
-        dir_url(&targets_destination),
+        dir_url(targets_destination),
     )
     .load()
     .unwrap();

--- a/tough/tests/repo_editor.rs
+++ b/tough/tests/repo_editor.rs
@@ -86,7 +86,7 @@ fn test_repo_editor() -> RepositoryEditor {
     let target3 = targets_path().join("file3.txt");
     let target_list = vec![target3];
 
-    let mut editor = RepositoryEditor::new(&root).unwrap();
+    let mut editor = RepositoryEditor::new(root).unwrap();
     editor
         .targets_expires(targets_expiration)
         .unwrap()
@@ -118,7 +118,7 @@ fn repository_editor_from_repository() {
     let root = repo_paths.root_path.clone();
     let repo = load_tuf_reference_impl(&mut repo_paths);
 
-    assert!(RepositoryEditor::from_repo(&root, repo).is_ok());
+    assert!(RepositoryEditor::from_repo(root, repo).is_ok());
 }
 
 // Create sign write and reload repo
@@ -227,7 +227,7 @@ fn create_sign_write_reload_repo() {
 
     assert!(signed_repo.write(&metadata_destination).is_ok());
     assert!(signed_repo
-        .link_targets(&targets_path(), &targets_destination, PathExists::Skip)
+        .link_targets(targets_path(), &targets_destination, PathExists::Skip)
         .is_ok());
     // Load the repo we just created
     let _new_repo = RepositoryLoader::new(
@@ -277,9 +277,9 @@ fn create_role_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
-        dir_url(&targets_destination),
+        dir_url(targets_destination),
     )
     .load()
     .unwrap();
@@ -328,7 +328,7 @@ fn create_role_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -352,7 +352,7 @@ fn create_role_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -391,7 +391,7 @@ fn create_role_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -426,9 +426,9 @@ fn create_role_flow() {
     // reload repo and verify that A and B role are included
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
-        dir_url(&metadata_destination),
-        dir_url(&targets_destination),
+        File::open(root).unwrap(),
+        dir_url(metadata_destination),
+        dir_url(targets_destination),
     )
     .load()
     .unwrap();
@@ -477,9 +477,9 @@ fn update_targets_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
-        dir_url(&targets_destination),
+        dir_url(targets_destination),
     )
     .load()
     .unwrap();
@@ -528,7 +528,7 @@ fn update_targets_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -552,7 +552,7 @@ fn update_targets_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -591,7 +591,7 @@ fn update_targets_flow() {
     // reload repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -626,7 +626,7 @@ fn update_targets_flow() {
     // reload repo and verify that A and B role are included
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -669,7 +669,7 @@ fn update_targets_flow() {
     // load repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -706,7 +706,7 @@ fn update_targets_flow() {
     //load the updated repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -755,7 +755,7 @@ fn update_targets_flow() {
     // load repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )
@@ -793,7 +793,7 @@ fn update_targets_flow() {
     //load the updated repo
     let root = root_path();
     let new_repo = RepositoryLoader::new(
-        File::open(&root).unwrap(),
+        File::open(root).unwrap(),
         dir_url(&metadata_destination),
         dir_url(&targets_destination),
     )

--- a/tough/tests/target_path_safety.rs
+++ b/tough/tests/target_path_safety.rs
@@ -66,7 +66,7 @@ fn create_root(root_path: &Path, consistent_snapshot: bool) -> Vec<Box<dyn KeySo
     )
     .unwrap();
 
-    std::fs::write(&root_path, signed_root.buffer()).unwrap();
+    std::fs::write(root_path, signed_root.buffer()).unwrap();
 
     keys
 }

--- a/tuftool/src/clone.rs
+++ b/tuftool/src/clone.rs
@@ -123,8 +123,8 @@ impl CloneArgs {
             );
 
             println!(
-                "Cloning repository:\n\tmetadata location: {:?}\n\ttargets location: {:?}",
-                self.metadata_dir, targets_dir
+                "Cloning repository:\n\tmetadata location: {:?}\n\ttargets location: {targets_dir:?}",
+                self.metadata_dir
             );
             if self.target_names.is_empty() {
                 repository

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -122,7 +122,7 @@ fn handle_download(repository: &Repository, outdir: &Path, raw_names: &[String])
         target_names
     };
 
-    println!("Downloading targets to {:?}", outdir);
+    println!("Downloading targets to {outdir:?}");
     std::fs::create_dir_all(outdir).context(error::DirCreateSnafu { path: outdir })?;
     for target in targets {
         download_target(&target)?;

--- a/tuftool/src/download_root.rs
+++ b/tuftool/src/download_root.rs
@@ -19,13 +19,13 @@ pub(crate) fn download_root<P>(
 where
     P: AsRef<Path>,
 {
-    let name = format!("{}.root.json", version);
+    let name = format!("{version}.root.json");
 
     let path = outdir.as_ref().join(&name);
     let url = metadata_base_url
         .join(&name)
         .context(error::UrlParseSnafu {
-            url: format!("{}/{}", metadata_base_url.as_str(), name),
+            url: format!("{name}/{}", metadata_base_url.as_str()),
         })?;
     root_warning(&path);
 

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -9,6 +9,7 @@
     clippy::use_self,
     // Caused by interacting with tough::schema::*._extra
     clippy::used_underscore_binding,
+    clippy::result_large_err,
 )]
 
 mod add_key_role;
@@ -175,11 +176,11 @@ fn main() -> ! {
     std::process::exit(match Program::from_args().run() {
         Ok(()) => 0,
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             if let Some(var) = std::env::var_os("RUST_BACKTRACE") {
                 if var != "0" {
                     if let Some(backtrace) = err.backtrace() {
-                        eprintln!("\n{:?}", backtrace);
+                        eprintln!("\n{backtrace:?}");
                     }
                 }
             }

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -233,7 +233,7 @@ impl Command {
             .tuf_key();
         let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair)?);
         clear_sigs(&mut root);
-        println!("{}", key_id);
+        println!("{key_id}");
         write_file(path, &root)
     }
 
@@ -275,11 +275,11 @@ impl Command {
         // https://github.com/briansmith/ring/issues/219
         let mut command = std::process::Command::new("openssl");
         command.args(["genpkey", "-algorithm", "RSA", "-pkeyopt"]);
-        command.arg(format!("rsa_keygen_bits:{}", bits));
+        command.arg(format!("rsa_keygen_bits:{bits}"));
         command.arg("-pkeyopt");
-        command.arg(format!("rsa_keygen_pubexp:{}", exponent));
+        command.arg(format!("rsa_keygen_pubexp:{exponent}"));
 
-        let command_str = format!("{:?}", command);
+        let command_str = format!("{command:?}");
         let output = command.output().context(error::CommandExecSnafu {
             command_str: &command_str,
         })?;
@@ -299,7 +299,7 @@ impl Command {
             .write(&stdout, &key_id)
             .context(error::WriteKeySourceSnafu)?;
         clear_sigs(&mut root);
-        println!("{}", key_id);
+        println!("{key_id}");
         write_file(path, &root)
     }
 

--- a/tuftool/tests/clone_command.rs
+++ b/tuftool/tests/clone_command.rs
@@ -78,7 +78,7 @@ fn assert_all_metadata(metadata_dir: &TempDir) {
 
 /// Given a `Command`, attach all the base args necessary for the `clone` subcommand
 fn clone_base_command<'a>(cmd: &'a mut Command, repo_paths: &RepoPaths) -> &'a mut Command {
-    cmd.args(&[
+    cmd.args([
         "clone",
         "--root",
         repo_paths.root_path.to_str().unwrap(),
@@ -95,7 +95,7 @@ fn clone_metadata() {
     let repo_paths = RepoPaths::new();
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&["--metadata-only"])
+        .args(["--metadata-only"])
         .assert()
         .success();
 
@@ -109,13 +109,13 @@ fn clone_metadata_target_args_failure() {
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     // --target-names
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&["--metadata-only", "--target-names", "foo"])
+        .args(["--metadata-only", "--target-names", "foo"])
         .assert()
         .failure();
 
     // --targets-url
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&[
+        .args([
             "--metadata-only",
             "--targets-url",
             repo_paths.targets_base_url.as_str(),
@@ -125,7 +125,7 @@ fn clone_metadata_target_args_failure() {
 
     // --targets-dir
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&[
+        .args([
             "--metadata-only",
             "--targets-dir",
             repo_paths.targets_outdir.path().to_str().unwrap(),
@@ -135,7 +135,7 @@ fn clone_metadata_target_args_failure() {
 
     // all target args
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&[
+        .args([
             "--metadata-only",
             "--targets-url",
             repo_paths.targets_base_url.as_str(),
@@ -155,7 +155,7 @@ fn clone_subset_targets() {
     let repo_paths = RepoPaths::new();
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&[
+        .args([
             "--targets-url",
             repo_paths.targets_base_url.as_str(),
             "--targets-dir",
@@ -181,7 +181,7 @@ fn clone_full_repo() {
     let repo_paths = RepoPaths::new();
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
     clone_base_command(&mut cmd, &repo_paths)
-        .args(&[
+        .args([
             "--targets-url",
             repo_paths.targets_base_url.as_str(),
             "--targets-dir",

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -29,7 +29,7 @@ fn create_command() {
     // Create a repo using tuftool and the reference tuf implementation targets
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             targets_input_dir.to_str().unwrap(),
@@ -122,7 +122,7 @@ fn create_with_incorrect_key() {
     // the command fails.
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             "input/dir/does/not/matter",
@@ -155,7 +155,7 @@ fn create_with_no_key() {
     // Misuse the tuftool create command by not passing any keys and assert failure
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             "/input/dir/does/not/matter",

--- a/tuftool/tests/create_repository_integration.rs
+++ b/tuftool/tests/create_repository_integration.rs
@@ -24,32 +24,32 @@ fn get_profile() -> String {
 fn initialize_root_json(root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "init", root_json])
+        .args(["root", "init", root_json])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "expire", root_json, "3030-09-22T00:00:00Z"])
+        .args(["root", "expire", root_json, "3030-09-22T00:00:00Z"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "root", "1"])
+        .args(["root", "set-threshold", root_json, "root", "1"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "snapshot", "1"])
+        .args(["root", "set-threshold", root_json, "snapshot", "1"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "targets", "1"])
+        .args(["root", "set-threshold", root_json, "targets", "1"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "timestamp", "1"])
+        .args(["root", "set-threshold", root_json, "timestamp", "1"])
         .assert()
         .success();
 }
@@ -57,7 +57,7 @@ fn initialize_root_json(root_json: &str) {
 fn gen_key(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "gen-rsa-key",
             root_json,
@@ -73,24 +73,24 @@ fn gen_key(key: &str, root_json: &str) {
 fn add_root_key(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "root"])
+        .args(["root", "add-key", root_json, key, "--role", "root"])
         .assert()
         .success();
 }
 fn add_key_all_role(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "snapshot"])
+        .args(["root", "add-key", root_json, key, "--role", "snapshot"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "targets"])
+        .args(["root", "add-key", root_json, key, "--role", "targets"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "timestamp"])
+        .args(["root", "add-key", root_json, key, "--role", "timestamp"])
         .assert()
         .success();
 }
@@ -98,7 +98,7 @@ fn add_key_all_role(key: &str, root_json: &str) {
 fn sign_root_json(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "sign", root_json, "-k", key])
+        .args(["root", "sign", root_json, "-k", key])
         .assert()
         .success();
 }
@@ -129,7 +129,7 @@ fn create_repository(root_key: &str, auto_generate: bool) {
     // Create a repo using tuftool and the reference tuf implementation targets
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             targets_input_dir.to_str().unwrap(),

--- a/tuftool/tests/delegation_commands.rs
+++ b/tuftool/tests/delegation_commands.rs
@@ -27,7 +27,7 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
     // Create a repo using tuftool and the reference tuf implementation data
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             targets_input_dir.to_str().unwrap(),
@@ -83,7 +83,7 @@ fn create_add_role_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -104,7 +104,7 @@ fn create_add_role_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -112,7 +112,7 @@ fn create_add_role_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -157,7 +157,7 @@ fn create_add_role_command() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "B",
@@ -178,7 +178,7 @@ fn create_add_role_command() {
     // add role B to A metadata and sign A meta
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -186,7 +186,7 @@ fn create_add_role_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -212,7 +212,7 @@ fn create_add_role_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -237,7 +237,7 @@ fn create_add_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(&add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -279,7 +279,7 @@ fn update_target_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -300,7 +300,7 @@ fn update_target_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -308,7 +308,7 @@ fn update_target_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -338,13 +338,13 @@ fn update_target_command() {
 
     // Update A's targets
     let ut_out = TempDir::new().unwrap();
-    let meta_out_url = dir_url(&ut_out.path().join("metadata"));
+    let meta_out_url = dir_url(ut_out.path().join("metadata"));
     let targets_out_url = ut_out.path().join("targets");
     let updated_metadata_base_url = &dir_url(new_repo_dir.path().join("metadata"));
     let targets_input_dir = test_utils::test_data().join("targets");
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -380,7 +380,7 @@ fn update_target_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -455,7 +455,7 @@ fn add_key_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -476,7 +476,7 @@ fn add_key_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -484,7 +484,7 @@ fn add_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -517,7 +517,7 @@ fn add_key_command() {
     let key_out = TempDir::new().unwrap();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -546,14 +546,14 @@ fn add_key_command() {
     let new_repo_dir = TempDir::new().unwrap();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "--role",
             "targets",
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&key_out.path().join("metadata")).as_str(),
+            dir_url(key_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -582,7 +582,7 @@ fn add_key_command() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "B",
@@ -603,7 +603,7 @@ fn add_key_command() {
     // add role B to A metadata and sign A meta with the added key
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -611,7 +611,7 @@ fn add_key_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key1.to_str().unwrap(),
             "--root",
@@ -637,7 +637,7 @@ fn add_key_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -662,7 +662,7 @@ fn add_key_command() {
             "--role",
             "A",
             "-i",
-            dir_url(&add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -702,7 +702,7 @@ fn remove_key_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -725,7 +725,7 @@ fn remove_key_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -733,7 +733,7 @@ fn remove_key_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -767,7 +767,7 @@ fn remove_key_command() {
     let key_out = TempDir::new().unwrap();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -796,14 +796,14 @@ fn remove_key_command() {
     let new_repo_dir = TempDir::new().unwrap();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "--role",
             "targets",
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&key_out.path().join("metadata")).as_str(),
+            dir_url(key_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -832,7 +832,7 @@ fn remove_key_command() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "B",
@@ -853,7 +853,7 @@ fn remove_key_command() {
     // add role B to A metadata and sign A meta with the removed key
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -861,7 +861,7 @@ fn remove_key_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key1.to_str().unwrap(),
             "--root",
@@ -905,7 +905,7 @@ fn remove_role_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -926,7 +926,7 @@ fn remove_role_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -934,7 +934,7 @@ fn remove_role_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -979,7 +979,7 @@ fn remove_role_command() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "B",
@@ -1000,7 +1000,7 @@ fn remove_role_command() {
     // add role B to A metadata
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -1008,7 +1008,7 @@ fn remove_role_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1040,7 +1040,7 @@ fn remove_role_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -1065,7 +1065,7 @@ fn remove_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(&add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -1077,7 +1077,7 @@ fn remove_role_command() {
     // remove role B from A metadata and sign A meta
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -1113,7 +1113,7 @@ fn remove_role_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -1138,7 +1138,7 @@ fn remove_role_command() {
             "--role",
             "A",
             "-i",
-            dir_url(&remove_b_out.path().join("metadata")).as_str(),
+            dir_url(remove_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -1180,7 +1180,7 @@ fn remove_role_recursive_command() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -1201,7 +1201,7 @@ fn remove_role_recursive_command() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -1209,7 +1209,7 @@ fn remove_role_recursive_command() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -1253,7 +1253,7 @@ fn remove_role_recursive_command() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "B",
@@ -1274,7 +1274,7 @@ fn remove_role_recursive_command() {
     // add role B to A metadata
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "A",
@@ -1282,7 +1282,7 @@ fn remove_role_recursive_command() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1314,7 +1314,7 @@ fn remove_role_recursive_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -1339,7 +1339,7 @@ fn remove_role_recursive_command() {
             "--role",
             "A",
             "-i",
-            dir_url(&add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -1351,7 +1351,7 @@ fn remove_role_recursive_command() {
     // remove role B from A metadata and sign A meta
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -1388,7 +1388,7 @@ fn remove_role_recursive_command() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -1413,7 +1413,7 @@ fn remove_role_recursive_command() {
             "--role",
             "targets",
             "-i",
-            dir_url(&remove_b_out.path().join("metadata")).as_str(),
+            dir_url(remove_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();
@@ -1466,7 +1466,7 @@ fn dubious_role_name() {
     // create role A
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             dubious_role_name,
@@ -1487,7 +1487,7 @@ fn dubious_role_name() {
     // add role to targets metadata and sign entire repo
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             "targets",
@@ -1495,7 +1495,7 @@ fn dubious_role_name() {
             "-o",
             new_repo_dir.path().to_str().unwrap(),
             "-i",
-            dir_url(&meta_out.path().join("metadata")).as_str(),
+            dir_url(meta_out.path().join("metadata")).as_str(),
             "-k",
             root_key.to_str().unwrap(),
             "--root",
@@ -1540,7 +1540,7 @@ fn dubious_role_name() {
     // create role B
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             funny_role_name,
@@ -1561,7 +1561,7 @@ fn dubious_role_name() {
     // add role B to A metadata and sign A meta
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "delegation",
             "--signing-role",
             dubious_role_name,
@@ -1569,7 +1569,7 @@ fn dubious_role_name() {
             "-o",
             add_b_out.path().to_str().unwrap(),
             "-i",
-            dir_url(&create_out.path().join("metadata")).as_str(),
+            dir_url(create_out.path().join("metadata")).as_str(),
             "-k",
             targets_key.to_str().unwrap(),
             "--root",
@@ -1607,7 +1607,7 @@ fn dubious_role_name() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -1632,7 +1632,7 @@ fn dubious_role_name() {
             "--role",
             dubious_role_name,
             "-i",
-            dir_url(&add_b_out.path().join("metadata")).as_str(),
+            dir_url(add_b_out.path().join("metadata")).as_str(),
         ])
         .assert()
         .success();

--- a/tuftool/tests/download_command.rs
+++ b/tuftool/tests/download_command.rs
@@ -12,7 +12,7 @@ use url::Url;
 /// Set an expectation in a test HTTP server which serves a file from `tuf-reference-impl`.
 fn create_successful_get(relative_path: &str) -> httptest::Expectation {
     let repo_dir = test_utils::test_data().join("tuf-reference-impl");
-    let file_bytes = std::fs::read(&repo_dir.join(relative_path)).unwrap();
+    let file_bytes = std::fs::read(repo_dir.join(relative_path)).unwrap();
     Expectation::matching(request::method_path("GET", format!("/{}", relative_path)))
         .times(1)
         .respond_with(
@@ -56,7 +56,7 @@ fn download_command(metadata_base_url: Url, targets_base_url: Url) {
     // Download a test repo.
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "download",
             "-r",
             root_json.to_str().unwrap(),
@@ -76,7 +76,7 @@ fn download_command(metadata_base_url: Url, targets_base_url: Url) {
     // Download again into the same outdir, this will fail because the directory exists.
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "download",
             "-r",
             root_json.to_str().unwrap(),
@@ -123,7 +123,7 @@ fn download_expired_repo(outdir: &Path, repo_dir: &TempDir, allow_expired_repo: 
     let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
     let targets_base_url = &test_utils::dir_url(repo_dir.path().join("targets"));
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
-    cmd.args(&[
+    cmd.args([
         "download",
         "-r",
         root_json.to_str().unwrap(),
@@ -176,7 +176,7 @@ fn download_safe_target_paths() {
     let tempdir = TempDir::new().unwrap();
     let outdir = tempdir.path().join("outdir");
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
-    cmd.args(&[
+    cmd.args([
         "download",
         "-r",
         root.to_str().unwrap(),

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -13,32 +13,32 @@ use tough::schema::{Root, Signed};
 fn initialize_root_json(root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "init", root_json])
+        .args(["root", "init", root_json])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "expire", root_json, "2020-09-22T00:00:00Z"])
+        .args(["root", "expire", root_json, "2020-09-22T00:00:00Z"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "root", "2"])
+        .args(["root", "set-threshold", root_json, "root", "2"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "snapshot", "1"])
+        .args(["root", "set-threshold", root_json, "snapshot", "1"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "targets", "1"])
+        .args(["root", "set-threshold", root_json, "targets", "1"])
         .assert()
         .success();
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-threshold", root_json, "timestamp", "1"])
+        .args(["root", "set-threshold", root_json, "timestamp", "1"])
         .assert()
         .success();
 }
@@ -46,7 +46,7 @@ fn initialize_root_json(root_json: &str) {
 fn add_key_root(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "root"])
+        .args(["root", "add-key", root_json, key, "--role", "root"])
         .assert()
         .success();
 }
@@ -54,7 +54,7 @@ fn add_key_root(key: &str, root_json: &str) {
 fn add_key_timestamp(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "timestamp"])
+        .args(["root", "add-key", root_json, key, "--role", "timestamp"])
         .assert()
         .success();
 }
@@ -62,14 +62,14 @@ fn add_key_timestamp(key: &str, root_json: &str) {
 fn add_key_snapshot(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "snapshot"])
+        .args(["root", "add-key", root_json, key, "--role", "snapshot"])
         .assert()
         .success();
 }
 fn add_key_targets(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "add-key", root_json, key, "--role", "targets"])
+        .args(["root", "add-key", root_json, key, "--role", "targets"])
         .assert()
         .success();
 }
@@ -85,7 +85,7 @@ fn sign_root_json(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
         // We don't have enough signatures to meet the threshold, so we have to pass `-i`
-        .args(&["root", "sign", root_json, "-i", "-k", key])
+        .args(["root", "sign", root_json, "-i", "-k", key])
         .assert()
         .success();
 }
@@ -94,7 +94,7 @@ fn sign_root_json_failure(key: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
         // We don't have enough signatures to meet the threshold, so we should fail
-        .args(&["root", "sign", root_json, "-k", key])
+        .args(["root", "sign", root_json, "-k", key])
         .assert()
         .failure();
 }
@@ -102,7 +102,7 @@ fn sign_root_json_failure(key: &str, root_json: &str) {
 fn sign_root_json_two_keys(key_1: &str, key_2: &str, root_json: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "sign", root_json, "-k", key_1, "-k", key_2])
+        .args(["root", "sign", root_json, "-k", key_1, "-k", key_2])
         .assert()
         .success();
 }
@@ -110,7 +110,7 @@ fn sign_root_json_two_keys(key_1: &str, key_2: &str, root_json: &str) {
 fn cross_sign(old_root: &str, new_root: &str, key: &str) {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "sign",
             new_root,
@@ -136,7 +136,12 @@ fn get_sign_len(root_json: &str) -> usize {
 
 fn check_signature_exists(root_json: &str, key_id: Decoded<Hex>) -> bool {
     let root = get_signed_root(root_json);
-    if root.signatures.iter().find(|sig| sig.keyid == key_id) == None {
+    if root
+        .signatures
+        .iter()
+        .find(|sig| sig.keyid == key_id)
+        .is_none()
+    {
         return false;
     }
     true
@@ -182,7 +187,7 @@ fn create_unstable_root() {
     // Set the threshold for roles with targets being more than 1
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "set-threshold",
             root_json.to_str().unwrap(),
@@ -196,7 +201,7 @@ fn create_unstable_root() {
     // Sign root.json (error because targets can never be validated root has 1 key but targets requires 2 signatures)
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "sign",
             out_dir.path().join("root.json").to_str().unwrap(),
@@ -221,7 +226,7 @@ fn create_invalid_root() {
     // Sign root.json (error because key is not valid)
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "sign",
             out_dir.path().join("root.json").to_str().unwrap(),
@@ -286,7 +291,7 @@ fn cross_sign_root_invalid_key() {
     //Sign 2.root.json with key not in 1.root.json
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "root",
             "sign",
             new_root_json.to_str().unwrap(),
@@ -349,7 +354,7 @@ fn set_version_root() {
     //set version to 5
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&["root", "set-version", root_json.to_str().unwrap(), "5"])
+        .args(["root", "set-version", root_json.to_str().unwrap(), "5"])
         .assert()
         .success();
 

--- a/tuftool/tests/test_utils.rs
+++ b/tuftool/tests/test_utils.rs
@@ -48,7 +48,7 @@ pub fn create_expired_repo<P: AsRef<Path>>(repo_dir: P) {
     // Create a repo using tuftool and the reference tuf implementation data
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             targets_input_dir.to_str().unwrap(),

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -28,7 +28,7 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
     // Create a repo using tuftool and the reference tuf implementation data
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "create",
             "-t",
             targets_input_dir.to_str().unwrap(),
@@ -78,7 +78,7 @@ fn update_command_without_new_targets() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-o",
             update_out.path().to_str().unwrap(),
@@ -150,7 +150,7 @@ fn update_command_with_new_targets() {
     // Update the repo we just created
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "-t",
             new_targets_input_dir.to_str().unwrap(),
@@ -225,7 +225,7 @@ fn update_with_incorrect_key() {
 
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "--outdir",
             "/outdir/does/not/matter",
@@ -257,7 +257,7 @@ fn update_with_incorrect_key() {
 fn update_with_no_key() {
     Command::cargo_bin("tuftool")
         .unwrap()
-        .args(&[
+        .args([
             "update",
             "--outdir",
             "/outdir/does/not/matter",
@@ -306,7 +306,7 @@ fn updates_expired_repo(
     let targets_version: u64 = 170;
     let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
     let mut cmd = Command::cargo_bin("tuftool").unwrap();
-    cmd.args(&[
+    cmd.args([
         "update",
         "-o",
         outdir.path().to_str().unwrap(),


### PR DESCRIPTION
**Description of changes:**

Bumps the rust toolchain to 1.66.1 and `cargo-deny` to 0.13.5 in actions runner.

Also addressed new `clippy` warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
