### PR TITLE
tough: make RetryStream private

### DIFF
--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -162,7 +162,7 @@ impl std::fmt::Debug for RequestState {
 }
 
 #[derive(Debug)]
-pub(crate) struct RetryStream {
+struct RetryStream {
     retry_state: RetryState,
     settings: HttpTransportBuilder,
     url: Url,
@@ -192,7 +192,7 @@ impl Stream for RetryStream {
 }
 
 impl RetryStream {
-    pub fn poll_err<E>(&mut self, error: E) -> Poll<Option<Result<bytes::Bytes, TransportError>>>
+    fn poll_err<E>(&mut self, error: E) -> Poll<Option<Result<bytes::Bytes, TransportError>>>
     where
         E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {


### PR DESCRIPTION


*Issue #, if available:*

Closes #698 

*Description of changes:*

The RetryStream object does not need to be exported outside of the http.rs module.

*Testing*

It compiles!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
