### PR TITLE
Fix publish issue

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,8 +73,6 @@ skip = [
     { name = "fastrand", version = "=1.9" },
     # several dependencies are using an old version of bitflags
     { name = "bitflags", version = "=1.3" },
-    # transient dependencies are using an older versions of regex-automata
-    { name = "regex-automata", version = "=0.1" },
     { name = "regex-automata", version = "=0.4" },
     # several dependencies are using an old version of socket2
     { name = "socket2", version = "=0.4" },

--- a/deny.toml
+++ b/deny.toml
@@ -59,6 +59,12 @@ license-files = [
 # Deny multiple versions or wildcard dependencies.
 multiple-versions = "deny"
 wildcards = "deny"
+# failure-server is an internal package used only in testing that we do not want to publish to
+# crates.io. When including it in tough's dev dependencies, it is necessary to do so without a
+# version number or else cargo publish will fail. The lack of a version number causes cargo deny
+# to ban failure-server as a wildcard-versioned dependency. The following line allows us to refer
+# to our own internal packages without a version number.
+allow-wildcard-paths = true
 
 skip = [
     # http-test is using an old version of bstr

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -37,7 +37,7 @@ url = "2"
 walkdir = "2"
 
 [dev-dependencies]
-failure-server = { path = "../integ/failure-server", version = "0.1" }
+failure-server = { path = "../integ/failure-server" }
 hex-literal = "0.4"
 httptest = "0.15"
 maplit = "1"


### PR DESCRIPTION
*Issue #, if available:*

#700 
Arises from #660, 967e02dfd19c74506111b22f600ef9cb360bc270

*Description of changes:*

```
    remove unused lines from deny.toml
```

```
    deny.toml: allow-wildcard-paths

    failure-server is an internal package used only in testing that we do
    not want to publish to crates.io. When including it in tough's dev-
    dependencies, it is necessary to do so without a version number or else
    cargo publish will fail. The lack of version number causes cargo deny
    to ban failure-server as a wildcard-versioned dependency. The following
    line allows us to refer to our own internal packages without a version
    number.
```

*Testing*

Used `cargo publish --dry-run` to verify this fixes the problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
