### PR TITLE
Exclude check-license workflows for non-Linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,11 @@ jobs:
       matrix:
         make_target: ["check-licenses", "build", "integ"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - os: windows-latest
+            make_target: check-licenses
+          - os: macos-latest
+            make_target: check-licenses
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

We now have a matrix job to ensure test coverage on all supported OS platforms. This also causes the `check-license` job to run on each OS.

The license check isn't platform specific, so this ends up being a little wasteful. This adds an exclude block to skip macOS and Windows since they are not needed and those particular OS's take longer to run than Linux.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
