### PR TITLE
Bump rust to 1.67.1 in actions runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-
-      - run: rustup default 1.66.1
+      - run: rustup default 1.67.1
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: make ${{ matrix.make_target }}

--- a/tough-ssm/src/error.rs
+++ b/tough-ssm/src/error.rs
@@ -12,7 +12,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     #[snafu(display("Unable to parse keypair: {}", source))]
     KeyPairParse {
-        source: tough::error::Error,
+        #[snafu(source(from(tough::error::Error, Box::new)))]
+        source: Box<tough::error::Error>,
         backtrace: Backtrace,
     },
 


### PR DESCRIPTION
Also addressed new clippy warning(s).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
