### PR TITLE
Release tough-v0.16.0 tuftool-v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "tough"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "tough-kms"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "tough-ssm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aws-config",
  "aws-sdk-ssm",
@@ -2789,7 +2789,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tuftool"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "assert_cmd",
  "aws-config",

--- a/tough-kms/CHANGELOG.md
+++ b/tough-kms/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2023-12-05
+
+### Changes
+- Dependency updates
+
 ## [0.7.0] - 2023-11-07
 
 ### Changes
@@ -123,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-kms-v0.7.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-kms-v0.8.0...develop
+[0.8.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.7.0...tough-kms-v0.8.0
 [0.7.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.6.0...tough-kms-v0.7.0
 [0.6.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.5.0...tough-kms-v0.6.0
 [0.5.0]: https://github.com/awslabs/tough/compare/tough-kms-v0.4.2...tough-kms-v0.5.0

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-kms"
-version = "0.7.0"
+version = "0.8.0"
 description = "Implements AWS KMS as a key source for TUF signing keys"
 authors = ["Shailesh Gothi <gothisg@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ aws-sdk-rust = ["aws-sdk-rust-rustls"]
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-kms/rustls"]
 
 [dependencies]
-tough = { version = "0.15", path = "../tough", features = ["http"] }
+tough = { version = "0.16", path = "../tough", features = ["http"] }
 ring = { version = "0.17", features = ["std"] }
 aws-sdk-kms = "0.36"
 aws-config = "0.57"

--- a/tough-ssm/CHANGELOG.md
+++ b/tough-ssm/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2023-12-06
+
+### Changes
+- Dependency updates
+
 ## [0.10.0] - 2023-11-07
 
 ### Changes
@@ -131,7 +136,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-ssm-v0.10.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-ssm-v0.11.0...develop
+[0.10.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.10.0...tough-ssm-v0.11.0
 [0.10.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.9.0...tough-ssm-v0.10.0
 [0.9.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.8.0...tough-ssm-v0.9.0
 [0.8.0]: https://github.com/awslabs/tough/compare/tough-ssm-v0.7.2...tough-ssm-v0.8.0

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough-ssm"
-version = "0.10.0"
+version = "0.11.0"
 description = "Implements AWS SSM as a key source for TUF signing keys"
 authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ aws-sdk-rust = ["aws-sdk-rust-rustls"]
 aws-sdk-rust-rustls = ["aws-config/rustls", "aws-sdk-ssm/rustls"]
 
 [dependencies]
-tough = { version = "0.15", path = "../tough", features = ["http"] }
+tough = { version = "0.16", path = "../tough", features = ["http"] }
 aws-sdk-ssm = "0.36"
 aws-config = "0.57"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2023-12-06
+### Changes
+- Dependency updates
+
 ## [0.15.0] - 2023-11-07
 ### Changes
 - ❗Breaking Change❗: Most public functions and traits have been changed to async, thanks @phu-cinemo  [#687]
@@ -247,7 +251,8 @@ For changes that require modification of calling code see #120 and #121.
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.15.0...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tough-v0.16.0...develop
+[0.15.0]: https://github.com/awslabs/tough/compare/tough-v0.15.0...tough-v0.16.0
 [0.15.0]: https://github.com/awslabs/tough/compare/tough-v0.14.0...tough-v0.15.0
 [0.14.0]: https://github.com/awslabs/tough/compare/tough-v0.13.0...tough-v0.14.0
 [0.13.0]: https://github.com/awslabs/tough/compare/tough-v0.12.5...tough-v0.13.0

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tough"
-version = "0.15.0"
+version = "0.16.0"
 description = "The Update Framework (TUF) repository client"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2023-12-06
+### Fixes
+- Fix a bug in `tuftool root gen-rsa-key` [#729]
+
+### Changes
+- Dependency updates.
+
+[#729]: https://github.com/awslabs/tough/pull/729
+
 ## [0.10.1] - 2023-11-07
 ### Changes
 - Dependency updates.
@@ -222,7 +231,8 @@ Major update: much of the logic in `tuftool` has been factored out and added to 
 ### Added
 - Everything!
 
-[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.10.1...develop
+[Unreleased]: https://github.com/awslabs/tough/compare/tuftool-v0.10.2...develop
+[0.10.2]: https://github.com/awslabs/tough/compare/tuftool-v0.10.1...tuftool-v0.10.2
 [0.10.1]: https://github.com/awslabs/tough/compare/tuftool-v0.10.0...tuftool-v0.10.1
 [0.10.0]: https://github.com/awslabs/tough/compare/tuftool-v0.9.0...tuftool-v0.10.0
 [0.9.0]: https://github.com/awslabs/tough/compare/tuftool-v0.8.2...tuftool-v0.9.0

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuftool"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utility for creating and signing The Update Framework (TUF) repositories"
 authors = ["iliana destroyer of worlds <iweller@amazon.com>"]
 license = "MIT OR Apache-2.0"
@@ -34,9 +34,9 @@ simplelog = "0.12"
 snafu = { version = "0.7", features = ["backtraces-impl-backtrace-crate"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
-tough = { version = "0.15", path = "../tough", features = ["http"] }
-tough-kms = { version = "0.7", path = "../tough-kms" }
-tough-ssm = { version = "0.10", path = "../tough-ssm" }
+tough = { version = "0.16", path = "../tough", features = ["http"] }
+tough-kms = { version = "0.8", path = "../tough-kms" }
+tough-ssm = { version = "0.11", path = "../tough-ssm" }
 url = "2"
 walkdir = "2"
 


### PR DESCRIPTION
Prepare a release.

`tuftool` v0.10.1 has an issue that needs to be fixed and the other releases are required to support it.