### PR TITLE
Add tuftool dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
-
 ## Security issue notifications
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 

--- a/tuftool/Dockerfile
+++ b/tuftool/Dockerfile
@@ -2,6 +2,6 @@
 
 FROM rust:slim
 RUN apt update && apt install -y openssl
-RUN cargo install --force tuftool
+RUN cargo install --force --locked tuftool
 RUN mkdir /share
 ENTRYPOINT ["tuftool"]

--- a/tuftool/Dockerfile
+++ b/tuftool/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:slim
+RUN apt update && apt install -y openssl
+RUN cargo install --force tuftool
+RUN mkdir /share
+ENTRYPOINT ["tuftool"]

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -135,6 +135,24 @@ tuftool download \
 
 `tuftool` respects the `HTTPS_PROXY` and `NO_PROXY` environment variables.
 
+## Container
+
+You can build a simple container image to avoid needing to install the Rust toolchain and dependencies or your local machine.
+
+To build the image run use Docker or Finch (same argument syntax, just replace `finch` for `docker`):
+
+```shell
+finch build -t tuftool .
+```
+
+To use tuftool, mount the host working directory to `/share`.
+
+For example, to mount the current directory for `download` you would do something like:
+
+```shell
+finch run -it -v $(pwd):/share tuftool download "/share/some_directory" ...
+```
+
 ## Testing
 
 Unit tests are run in the usual manner: `cargo test`.

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -139,10 +139,10 @@ tuftool download \
 
 You can build a simple container image to avoid needing to install the Rust toolchain and dependencies or your local machine.
 
-To build the image run use Docker or Finch (same argument syntax, just replace `finch` for `docker`):
+To build the image use Docker or Finch (same argument syntax, just replace 
+`docker` for `finch`):
 
 ```shell
-cd finch
 docker build -t tuftool .
 ```
 

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -142,7 +142,8 @@ You can build a simple container image to avoid needing to install the Rust tool
 To build the image run use Docker or Finch (same argument syntax, just replace `finch` for `docker`):
 
 ```shell
-finch build -t tuftool .
+cd finch
+docker build -t tuftool .
 ```
 
 To use tuftool, mount the host working directory to `/share`.

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -151,7 +151,7 @@ To use tuftool, mount the host working directory to `/share`.
 For example, to mount the current directory for `download` you would do something like:
 
 ```shell
-finch run -it -v $(pwd):/share tuftool download "/share/some_directory" ...
+docker run -it -v $(pwd):/share tuftool download "/share/some_directory" ...
 ```
 
 ## Testing


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This PR adds a very simple Dockerfile for `tuftool`

This solves a problem for Bottlerocket users who have been [challenged to download all the dependencies for tuftool just to get an image](https://github.com/bottlerocket-os/bottlerocket/discussions/2779). Additionally, this potentially avoids the need to create a cross compiled binary (see #662)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
