### PR TITLE
Resolve clap v4 deprecated api

### DIFF
--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -13,34 +13,34 @@ use url::Url;
 #[derive(Debug, Parser)]
 pub(crate) struct DownloadArgs {
     /// Allow repo download for expired metadata
-    #[clap(long)]
+    #[arg(long)]
     allow_expired_repo: bool,
 
     /// Allow downloading the root.json file (unsafe)
-    #[clap(long)]
+    #[arg(long)]
     allow_root_download: bool,
 
     /// TUF repository metadata base URL
-    #[clap(short, long = "metadata-url")]
+    #[arg(short, long = "metadata-url")]
     metadata_base_url: Url,
 
     /// Download only these targets, if specified
-    #[clap(short = 'n', long = "target-name")]
+    #[arg(short = 'n', long = "target-name")]
     target_names: Vec<String>,
 
     /// Path to root.json file for the repository
-    #[clap(short, long)]
+    #[arg(short, long)]
     root: Option<PathBuf>,
 
     /// TUF repository targets base URL
-    #[clap(short, long = "targets-url")]
+    #[arg(short, long = "targets-url")]
     targets_base_url: Url,
 
     /// Output directory for targets (will be created and must not already exist)
     outdir: PathBuf,
 
     /// Remote root.json version number
-    #[clap(short = 'v', long, default_value = "1")]
+    #[arg(short = 'v', long, default_value = "1")]
     root_version: NonZeroU64,
 }
 
@@ -137,4 +137,10 @@ async fn handle_download(
         download_target(target).await?;
     }
     Ok(())
+}
+
+#[test]
+fn verify_download_args_cli() {
+    use clap::CommandFactory;
+    DownloadArgs::command().debug_assert()
 }

--- a/tuftool/src/main.rs
+++ b/tuftool/src/main.rs
@@ -51,9 +51,9 @@ static SPEC_VERSION: &str = "1.0.0";
 #[command(version)]
 struct Program {
     /// Set logging verbosity [trace|debug|info|warn|error]
-    #[clap(name = "log-level", short, long, default_value = "info")]
+    #[arg(id = "log-level", short, long, default_value = "info")]
     log_level: LevelFilter,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Command,
 }
 
@@ -84,7 +84,7 @@ enum Command {
     /// Download a TUF repository's targets
     Download(download::DownloadArgs),
     /// Manipulate a root.json metadata file
-    #[clap(subcommand)]
+    #[command(subcommand)]
     Root(root::Command),
     /// Transfer a TUF repository's metadata from a previous root to a new root
     TransferMetadata(transfer_metadata::TransferMetadataArgs),
@@ -246,10 +246,10 @@ async fn main() -> ! {
 #[derive(Parser, Debug)]
 struct Delegation {
     /// The signing role
-    #[clap(long = "signing-role", required = true)]
+    #[arg(long = "signing-role", required = true)]
     role: String,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: DelegationCommand,
 }
 
@@ -286,4 +286,22 @@ impl DelegationCommand {
             DelegationCommand::Remove(args) => args.run(role).await,
         }
     }
+}
+
+#[test]
+fn verify_program_cli() {
+    use clap::CommandFactory;
+    Program::command().debug_assert()
+}
+
+#[test]
+fn verify_command_cli() {
+    use clap::CommandFactory;
+    Command::command().debug_assert()
+}
+
+#[test]
+fn verify_delegation_cli() {
+    use clap::CommandFactory;
+    Delegation::command().debug_assert()
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Checked deprecated api with `cargo check --features clap/deprecated`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
