### PR TITLE
tuftool: Add --version option

### DIFF
--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -48,6 +48,7 @@ static SPEC_VERSION: &str = "1.0.0";
 
 /// This wrapper enables global options and initializes the logger before running any subcommands.
 #[derive(Parser)]
+#[command(version)]
 struct Program {
     /// Set logging verbosity [trace|debug|info|warn|error]
     #[clap(name = "log-level", short, long, default_value = "info")]


### PR DESCRIPTION
*Issue #, if available:*

Closes #608

*Description of changes:*

This adds a `--version` to the `tuftool` command to print out the tool's version number.

```sh
$ tuftool --version
tuftool 0.10.1

$ tuftool --help
This wrapper enables global options and initializes the logger before running any subcommands

Usage: tuftool [OPTIONS] <COMMAND>

Commands:
  clone              Clone a TUF repository, including metadata and some or all targets
  create             Create a TUF repository
  delegation         Delegation Commands
  download           Download a TUF repository's targets
  root               Manipulate a root.json metadata file
  transfer-metadata  Transfer a TUF repository's metadata from a previous root to a new root
  update             Update a TUF repository's metadata and optionally add targets
  help               Print this message or the help of the given subcommand(s)

Options:
  -l, --log-level <log-level>  Set logging verbosity [trace|debug|info|warn|error] [default: info]
  -h, --help                   Print help
  -V, --version                Print version
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
