### PR TITLE
build(deps): bump clap from 3.2.25 to 4.3.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,17 +139,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -537,12 +575,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -652,42 +684,50 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "indexmap",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation"
@@ -1093,15 +1133,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1298,6 +1329,17 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itertools"
@@ -1522,7 +1564,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1604,12 +1646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,7 +1686,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3127afbfc30b4cad60c34aeb741fb562a808642b81142bcf4afb73142da960"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "serde",
 ]
 
@@ -1873,7 +1909,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1991,7 +2027,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64",
 ]
 
 [[package]]
@@ -2291,12 +2327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,7 +2531,7 @@ dependencies = [
  "aws-sdk-kms",
  "aws-smithy-client",
  "aws-smithy-http",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "http",
  "pem",
@@ -2723,6 +2753,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -20,7 +20,7 @@ aws-config = "0.55"
 aws-sdk-kms = "0.28"
 aws-sdk-ssm = "0.28"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 hex = "0.4"
 log = "0.4"
 maplit = "1"

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -12,43 +12,42 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use tough::editor::targets::TargetsEditor;
-use tough::key_source::KeySource;
 use url::Url;
 
 #[derive(Debug, Parser)]
 pub(crate) struct AddKeyArgs {
-    /// Key files to sign with
-    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
-    keys: Vec<Box<dyn KeySource>>,
-
-    /// New keys to be used for role
-    #[clap(long = "new-key", required = true, parse(try_from_str = parse_key_source))]
-    new_keys: Vec<Box<dyn KeySource>>,
+    /// The role for the keys to be added to
+    #[arg(long)]
+    delegated_role: Option<String>,
 
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
-    #[clap(short = 'e', long = "expires", parse(try_from_str = parse_datetime))]
+    #[arg(short, long, value_parser = parse_datetime)]
     expires: DateTime<Utc>,
 
-    /// Version of role file
-    #[clap(short = 'v', long = "version")]
-    version: NonZeroU64,
+    /// Key files to sign with
+    #[arg(short, long = "key", required = true)]
+    keys: Vec<String>,
 
-    /// Path to root.json file for the repository
-    #[clap(short = 'r', long = "root")]
-    root: PathBuf,
+    /// New keys to be used for role
+    #[arg(long = "new-key", required = true)]
+    new_keys: Vec<String>,
 
     /// TUF repository metadata base URL
-    #[clap(short = 'm', long = "metadata-url")]
+    #[arg(short, long = "metadata-url")]
     metadata_base_url: Url,
 
     /// The directory where the repository will be written
-    #[clap(short = 'o', long = "outdir")]
+    #[arg(short, long)]
     outdir: PathBuf,
 
-    /// The role for the keys to be added to
-    #[clap(long = "delegated-role")]
-    delegated_role: Option<String>,
+    /// Path to root.json file for the repository
+    #[arg(short, long)]
+    root: PathBuf,
+
+    /// Version of role file
+    #[arg(short, long)]
+    version: NonZeroU64,
 }
 
 impl AddKeyArgs {
@@ -67,7 +66,8 @@ impl AddKeyArgs {
         // create the keypairs to add
         let mut key_pairs = HashMap::new();
         for source in &self.new_keys {
-            let key_pair = source
+            let key_source = parse_key_source(source)?;
+            let key_pair = key_source
                 .as_sign()
                 .context(error::KeyPairFromKeySourceSnafu)?
                 .tuf_key();
@@ -79,12 +79,19 @@ impl AddKeyArgs {
                 key_pair,
             );
         }
+
+        let mut keys = Vec::new();
+        for source in &self.keys {
+            let key_source = parse_key_source(source)?;
+            keys.push(key_source);
+        }
+
         let updated_role = editor
             .add_key(key_pairs, self.delegated_role.as_deref())
             .context(error::LoadMetadataSnafu)?
             .version(self.version)
             .expires(self.expires)
-            .sign(&self.keys)
+            .sign(&keys)
             .context(error::SignRepoSnafu)?;
         let metadata_destination_out = &self.outdir.join("metadata");
         updated_role

--- a/tuftool/src/clone.rs
+++ b/tuftool/src/clone.rs
@@ -14,49 +14,45 @@ use url::Url;
 
 #[derive(Debug, Parser)]
 pub(crate) struct CloneArgs {
-    /// Path to root.json file for the repository
-    #[clap(
-        short = 'r',
-        long = "root",
-        required_if("allow-root-download", "false")
-    )]
-    root: Option<PathBuf>,
-
-    /// Remote root.json version number
-    #[clap(short = 'v', long = "root-version", default_value = "1")]
-    root_version: NonZeroU64,
-
-    /// TUF repository metadata base URL
-    #[clap(short = 'm', long = "metadata-url")]
-    metadata_base_url: Url,
-
-    /// TUF repository targets base URL
-    #[clap(short = 't', long = "targets-url", required_unless = "metadata-only")]
-    targets_base_url: Option<Url>,
-
-    /// Allow downloading the root.json file (unsafe)
-    #[clap(long)]
-    allow_root_download: bool,
-
     /// Allow repo download for expired metadata (unsafe)
-    #[clap(long)]
+    #[arg(long)]
     allow_expired_repo: bool,
 
-    /// Download only these targets, if specified
-    #[clap(short = 'n', long = "target-names", conflicts_with = "metadata-only")]
-    target_names: Vec<String>,
-
-    /// Output directory of targets
-    #[clap(long, required_unless = "metadata-only")]
-    targets_dir: Option<PathBuf>,
+    /// Allow downloading the root.json file (unsafe)
+    #[arg(long)]
+    allow_root_download: bool,
 
     /// Output directory of metadata
-    #[clap(long)]
+    #[arg(long)]
     metadata_dir: PathBuf,
 
     /// Only download the repository metadata, not the targets
-    #[clap(long, conflicts_with_all(&["target-names", "targets-dir", "targets-base-url"]))]
+    #[arg(long, conflicts_with_all(&["target_names", "targets_dir", "targets_base_url"]))]
     metadata_only: bool,
+
+    /// TUF repository metadata base URL
+    #[arg(short, long = "metadata-url")]
+    metadata_base_url: Url,
+
+    /// Path to root.json file for the repository
+    #[arg(short, long, required_if_eq("allow_root_download", "false"))]
+    root: Option<PathBuf>,
+
+    /// Download only these targets, if specified
+    #[arg(short = 'n', long, conflicts_with = "metadata_only")]
+    target_names: Vec<String>,
+
+    /// Output directory of targets
+    #[arg(long, required_unless_present = "metadata_only")]
+    targets_dir: Option<PathBuf>,
+
+    /// TUF repository targets base URL
+    #[arg(short, long = "targets-url", required_unless_present = "metadata_only")]
+    targets_base_url: Option<Url>,
+
+    /// Remote root.json version number
+    #[arg(short = 'v', long, default_value = "1")]
+    root_version: NonZeroU64,
 }
 
 #[rustfmt::skip]

--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -12,54 +12,11 @@ use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use tough::editor::signed::PathExists;
 use tough::editor::RepositoryEditor;
-use tough::key_source::KeySource;
 
 #[derive(Debug, Parser)]
 pub(crate) struct CreateArgs {
-    /// Key files to sign with
-    #[clap(short = 'k', long = "key", required = true, parse(try_from_str = parse_key_source))]
-    keys: Vec<Box<dyn KeySource>>,
-
-    /// Version of snapshot.json file
-    #[clap(long = "snapshot-version")]
-    snapshot_version: NonZeroU64,
-    /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
-    /// 7 days'
-    #[clap(long = "snapshot-expires", parse(try_from_str = parse_datetime))]
-    snapshot_expires: DateTime<Utc>,
-
-    /// Version of targets.json file
-    #[clap(long = "targets-version")]
-    targets_version: NonZeroU64,
-    /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
-    /// 7 days'
-    #[clap(long = "targets-expires", parse(try_from_str = parse_datetime))]
-    targets_expires: DateTime<Utc>,
-
-    /// Version of timestamp.json file
-    #[clap(long = "timestamp-version")]
-    timestamp_version: NonZeroU64,
-    /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
-    /// 7 days'
-    #[clap(long = "timestamp-expires", parse(try_from_str = parse_datetime))]
-    timestamp_expires: DateTime<Utc>,
-
-    /// Path to root.json file for the repository
-    #[clap(short = 'r', long = "root")]
-    root: PathBuf,
-
-    /// Directory of targets
-    #[clap(short = 't', long = "add-targets")]
-    targets_indir: PathBuf,
-
-    /// Behavior when a target exists with the same name and hash in the targets directory,
-    /// for example from another repository when they share a targets directory.
-    /// Options are "replace", "fail", and "skip"
-    #[clap(long = "target-path-exists", default_value = "skip")]
-    target_path_exists: PathExists,
-
     /// Follow symbolic links in the given directory when adding targets
-    #[clap(short = 'f', long = "follow")]
+    #[arg(short, long)]
     follow: bool,
 
     /// Number of target hashing threads to run when adding targets
@@ -67,16 +24,67 @@ pub(crate) struct CreateArgs {
     // No default is specified in structopt here. This is because rayon
     // automatically spawns the same number of threads as cores when any
     // of its parallel methods are called.
-    #[clap(short = 'j', long = "jobs")]
+    #[arg(short, long)]
     jobs: Option<NonZeroUsize>,
 
+    /// Key files to sign with
+    #[arg(short, long = "key", required = true)]
+    keys: Vec<String>,
+
     /// The directory where the repository will be written
-    #[clap(short = 'o', long = "outdir")]
+    #[arg(short, long)]
     outdir: PathBuf,
+
+    /// Path to root.json file for the repository
+    #[arg(short, long)]
+    root: PathBuf,
+
+    /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[arg(long, value_parser = parse_datetime)]
+    snapshot_expires: DateTime<Utc>,
+
+    /// Version of snapshot.json file
+    #[arg(long)]
+    snapshot_version: NonZeroU64,
+
+    /// Directory of targets
+    #[arg(short, long = "add-targets")]
+    targets_indir: PathBuf,
+
+    /// Behavior when a target exists with the same name and hash in the targets directory,
+    /// for example from another repository when they share a targets directory.
+    /// Options are "replace", "fail", and "skip"
+    #[arg(long, default_value = "skip")]
+    target_path_exists: PathExists,
+
+    /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[arg(long, value_parser = parse_datetime)]
+    targets_expires: DateTime<Utc>,
+
+    /// Version of targets.json file
+    #[arg(long)]
+    targets_version: NonZeroU64,
+
+    /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
+    /// 7 days'
+    #[arg(long, value_parser = parse_datetime)]
+    timestamp_expires: DateTime<Utc>,
+
+    /// Version of timestamp.json file
+    #[arg(long)]
+    timestamp_version: NonZeroU64,
 }
 
 impl CreateArgs {
     pub(crate) fn run(&self) -> Result<()> {
+        let mut keys = Vec::new();
+        for source in &self.keys {
+            let key_source = parse_key_source(source)?;
+            keys.push(key_source);
+        }
+
         // If a user specifies job count we override the default, which is
         // the number of cores.
         if let Some(jobs) = self.jobs {
@@ -106,7 +114,7 @@ impl CreateArgs {
                 .context(error::DelegationStructureSnafu)?;
         }
 
-        let signed_repo = editor.sign(&self.keys).context(error::SignRepoSnafu)?;
+        let signed_repo = editor.sign(&keys).context(error::SignRepoSnafu)?;
 
         let metadata_dir = &self.outdir.join("metadata");
         let targets_outdir = &self.outdir.join("targets");

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -13,36 +13,36 @@ use url::Url;
 
 #[derive(Debug, Parser)]
 pub(crate) struct DownloadArgs {
-    /// Path to root.json file for the repository
-    #[clap(short = 'r', long = "root")]
-    root: Option<PathBuf>,
-
-    /// Remote root.json version number
-    #[clap(short = 'v', long = "root-version", default_value = "1")]
-    root_version: NonZeroU64,
-
-    /// TUF repository metadata base URL
-    #[clap(short = 'm', long = "metadata-url")]
-    metadata_base_url: Url,
-
-    /// TUF repository targets base URL
-    #[clap(short = 't', long = "targets-url")]
-    targets_base_url: Url,
+    /// Allow repo download for expired metadata
+    #[clap(long)]
+    allow_expired_repo: bool,
 
     /// Allow downloading the root.json file (unsafe)
     #[clap(long)]
     allow_root_download: bool,
 
+    /// TUF repository metadata base URL
+    #[clap(short, long = "metadata-url")]
+    metadata_base_url: Url,
+
     /// Download only these targets, if specified
     #[clap(short = 'n', long = "target-name")]
     target_names: Vec<String>,
 
+    /// Path to root.json file for the repository
+    #[clap(short, long)]
+    root: Option<PathBuf>,
+
+    /// TUF repository targets base URL
+    #[clap(short, long = "targets-url")]
+    targets_base_url: Url,
+
     /// Output directory for targets (will be created and must not already exist)
     outdir: PathBuf,
 
-    /// Allow repo download for expired metadata
-    #[clap(long)]
-    allow_expired_repo: bool,
+    /// Remote root.json version number
+    #[clap(short = 'v', long, default_value = "1")]
+    root_version: NonZeroU64,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(path: P) {

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -50,12 +50,7 @@ static SPEC_VERSION: &str = "1.0.0";
 #[derive(Parser)]
 struct Program {
     /// Set logging verbosity [trace|debug|info|warn|error]
-    #[clap(
-        name = "log-level",
-        short = 'l',
-        long = "log-level",
-        default_value = "info"
-    )]
+    #[clap(name = "log-level", short, long, default_value = "info")]
     log_level: LevelFilter,
     #[clap(subcommand)]
     cmd: Command,
@@ -79,21 +74,21 @@ impl Program {
 
 #[derive(Debug, Parser)]
 enum Command {
+    /// Clone a TUF repository, including metadata and some or all targets
+    Clone(clone::CloneArgs),
     /// Create a TUF repository
     Create(create::CreateArgs),
+    /// Delegation Commands
+    Delegation(Delegation),
     /// Download a TUF repository's targets
     Download(download::DownloadArgs),
-    /// Update a TUF repository's metadata and optionally add targets
-    Update(Box<update::UpdateArgs>),
     /// Manipulate a root.json metadata file
     #[clap(subcommand)]
     Root(root::Command),
-    /// Delegation Commands
-    Delegation(Delegation),
-    /// Clone a TUF repository, including metadata and some or all targets
-    Clone(clone::CloneArgs),
     /// Transfer a TUF repository's metadata from a previous root to a new root
     TransferMetadata(transfer_metadata::TransferMetadataArgs),
+    /// Update a TUF repository's metadata and optionally add targets
+    Update(Box<update::UpdateArgs>),
 }
 
 impl Command {
@@ -177,7 +172,7 @@ fn process_target(path: &Path) -> Result<(TargetName, Target)> {
 }
 
 fn main() -> ! {
-    std::process::exit(match Program::from_args().run() {
+    std::process::exit(match Program::parse().run() {
         Ok(()) => 0,
         Err(err) => {
             eprintln!("{err}");
@@ -211,18 +206,18 @@ impl Delegation {
 
 #[derive(Debug, Parser)]
 enum DelegationCommand {
-    /// Creates a delegated role
-    CreateRole(Box<create_role::CreateRoleArgs>),
-    /// Add delegated role
-    AddRole(Box<add_role::AddRoleArgs>),
-    /// Update Delegated targets
-    UpdateDelegatedTargets(Box<update_targets::UpdateTargetsArgs>),
     /// Add a key to a delegated role
     AddKey(Box<add_key_role::AddKeyArgs>),
-    /// Remove a key from a delegated role
-    RemoveKey(Box<remove_key_role::RemoveKeyArgs>),
+    /// Add delegated role
+    AddRole(Box<add_role::AddRoleArgs>),
+    /// Creates a delegated role
+    CreateRole(Box<create_role::CreateRoleArgs>),
     /// Remove a role
     Remove(Box<remove_role::RemoveRoleArgs>),
+    /// Remove a key from a delegated role
+    RemoveKey(Box<remove_key_role::RemoveKeyArgs>),
+    /// Update Delegated targets
+    UpdateDelegatedTargets(Box<update_targets::UpdateTargetsArgs>),
 }
 
 impl DelegationCommand {


### PR DESCRIPTION
Alternative to #652

Bumps [clap](https://github.com/clap-rs/clap) from 3.2.25 to 4.3.21.
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/v3.2.25...v4.3.21)

---
updated-dependencies:
- dependency-name: clap dependency-type: direct:production update-type: version-update:semver-major ...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
