### PR TITLE
tough datastore: treat system_time as critical section and document

### DIFF
--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -71,6 +71,9 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failure to obtain a lock in the system_time function: {}", message))]
+    DatastoreTimeLock { message: String },
+
     #[snafu(display("Failed to create directory '{}': {}", path.display(), source))]
     DirCreate {
         path: PathBuf,


### PR DESCRIPTION
*Issue #, if available:*

Closes #604 
Documents which Datastore functions are thread safe and which one is not, see #602

*Description of changes:*

Adds documentation to the Datastore, moves the system_time function into the Datastore, and adds a lock guard to ensure thread safety of that function.

*Testing*

I tested this with our internal monitoring system for Bottlerocket repos and it worked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
