### PR TITLE
tuftool: trivial unit test cleanup

### DIFF
--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -136,15 +136,7 @@ fn get_sign_len(root_json: &str) -> usize {
 
 fn check_signature_exists(root_json: &str, key_id: Decoded<Hex>) -> bool {
     let root = get_signed_root(root_json);
-    if root
-        .signatures
-        .iter()
-        .find(|sig| sig.keyid == key_id)
-        .is_none()
-    {
-        return false;
-    }
-    true
+    root.signatures.iter().any(|sig| sig.keyid == key_id)
 }
 
 fn get_version(root_json: &str) -> NonZeroU64 {


### PR DESCRIPTION
*Description of changes:*

Addresses a warning from `cargo clippy --test` where a check being used in the unit tests could be simplified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
