### PR TITLE
clippy: Fix new lints with 1.72.0

### DIFF
--- a/tough-kms/src/lib.rs
+++ b/tough-kms/src/lib.rs
@@ -71,7 +71,7 @@ impl fmt::Debug for KmsKeySource {
         f.debug_struct("KmsKeySource")
             .field("key_id", &self.key_id)
             .field("profile", &self.profile)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -163,7 +163,7 @@ impl fmt::Debug for KmsRsaKey {
             .field("key_id", &self.key_id)
             .field("signing_algorithm", &self.signing_algorithm)
             .field("public_key", &self.public_key)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -41,7 +41,7 @@ impl Repository {
 
         // Fetch targets and save them to the outdir
         if let Some(target_list) = targets_subset {
-            for raw_name in target_list.iter() {
+            for raw_name in target_list {
                 let target_name = TargetName::new(raw_name.as_ref())?;
                 self.cache_target(&targets_outdir, &target_name)?;
             }

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -300,7 +300,7 @@ impl TargetsEditor {
                     delegated_role.keyids.extend(keyids.clone());
                 }
             }
-            for delegated_role in self.new_roles.get_or_insert(Vec::new()).iter_mut() {
+            for delegated_role in &mut *self.new_roles.get_or_insert(Vec::new()) {
                 if delegated_role.name == role {
                     delegated_role.keyids.extend(keyids.clone());
                 }

--- a/tough/src/target_name.rs
+++ b/tough/src/target_name.rs
@@ -258,7 +258,7 @@ fn resolved_8() {
 
 #[test]
 fn uncleaned_1() {
-    let name = r#"~/\.\."#;
+    let name = r"~/\.\.";
     let actual = clean_name(name).unwrap();
     let expected = name;
     assert_eq!(expected, &actual);
@@ -266,7 +266,7 @@ fn uncleaned_1() {
 
 #[test]
 fn uncleaned_2() {
-    let name = r#"funky\/\.\.\/name"#;
+    let name = r"funky\/\.\.\/name";
     let actual = clean_name(name).unwrap();
     let expected = name;
     assert_eq!(expected, &actual);

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -92,7 +92,7 @@ fn add_keys_all_roles(keys: Vec<&str>, root_json: &str) {
     add_key_root(&keys, root_json);
 
     // Only add the first key for the rest until we have tests that want it for all keys
-    let key = keys.get(0).unwrap();
+    let key = keys.first().unwrap();
     add_key_timestamp(key, root_json);
     add_key_snapshot(key, root_json);
     add_key_targets(key, root_json);


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The new rust clippy enforces more lints. This addresses warnings that will be flagged with the new 1.72.0 toolchain.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
