### PR TITLE
[RFC] add a lifetime parameter to Transport::fetch and Repository::read_target

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -260,7 +260,7 @@ impl Repository {
         target: &Target,
         digest: &[u8],
         filename: &str,
-    ) -> Result<impl Read> {
+    ) -> Result<impl Read + '_> {
         fetch_sha256(
             self.transport.as_ref(),
             self.targets_base_url

--- a/tough/src/fetch.rs
+++ b/tough/src/fetch.rs
@@ -8,12 +8,12 @@ use snafu::ResultExt;
 use std::io::Read;
 use url::Url;
 
-pub(crate) fn fetch_max_size(
-    transport: &dyn Transport,
+pub(crate) fn fetch_max_size<'a>(
+    transport: &'a dyn Transport,
     url: Url,
     max_size: u64,
     specifier: &'static str,
-) -> Result<impl Read + Send> {
+) -> Result<impl Read + Send + 'a> {
     Ok(MaxSizeAdapter::new(
         transport
             .fetch(url.clone())
@@ -23,13 +23,13 @@ pub(crate) fn fetch_max_size(
     ))
 }
 
-pub(crate) fn fetch_sha256(
-    transport: &dyn Transport,
+pub(crate) fn fetch_sha256<'a>(
+    transport: &'a dyn Transport,
     url: Url,
     size: u64,
     specifier: &'static str,
     sha256: &[u8],
-) -> Result<impl Read + Send> {
+) -> Result<impl Read + Send + 'a> {
     Ok(DigestAdapter::sha256(
         Box::new(MaxSizeAdapter::new(
             transport

--- a/tough/src/io.rs
+++ b/tough/src/io.rs
@@ -6,15 +6,15 @@ use ring::digest::{Context, SHA256};
 use std::io::{self, Read};
 use url::Url;
 
-pub(crate) struct DigestAdapter {
+pub(crate) struct DigestAdapter<'a> {
     url: Url,
-    reader: Box<dyn Read + Send>,
+    reader: Box<dyn Read + Send + 'a>,
     hash: Vec<u8>,
     digest: Option<Context>,
 }
 
-impl DigestAdapter {
-    pub(crate) fn sha256(reader: Box<dyn Read + Send>, hash: &[u8], url: Url) -> Self {
+impl<'a> DigestAdapter<'a> {
+    pub(crate) fn sha256(reader: Box<dyn Read + Send + 'a>, hash: &[u8], url: Url) -> Self {
         Self {
             url,
             reader,
@@ -24,7 +24,7 @@ impl DigestAdapter {
     }
 }
 
-impl Read for DigestAdapter {
+impl<'a> Read for DigestAdapter<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         assert!(
             self.digest.is_some(),
@@ -52,8 +52,8 @@ impl Read for DigestAdapter {
     }
 }
 
-pub(crate) struct MaxSizeAdapter {
-    reader: Box<dyn Read + Send>,
+pub(crate) struct MaxSizeAdapter<'a> {
+    reader: Box<dyn Read + Send + 'a>,
     /// How the `max_size` was specified. For example the max size of `root.json` is specified by
     /// the `max_root_size` argument in `Settings`. `specifier` is used to construct an error
     /// message when the `MaxSizeAdapter` detects that too many bytes have been read.
@@ -62,9 +62,9 @@ pub(crate) struct MaxSizeAdapter {
     counter: u64,
 }
 
-impl MaxSizeAdapter {
+impl<'a> MaxSizeAdapter<'a> {
     pub(crate) fn new(
-        reader: Box<dyn Read + Send>,
+        reader: Box<dyn Read + Send + 'a>,
         specifier: &'static str,
         max_size: u64,
     ) -> Self {
@@ -77,7 +77,7 @@ impl MaxSizeAdapter {
     }
 }
 
-impl Read for MaxSizeAdapter {
+impl<'a> Read for MaxSizeAdapter<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let size = self.reader.read(buf)?;
         self.counter += size as u64;

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -426,7 +426,7 @@ impl Repository {
     /// before its checksum is validated. If the maximum size is reached or there is a checksum
     /// mismatch, the reader returns a [`std::io::Error`]. **Consumers of this library must not use
     /// data from the reader if it returns an error.**
-    pub fn read_target(&self, name: &TargetName) -> Result<Option<impl Read + Send>> {
+    pub fn read_target(&self, name: &TargetName) -> Result<Option<impl Read + Send + '_>> {
         // Check for repository metadata expiration.
         if self.expiration_enforcement == ExpirationEnforcement::Safe {
             ensure!(

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -16,7 +16,7 @@ use url::Url;
 /// implementing a `Transport`.
 pub trait Transport: Debug + DynClone {
     /// Opens a `Read` object for the file specified by `url`.
-    fn fetch(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError>;
+    fn fetch(&self, url: Url) -> Result<Box<dyn Read + Send + '_>, TransportError>;
 }
 
 // Implements `Clone` for `Transport` trait objects (i.e. on `Box::<dyn Clone>`). To facilitate
@@ -206,7 +206,7 @@ impl DefaultTransport {
 }
 
 impl Transport for DefaultTransport {
-    fn fetch(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError> {
+    fn fetch(&self, url: Url) -> Result<Box<dyn Read + Send + '_>, TransportError> {
         match url.scheme() {
             "file" => self.file.fetch(url),
             "http" | "https" => self.handle_http(url),
@@ -230,7 +230,7 @@ impl DefaultTransport {
     }
 
     #[cfg(feature = "http")]
-    fn handle_http(&self, url: Url) -> Result<Box<dyn Read + Send>, TransportError> {
+    fn handle_http(&self, url: Url) -> Result<Box<dyn Read + Send + '_>, TransportError> {
         self.http.fetch(url)
     }
 }


### PR DESCRIPTION
Looking for feedback on this one -- is this desirable?

*Issue #, if available:*

*Description of changes:*

Add a lifetime parameter to `Transport::fetch` and `Repository::read_target`.

This is useful in cases where you're implementing a transport that borrows from the reader (e.g. if you're reading a TUF repository from a zip file, returning a [`ZipFile<'a>`](https://docs.rs/zip/latest/zip/read/struct.ZipFile.html) as the transport).

This is a breaking change because `read_target` now borrows from `self`. I don't think that's a major issue, because in most cases you're going to keep the `Repository` open for longer than any of the targets you read from it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.