### PR TITLE
tuftool: Allow providing multiple keys to `root add-key`

### DIFF
--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -57,9 +57,9 @@ tuftool root set-threshold "${ROOT}" timestamp 1
 tuftool root gen-rsa-key "${ROOT}" "${WRK}/keys/root.pem" --role root
 
 # for this example we will re-use the same key for the other standard roles
-tuftool root add-key "${ROOT}" "${WRK}/keys/root.pem" --role snapshot
-tuftool root add-key "${ROOT}" "${WRK}/keys/root.pem" --role targets
-tuftool root add-key "${ROOT}" "${WRK}/keys/root.pem" --role timestamp
+tuftool root add-key "${ROOT}" -k "${WRK}/keys/root.pem" --role snapshot
+tuftool root add-key "${ROOT}" -k "${WRK}/keys/root.pem" --role targets
+tuftool root add-key "${ROOT}" -k "${WRK}/keys/root.pem" --role timestamp
 
 # sign root.json
 tuftool root sign "${ROOT}" -k "${WRK}/keys/root.pem"


### PR DESCRIPTION
**Issue #, if available:**

Closes: #479 

**Description of changes:**

This command is often used to add multiple keys to a role. That currently means calling the command multiple times, once for each key.

Since this is a common scenario, this changes the subcommand to allow providing multiple keys are part of one invocation.

**Note**: This is a breaking change for the CLI. The singular key used to be provided as a positional argument to the command. This now requires passing it as `-k` or `--key` to match the pattern used in other `tuftool` commands.

**Testing done**

Added unit test to cover case of providing multiple keys.

Created two testkeys in KMS and initialized new root (5.root.json). Verified keys could be added and new public key data matches test keys.

```sh
~/MCM-63706822 - $ tuftool root add-key 5.root.json -k aws-kms://default/alias/bottlerocket-root-2023-08-07 -k aws-kms://default/alias/bottlerocket-root-2023-08-07-1 -r root
420d8813216cf5e6f9d7446591d0fcc0d978f8f1e8fb8a1a61d95dc49e00d6fa
2bf157f0eb68996fa0098eef0059127810d4ab302d631583aae224df81567c5f
~/MCM-63706822 - $ jq . 5.root.json 
{
  "signed": {
    "_type": "root",
    "spec_version": "1.0.0",
    "consistent_snapshot": true,
    "version": 5,
    "expires": "2024-08-03T00:00:00Z",
    "keys": {
      "420d8813216cf5e6f9d7446591d0fcc0d978f8f1e8fb8a1a61d95dc49e00d6fa": {
        "keytype": "rsa",
        "keyval": {
          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA7hhgvC82t3xsE+2+eODB\nS5Y7tR+xXWplJgxN/CMkNP1n2f2C0SSrOHHuinWfXZB5HHewwTQ8Bjr++6VhFSj4\nGrLRZsvpDg3g+MBK4qK2Az+30I1zSu6a/L257BoXfKyRP3vV0Eyfb32yZr+8FupN\n7DSyABeag2AIwGelKW+hSp7vIQsL9yYs9zIoLQRkqljl4oNe/VkaGYf2z39EqA6f\n4866YSmQ+YEMIqBTDFICPJfJLJy/nhqvaI66vK5/7D8JKOGenFOj1/L4FjOM5UqK\nN92xFg6gCq48tka89LfgePbUOyYcs/kT4CrwndsC46hwCZCVTOkKr6QMG8Sf111y\nIP5plh6p4PJj/kzTFriAdIBxonoqcFKUOMG9qKk4n5KD+O0LsfTeRmq+AEW5g8sA\nq3gOusAXobvijAz9CjPb8hVwf2PgOAP+zb22diBLv2LAm6PCbYiEk79ifaz0McEC\nDlxxj+R744rb7MIGLkLkt2EgmuyJaZC9Aw+oClICUDGNAgMBAAE=\n-----END PUBLIC KEY-----\n"
        },
        "scheme": "rsassa-pss-sha256"
      },
      "2bf157f0eb68996fa0098eef0059127810d4ab302d631583aae224df81567c5f": {
        "keytype": "rsa",
        "keyval": {
          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAz8z2CZ3A3RLOffrDjenl\ngBzlMxixaupMSIBqBefEjTOOQ89ecqC4FebWh9X8rY105fhwWuXwaoh5wBu3RFJj\nerduBBQGHen+b0d1AAtdaH4/fP1VQ6tKfPU2MXyLmaA8ubnxXwWuCEgr3H2Jj6FH\npi9en4NH7foo01n84ZPTyPhb68SmuHgsbfD/2eIzSUYGeab8Fo985gWcii+P/yPy\n2vre9buc6ezsmpIRiMMdfwJlRS+fwrleJGgSzf7xilQJX9uimUNnlrH+zJkm8Jmm\n2ltwEjsoH/2mGHlv8Z8LQ5lViz4ztYy1KUy2yeZ/CQPZwzkgg1MwKQ/8AAigMMD8\nOAjE/6ZbFcsVIIV0R+8HOZW9mrvZO7Av7l6giWatNI21/m2V5+MzW/201LpX11OL\nxW+L6R1TSpdNeQhl5p1iPM0QXhXrQnITTR4x505HeVI9qPapi4QN3sPaNgCw1BJ2\n1vC3tYtizeJulJRAJybPJTNQ5BXhjkff4D1WVsonV/sTAgMBAAE=\n-----END PUBLIC KEY-----\n"
        },
        "scheme": "rsassa-pss-sha256"
      }
    },
    "roles": {
      "timestamp": {
        "keyids": [],
        "threshold": 1
      },
      "root": {
        "keyids": [
          "420d8813216cf5e6f9d7446591d0fcc0d978f8f1e8fb8a1a61d95dc49e00d6fa",
          "2bf157f0eb68996fa0098eef0059127810d4ab302d631583aae224df81567c5f"
        ],
        "threshold": 2
      },
      "targets": {
        "keyids": [],
        "threshold": 1
      },
      "snapshot": {
        "keyids": [],
        "threshold": 1
      }
    }
  },
  "signatures": []
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
