### PR TITLE
tough: add Send and Sync to Repository transport

### DIFF
--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -162,7 +162,7 @@ where
     root: R,
     metadata_base_url: Url,
     targets_base_url: Url,
-    transport: Option<Box<dyn Transport>>,
+    transport: Option<Box<dyn Transport + Send + Sync>>,
     limits: Option<Limits>,
     datastore: Option<PathBuf>,
     expiration_enforcement: Option<ExpirationEnforcement>,
@@ -197,7 +197,7 @@ impl<R: Read> RepositoryLoader<R> {
 
     /// Set the transport. If no transport has been set, [`DefaultTransport`] will be used.
     #[must_use]
-    pub fn transport<T: Transport + 'static>(mut self, transport: T) -> Self {
+    pub fn transport<T: Transport + Send + Sync + 'static>(mut self, transport: T) -> Self {
         self.transport = Some(Box::new(transport));
         self
     }
@@ -295,7 +295,7 @@ pub enum Prefix {
 /// You can create a `Repository` using a [`RepositoryLoader`].
 #[derive(Debug, Clone)]
 pub struct Repository {
-    transport: Box<dyn Transport>,
+    transport: Box<dyn Transport + Send + Sync>,
     consistent_snapshot: bool,
     datastore: Datastore,
     earliest_expiration: DateTime<Utc>,

--- a/tough/tests/http.rs
+++ b/tough/tests/http.rs
@@ -45,7 +45,7 @@ mod http_happy {
         run_http_test(DefaultTransport::default());
     }
 
-    fn run_http_test<T: Transport + 'static>(transport: T) {
+    fn run_http_test<T: Transport + Send + Sync + 'static>(transport: T) {
         let server = Server::run();
         let repo_dir = test_data().join("tuf-reference-impl");
         server.expect(create_successful_get("metadata/timestamp.json"));


### PR DESCRIPTION
*Description of changes:*

Additional lifetime parameter introduced in #563 resulted in a lifetime mismatch in [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket)'s [validate_repo module](https://github.com/bottlerocket-os/bottlerocket/blob/develop/tools/pubsys/src/repo/validate_repo/mod.rs#L46). To be able to pass Repository into a thread pool we should allow for Send + Sync in transport.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
