### PR TITLE
print detailed SDK errors for KMS and SSM

### DIFF
--- a/tough-kms/src/error.rs
+++ b/tough-kms/src/error.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::default_trait_access)]
 
 use snafu::{Backtrace, Snafu};
+use std::error::Error as _;
 
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -31,7 +32,7 @@ pub enum Error {
     "Failed to get public key for aws-kms://{}/{} : {}",
     profile.as_deref().unwrap_or(""),
     key_id,
-    source,
+    source.source().map_or("unknown".to_string(), std::string::ToString::to_string),
     ))]
     KmsGetPublicKey {
         profile: Option<String>,
@@ -50,7 +51,11 @@ pub enum Error {
     PublicKeyParse { source: tough::schema::Error },
 
     /// The library failed to get the message signature from AWS KMS
-    #[snafu(display("Error while signing message for aws-kms://{}/{} : {}", profile.as_deref().unwrap_or(""), key_id, source))]
+    #[snafu(display("Error while signing message for aws-kms://{}/{} : {}",
+    profile.as_deref().unwrap_or(""),
+    key_id,
+    source.source().map_or("unknown".to_string(), std::string::ToString::to_string)
+    ))]
     KmsSignMessage {
         key_id: String,
         profile: Option<String>,

--- a/tough-ssm/src/error.rs
+++ b/tough-ssm/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use snafu::{Backtrace, Snafu};
+use std::error::Error as _;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -29,7 +30,7 @@ pub enum Error {
         "Failed to get aws-ssm://{}{}: {}",
         profile.as_deref().unwrap_or(""),
         parameter_name,
-        source,
+        source.source().map_or("unknown".to_string(), std::string::ToString::to_string),
     ))]
     SsmGetParameter {
         profile: Option<String>,
@@ -54,7 +55,7 @@ pub enum Error {
         "Failed to put aws-ssm://{}{}: {}",
         profile.as_deref().unwrap_or(""),
         parameter_name,
-        source,
+        source.source().map_or("unknown".to_string(), std::string::ToString::to_string),
     ))]
     SsmPutParameter {
         profile: Option<String>,


### PR DESCRIPTION
**Issue #, if available:**
Fixes #661 

**Description of changes:**
Call `Error::source` on SDK errors to print more details about the underlying cause.

**Testing:**
Before:
```
$ tuftool root add-key 99.root.json -k aws-kms://my-key-account/alias/foo -r root
Unable to parse keypair: Failed to get public key for aws-kms://my-key-account/alias/foo : failed to construct request
```

After:
```
$ tuftool root add-key 99.root.json -k aws-kms://my-key-account/alias/foo -r root
Unable to parse keypair: Failed to get public key for aws-kms://my-key-account/alias/foo : failed to load credentials from the credentials cache
```

**Terms of contribution:**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
