### PR TITLE
tough: Add 1 second tolerance to `system_time` stepped back check

### DIFF
--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -599,9 +599,9 @@ fn system_time(datastore: &Datastore) -> Result<DateTime<Utc>> {
     let sys_time = Utc::now();
 
     if let Some(Ok(latest_known_time)) = poss_latest_known_time {
-        // Make sure the sampled system time did not go back in time
+        // Make sure the sampled system time did not go back in time with a tolerance of 1 second
         ensure!(
-            sys_time >= latest_known_time,
+            sys_time >= latest_known_time - chrono::Duration::seconds(1),
             error::SystemTimeSteppedBackwardSnafu {
                 sys_time,
                 latest_known_time


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In a new system, the system time may not initially be monotonic. When downloading many targets across several threads, a time update can cause the previously latest known time to be in the future (according to the system). As a result adding a 1 second tolerance to the time check should resolve this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
