### PR TITLE
tuftool: add OpenSSL dependency info to README

### DIFF
--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -1,5 +1,11 @@
 **tuftool** is a Rust command-line utility for generating and signing TUF repositories.
 
+## Dependencies
+
+Make sure you have the following dependencies present on your system before installing `tuftool`:
+
+- OpenSSL: install `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
+
 ## Installing
 
 To install the latest version of `tuftool`:


### PR DESCRIPTION
Closes #574 

*Description of changes:*

Adds information about installing OpenSSL libraries, prior to installing `tuftool`, to the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
