### PR TITLE
fix: timestamp.json meta can has optional fields

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -96,7 +96,8 @@ impl Repository {
     {
         self.cache_file_from_transport(
             self.snapshot_filename().as_str(),
-            self.max_snapshot_size()?,
+            self.max_snapshot_size()?
+                .unwrap_or(self.limits.max_snapshot_size),
             "timestamp.json",
             &metadata_outdir,
         )
@@ -237,7 +238,7 @@ impl Repository {
     }
 
     /// Gets the max size of the snapshot.json file as specified by the timestamp file.
-    fn max_snapshot_size(&self) -> Result<u64> {
+    fn max_snapshot_size(&self) -> Result<Option<u64>> {
         let snapshot_meta =
             self.timestamp()
                 .signed

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -17,8 +17,8 @@ use crate::key_source::KeySource;
 use crate::schema::decoded::{Decoded, Hex};
 use crate::schema::key::Key;
 use crate::schema::{
-    Hashes, KeyHolder, PathSet, Role, RoleType, Root, Signed, Snapshot, SnapshotMeta, Target,
-    Targets, Timestamp, TimestampMeta,
+    Hashes, KeyHolder, Metafile, PathSet, Role, RoleType, Root, Signed, Snapshot, Target, Targets,
+    Timestamp,
 };
 use crate::transport::{IntoVec, Transport};
 use crate::{encode_filename, Limits};
@@ -700,13 +700,13 @@ impl RepositoryEditor {
         Ok(snapshot)
     }
 
-    /// Build a `SnapshotMeta` struct from a given `SignedRole<R>`. This metadata
+    /// Build a `Metafiles` struct from a given `SignedRole<R>`. This metadata
     /// includes the sha256 and length of the signed role.
-    fn snapshot_meta<R>(role: &SignedRole<R>) -> SnapshotMeta
+    fn snapshot_meta<R>(role: &SignedRole<R>) -> Metafile
     where
         R: Role,
     {
-        SnapshotMeta {
+        Metafile {
             hashes: Some(Hashes {
                 sha256: role.sha256.to_vec().into(),
                 _extra: HashMap::new(),
@@ -738,18 +738,18 @@ impl RepositoryEditor {
         Ok(timestamp)
     }
 
-    /// Build a `TimestampMeta` struct from a given `SignedRole<R>`. This metadata
+    /// Build a `Metafiles` struct from a given `SignedRole<R>`. This metadata
     /// includes the sha256 and length of the signed role.
-    fn timestamp_meta<R>(role: &SignedRole<R>) -> TimestampMeta
+    fn timestamp_meta<R>(role: &SignedRole<R>) -> Metafile
     where
         R: Role,
     {
-        TimestampMeta {
-            hashes: Hashes {
+        Metafile {
+            hashes: Some(Hashes {
                 sha256: role.sha256.to_vec().into(),
                 _extra: HashMap::new(),
-            },
-            length: role.length,
+            }),
+            length: Some(role.length),
             version: role.signed.signed.version(),
             _extra: HashMap::new(),
         }

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -256,11 +256,11 @@ pub struct Snapshot {
     /// Determines when metadata should be considered expired and no longer trusted by clients.
     pub expires: DateTime<Utc>,
 
-    /// A list of what the TUF spec calls 'METAFILES' (`SnapshotMeta` objects). The TUF spec
+    /// A list of what the TUF spec calls 'METAFILES' (`Metafiles` objects). The TUF spec
     /// describes the hash key in 4.4: METAPATH is the file path of the metadata on the repository
     /// relative to the metadata base URL. For snapshot.json, these are top-level targets metadata
     /// and delegated targets metadata.
-    pub meta: HashMap<String, SnapshotMeta>,
+    pub meta: HashMap<String, Metafile>,
 
     /// Extra arguments found during deserialization.
     ///
@@ -272,7 +272,7 @@ pub struct Snapshot {
     pub _extra: HashMap<String, Value>,
 }
 
-/// Represents a metadata file in a `snapshot.json` file.
+/// Represents a metadata file in a `snapshot.json` and in a `timestamp.json` file.
 /// TUF 4.4: METAFILES is an object whose format is the following:
 /// ```text
 ///  { METAPATH : {
@@ -292,7 +292,7 @@ pub struct Snapshot {
 ///    },
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SnapshotMeta {
+pub struct Metafile {
     /// LENGTH is the integer length in bytes of the metadata file at METAPATH. It is OPTIONAL and
     /// can be omitted to reduce the snapshot metadata file size. In that case the client MUST use a
     /// custom download limit for the listed metadata.
@@ -1112,7 +1112,7 @@ pub struct Timestamp {
 
     /// METAFILES is the same as described for the snapshot.json file. In the case of the
     /// timestamp.json file, this MUST only include a description of the snapshot.json file.
-    pub meta: HashMap<String, TimestampMeta>,
+    pub meta: HashMap<String, Metafile>,
 
     /// Extra arguments found during deserialization.
     ///
@@ -1121,29 +1121,6 @@ pub struct Timestamp {
     /// If you're instantiating this struct, you should make this `HashMap::empty()`.
     #[serde(flatten)]
     #[serde(deserialize_with = "de::extra_skip_type")]
-    pub _extra: HashMap<String, Value>,
-}
-
-/// METAFILES is the same as described for the snapshot.json file. In the case of the timestamp.json
-/// file, this MUST only include a description of the snapshot.json file.
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
-pub struct TimestampMeta {
-    /// The integer length in bytes of the snapshot.json file.
-    pub length: u64,
-
-    /// The hashes of the snapshot.json file.
-    pub hashes: Hashes,
-
-    /// An integer that is greater than 0. Clients MUST NOT replace a metadata file with a version
-    /// number less than the one currently trusted.
-    pub version: NonZeroU64,
-
-    /// Extra arguments found during deserialization.
-    ///
-    /// We must store these to correctly verify signatures for this object.
-    ///
-    /// If you're instantiating this struct, you should make this `HashMap::empty()`.
-    #[serde(flatten)]
     pub _extra: HashMap<String, Value>,
 }
 

--- a/tough/tests/interop.rs
+++ b/tough/tests/interop.rs
@@ -80,6 +80,7 @@ async fn test_tuf_reference_impl_default_transport() {
         max_root_size: 1000,
         max_targets_size: 2000,
         max_timestamp_size: 3000,
+        max_snapshot_size: 4000,
         max_root_updates: 1,
     })
     .datastore(datastore.path())


### PR DESCRIPTION
_Issue #, if available:_

Fixes issue https://github.com/awslabs/tough/issues/771

_Description of changes:_

According to the TUF specification, the `meta` attribute of
`timestamp.json` must follow the same specification of `METAFILES`.
That means it has optional `LENGTH` and `HASHES`.

See [this](https://theupdateframework.github.io/specification/latest/#file-formats-timestamp) section of the TUF specification.

I've handled a missing `LENGTH` and `HASHES` in the `timestamp.json` file using the same logic used by the library when loading targets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
