### PR TITLE
Removes rust openssl dependencies in tuftool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,25 +1639,27 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2484,6 +2486,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,8 @@ allow = [
 ]
 
 exceptions = [
+    # Explicitly allows MPL-2 being pulled in through reqwest's rustls dependency chain (which uses webpki)
+    { name = "webpki-roots", allow = ["MPL-2.0"], version = "*" },
     { name = "unicode-ident", version = "1.0.2", allow = ["MIT", "Apache-2.0", "Unicode-DFS-2016"] },
 ]
 

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -27,7 +27,7 @@ maplit = "1.0.1"
 olpc-cjson = { version = "0.1.0", path = "../olpc-cjson" }
 pem = "1.1.1"
 rayon = "1.6"
-reqwest = { version = "0.11.1", features = ["blocking"] }
+reqwest = { version = "0.11.1", default-features = false, features = ["blocking", "rustls-tls"] }
 ring = { version = "0.16.16", features = ["std"] }
 serde = "1.0.144"
 serde_json = "1.0.91"


### PR DESCRIPTION
*Issue #, if available:*

N/a

*Description of changes:*

This patch removes the `openssl` rust build dependencies in `tuftool`. These were being pulled in from `reqwest` since its default features use `native-tls`.

Now, the only reference in the rust build-chain is to `openssl-probe` which is a dependency of `rustls-native-certs`

```
❯ cargo tree -p tuftool | rg openssl
│   │   │   │   │   │   ├── openssl-probe v0.1.5
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
