### PR TITLE
tuftool: Allow specifying version in `root init`

### DIFF
--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -176,6 +176,46 @@ fn create_root() {
 }
 
 #[test]
+fn create_root_to_version() {
+    let out_dir = TempDir::new().unwrap();
+    let root_json = out_dir.path().join("root.json");
+    let version = NonZeroU64::new(99).unwrap();
+
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args([
+            "root",
+            "init",
+            root_json.to_str().unwrap(),
+            "--version",
+            "99",
+        ])
+        .assert()
+        .success();
+
+    // validate version number
+    assert_eq!(get_version(root_json.to_str().unwrap()), version);
+}
+
+#[test]
+fn create_root_invalid_version() {
+    let out_dir = TempDir::new().unwrap();
+    let root_json = out_dir.path().join("root.json");
+
+    Command::cargo_bin("tuftool")
+        .unwrap()
+        .args([
+            "root",
+            "init",
+            root_json.to_str().unwrap(),
+            "--version",
+            "0",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
 // Ensure creating an unstable root throws error
 fn create_unstable_root() {
     let out_dir = TempDir::new().unwrap();
@@ -351,13 +391,13 @@ fn set_version_root() {
     initialize_root_json(root_json.to_str().unwrap());
     let version = NonZeroU64::new(5).unwrap();
 
-    //set version to 5
+    // set version to 5
     Command::cargo_bin("tuftool")
         .unwrap()
         .args(["root", "set-version", root_json.to_str().unwrap(), "5"])
         .assert()
         .success();
 
-    //validate version number
+    // validate version number
     assert_eq!(get_version(root_json.to_str().unwrap()), version);
 }


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

A new repo is created by calling `tuftool root init <path>`. It is a common pattern when renewing an expiring root to then have to call `tuftool root bump-version` multiple times or `tuftool root set-version`.

Since this is so common, this change makes it possible to provide an optional initial version to `root init` to avoid needing to run multiple commmands. This adds an optional `--version` argument that can take a positive integer to set as the initial root version.

**Testing done:**

- [x] Unit tests added covering success and failure cases.
- [x] Viewed `tuftool root init --help` output and verified correct help information
- [x] Ran normal `tuftool root init test.json` and verified created successfully with the normal initial version of 1
- [x] Ran `tuftool root init --version 5 test.json` and verified created successfully with initial version set to 5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
