### PR TITLE
tough: Prepare for `0.13.1` tough release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "dyn-clone",

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2023-03-20
+
+### Changes
+- Fix race condition in system_time [#591]
+
+[#591]: https://github.com/awslabs/tough/pull/591
+
 ## [0.13.0] - 2023-03-02
 ### Breaking Changes
 - Add a lifetime parameter to Transport::fetch and Repository::read_target, thanks @sunshowers [#563]
@@ -223,7 +230,8 @@ For changes that require modification of calling code see #120 and #121.
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.13.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.13.1...develop
+[0.13.1]: https://github.com/awslabs/tough/compare/tough-v0.13.0...tough-v0.13.1
 [0.13.0]: https://github.com/awslabs/tough/compare/tough-v0.12.5...tough-v0.13.0
 [0.12.5]: https://github.com/awslabs/tough/compare/tough-v0.12.4...tough-v0.12.5
 [0.12.4]: https://github.com/awslabs/tough/compare/tough-v0.12.3...tough-v0.12.4

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.13.0"
+version = "0.13.1"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updates the tough changelog and version to 0.13.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
