### PR TITLE
support compiling for wasm32 architecture

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,4 +25,5 @@ jobs:
       - run: rustup default 1.66.1
       - run: rustup component add rustfmt
       - run: rustup component add clippy
+      - run: rustup target add wasm32-unknown-unknown
       - run: make ${{ matrix.make_target }}

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build:
 	cargo clippy --locked -- -D warnings
 	cargo build --locked -p olpc-cjson
 	cargo build --locked -p tough
+	cargo build --locked -p tough --target wasm32-unknown-unknown
 	cargo build --locked -p tough-ssm
 	cargo build --locked -p tough-kms
 	cargo build --locked -p tuftool
@@ -34,3 +35,4 @@ integ:
 	set +e
 	cd tough && cargo test --features '' --locked
 	cd tough && cargo test --all-features --locked
+	cd tough && cargo test --no-default-features --locked --target wasm32-unknown-unknown

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -15,7 +15,7 @@ globset = { version = "0.4" }
 hex = "0.4"
 log = "0.4"
 olpc-cjson = { version = "0.1", path = "../olpc-cjson" }
-path-absolutize = "3"
+path-absolutize = { version = "3", features = ["use_unix_paths_on_wasm"] }
 pem = "1"
 percent-encoding = "2"
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking"] }

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -32,6 +32,7 @@
 
 mod cache;
 mod datastore;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod editor;
 pub mod error;
 mod fetch;


### PR DESCRIPTION
*Description of changes:*

Add feature flags for dependencies to work on wasm target architectures, and exclude the editor module when wasm32 target is set since it relies on filesystem operations not available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
