### PR TITLE
fix all_targets iterator type

### DIFF
--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -411,7 +411,7 @@ impl Repository {
     }
 
     ///return a vec of all targets including all target files delegated by targets
-    pub fn all_targets(&self) -> impl Iterator + '_ {
+    pub fn all_targets(&self) -> impl Iterator<Item = (&TargetName, &schema::Target)> + '_ {
         self.targets.signed.targets_iter()
     }
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #560

*Description of changes:*

Include the type in an `impl Iterator` return so that the return type is usable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
