### PR TITLE
Fix up path prefix check for windows

### DIFF
--- a/tough/src/target_name.rs
+++ b/tough/src/target_name.rs
@@ -137,7 +137,7 @@ fn clean_name(name: &str) -> Result<String> {
                 .context(error::TargetNameComponentsEmptySnafu { name })?
                 .as_os_str();
 
-            // If the first component isn't the main separator ( unix `/`, windows '\' ) 
+            // If the first component isn't the main separator ( unix `/`, windows '\' )
             // then there is a bug or behavior change in absolutize_from.
             ensure!(
                 first_component == std::path::MAIN_SEPARATOR_STR,

--- a/tough/src/target_name.rs
+++ b/tough/src/target_name.rs
@@ -137,10 +137,10 @@ fn clean_name(name: &str) -> Result<String> {
                 .context(error::TargetNameComponentsEmptySnafu { name })?
                 .as_os_str();
 
-            // If the first component isn't `/` then there is a bug or behavior change in
+            // If the first component isn't the main separator ( unix `/`, windows '\' ) then there is a bug or behavior change in
             // absolutize_from.
             ensure!(
-                first_component == "/",
+                first_component == std::path::MAIN_SEPARATOR_STR,
                 error::TargetNameRootMissingSnafu { name }
             );
 

--- a/tough/src/target_name.rs
+++ b/tough/src/target_name.rs
@@ -137,8 +137,8 @@ fn clean_name(name: &str) -> Result<String> {
                 .context(error::TargetNameComponentsEmptySnafu { name })?
                 .as_os_str();
 
-            // If the first component isn't the main separator ( unix `/`, windows '\' ) then there is a bug or behavior change in
-            // absolutize_from.
+            // If the first component isn't the main separator ( unix `/`, windows '\' ) 
+            // then there is a bug or behavior change in absolutize_from.
             ensure!(
                 first_component == std::path::MAIN_SEPARATOR_STR,
                 error::TargetNameRootMissingSnafu { name }


### PR DESCRIPTION
*Issue #, if available:*

#347 (somewhat, I think)

*Description of changes:*

When loading a repository, the absolutized path will start with \ instead of /, so I changed It to use `std::path::MAIN_SEPARATOR_STR`. This allows me to use the Repository struct on Windows properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
