### PR TITLE
deps: Clean up base64 references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,12 +537,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -1650,7 +1644,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3127afbfc30b4cad60c34aeb741fb562a808642b81142bcf4afb73142da960"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "serde",
 ]
 
@@ -1873,7 +1867,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
- "base64 0.21.2",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1991,7 +1985,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64",
 ]
 
 [[package]]
@@ -2501,7 +2495,7 @@ dependencies = [
  "aws-sdk-kms",
  "aws-smithy-client",
  "aws-smithy-http",
- "base64 0.21.2",
+ "base64",
  "bytes",
  "http",
  "pem",

--- a/deny.toml
+++ b/deny.toml
@@ -63,8 +63,6 @@ wildcards = "deny"
 skip = [
     # num_cpus and clap is using old versions of hermit-abi
     { name = "hermit-abi" },
-    # pem and using an old version of base64
-    { name = "base64", version = "=0.13.1" },
     # globset is using an old version of aho-corasick
     { name = "aho-corasick", version = "=0.7.20" },
     # clap and other crates use an old version of syn

--- a/tough-kms/tests/all_test.rs
+++ b/tough-kms/tests/all_test.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 mod test_utils;
+use base64::engine::general_purpose::STANDARD as base64_engine;
+use base64::Engine as _;
 use ring::rand::SystemRandom;
 use serde::{Deserialize, Deserializer};
 use std::fs::File;
@@ -16,7 +18,7 @@ where
     D: Deserializer<'de>,
 {
     let s = <String>::deserialize(deserializer)?;
-    let b = base64::decode(s).unwrap();
+    let b = base64_engine.decode(s).unwrap();
     Ok(b.into())
 }
 


### PR DESCRIPTION
*Description of changes:*

With the recent upgrades of pem and base64 being done in two different PRs, there were a few leftover things to clean up related to base64.

The Cargo.lock file still has a reference to base64 0.13.1. With both pem and base64 updated, there actually wasn't anything referencing this version anymore and any references to 0.13.1 should be removed from the lock file.

With the newer pem dependency, there is not a transient dependency to the older base64 being pulled in. The cargo deny configuration still had a reference to this older version that is no longer needed.

There have also been some minor changes in how encode/decode are called with the base64 library. A deprecated method was still being used. That is now updated to the preferred/non-deprecated method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
