### PR TITLE
Bump rust to 1.78.0 in actions runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 
 env:
-  # From-scratch builds with incremental compilation enabled adds unneeded performance and disk overhead. 
+  # From-scratch builds with incremental compilation enabled adds unneeded performance and disk overhead.
   CARGO_INCREMENTAL: "0"
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
           key: ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ hashFiles('.github/cache_bust') }}-${{ runner.os }}-${{ matrix.make_target }}
-      - run: rustup default 1.76.0
+      - run: rustup default 1.78.0
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: make ${{ matrix.make_target }}

--- a/tough-kms/src/lib.rs
+++ b/tough-kms/src/lib.rs
@@ -61,7 +61,7 @@ pub struct KmsKeySource {
     pub profile: Option<String>,
     /// Identifies an asymmetric CMK in AWS KMS.
     pub key_id: String,
-    /// KmsClient Object to query AWS KMS
+    /// `KmsClient` Object to query AWS KMS
     pub client: Option<KmsClient>,
     /// Signing Algorithm to be used for the message digest, only `KmsSigningAlgorithm::RsassaPssSha256` is supported at present.
     pub signing_algorithm: KmsSigningAlgorithm,
@@ -146,7 +146,7 @@ pub struct KmsRsaKey {
     key_id: String,
     /// Aws account profile
     profile: Option<String>,
-    /// KmsClient Object to query AWS KMS
+    /// `KmsClient` Object to query AWS KMS
     client: Option<KmsClient>,
     /// Public Key corresponding to Customer Managed Key
     public_key: Decoded<RsaPem>,

--- a/tough/src/datastore.rs
+++ b/tough/src/datastore.rs
@@ -17,7 +17,7 @@ use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 pub(crate) struct Datastore {
     /// A lock around retrieving the datastore path.
     path_lock: Arc<RwLock<DatastorePath>>,
-    /// A lock to treat the system_time function as a critical section.
+    /// A lock to treat the `system_time` function as a critical section.
     time_lock: Arc<Mutex<()>>,
 }
 

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -612,7 +612,7 @@ pub enum Error {
         source: schema::Error,
     },
 
-    /// SignedDelegatedTargets has more than 1 signed targets
+    /// `SignedDelegatedTargets` has more than 1 signed targets
     #[snafu(display("Exactly 1 role was required, but {} were created", count))]
     InvalidRoleCount { count: usize },
 
@@ -620,7 +620,7 @@ pub enum Error {
     #[snafu(display("Could not create a targets map: {}", source))]
     TargetsMap { source: schema::Error },
 
-    /// A key_holder wasn't set
+    /// A `key_holder` wasn't set
     #[snafu(display("A key holder must be set"))]
     NoKeyHolder,
 

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -57,7 +57,7 @@ pub enum Key {
         #[serde(flatten)]
         _extra: HashMap<String, Value>,
     },
-    /// An EcdsaKey.
+    /// An Ecdsa key.
     Ecdsa {
         /// The Ecdsa key.
         keyval: EcdsaKey,
@@ -67,7 +67,7 @@ pub enum Key {
         #[serde(flatten)]
         _extra: HashMap<String, Value>,
     },
-    /// An EcdsaKey with the old key type.
+    /// An Ecdsa key with the old key type.
     #[serde(rename = "ecdsa-sha2-nistp256")]
     EcdsaOld {
         /// The Ecdsa key.

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::used_underscore_binding)] // #20
+#![allow(clippy::used_underscore_binding, clippy::pub_underscore_fields)] // #20
 
 //! Provides the schema objects as defined by the TUF spec.
 
@@ -61,7 +61,7 @@ derive_fromstr_from_deserialize!(RoleType);
 /// A role identifier
 #[derive(Debug, Clone)]
 pub enum RoleId {
-    /// Top level roles are identified by a RoleType
+    /// Top level roles are identified by a `RoleType`
     StandardRole(RoleType),
     /// A delegated role is identified by a String
     DelegatedRole(String),
@@ -898,12 +898,12 @@ pub enum PathSet {
     #[serde(rename = "paths")]
     Paths(Vec<PathPattern>),
 
-    /// The "path_hash_prefixes" list is used to succinctly describe a set of target paths.
-    /// Specifically, each HEX_DIGEST in "path_hash_prefixes" describes a set of target paths;
-    /// therefore, "path_hash_prefixes" is the union over each prefix of its set of target paths.
+    /// The `path_hash_prefixes` list is used to succinctly describe a set of target paths.
+    /// Specifically, each `HEX_DIGEST` in `path_hash_prefixes` describes a set of target paths;
+    /// therefore, `path_hash_prefixes` is the union over each prefix of its set of target paths.
     /// The target paths must meet this condition: each target path, when hashed with the SHA-256
-    /// hash function to produce a 64-byte hexadecimal digest (HEX_DIGEST), must share the same
-    /// prefix as one of the prefixes in "path_hash_prefixes". This is useful to split a large
+    /// hash function to produce a 64-byte hexadecimal digest (`HEX_DIGEST`), must share the same
+    /// prefix as one of the prefixes in `path_hash_prefixes`. This is useful to split a large
     /// number of targets into separate bins identified by consistent hashing.
     #[serde(rename = "path_hash_prefixes")]
     PathHashPrefixes(Vec<PathHashPrefix>),

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -127,9 +127,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Can't build URL from path '{}'", path.display()))]
-    FileUrl { path: PathBuf, backtrace: Backtrace },
-
     #[snafu(display("Failed to write to {}: {}", path.display(), source))]
     FileWrite {
         path: PathBuf,
@@ -295,25 +292,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to add targets from directory '{}': {}", dir.display(), source))]
-    TargetsFromDir {
-        dir: PathBuf,
-        source: tough::error::Error,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Target not found: {}", target))]
-    TargetNotFound {
-        target: String,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Failed to create temporary directory: {}", source))]
-    TempDir {
-        source: std::io::Error,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Unrecognized URL scheme \"{}\"", scheme))]
     UnrecognizedScheme {
         scheme: String,
@@ -370,12 +348,6 @@ pub(crate) enum Error {
     WriteRoles {
         roles: Vec<String>,
         source: tough::error::Error,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Failed writing target data to disk: {}", source))]
-    WriteTarget {
-        source: std::io::Error,
         backtrace: Backtrace,
     },
 


### PR DESCRIPTION
*Description of changes:*

Bumps rust to 1.78.0 and addresses the `clippy` warnings that came with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
