### PR TITLE
Fixing datetime tuf specification

### DIFF
--- a/tuftool/src/datetime.rs
+++ b/tuftool/src/datetime.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{self, Result};
 
-use chrono::{DateTime, FixedOffset, TimeDelta,Timelike, Utc};
+use chrono::{DateTime, FixedOffset, TimeDelta, Timelike, Utc};
 use snafu::{ensure, OptionExt, ResultExt};
 
 /// Parses a user-specified datetime, either in full RFC 3339 format, or a shorthand like "in 7

--- a/tuftool/src/datetime.rs
+++ b/tuftool/src/datetime.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{self, Result};
 
-use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
+use chrono::{DateTime, FixedOffset, TimeDelta,Timelike, Utc};
 use snafu::{ensure, OptionExt, ResultExt};
 
 /// Parses a user-specified datetime, either in full RFC 3339 format, or a shorthand like "in 7
@@ -71,6 +71,6 @@ pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
     };
 
     let now = Utc::now();
-    let then = now + duration;
+    let then = (now + duration).with_nanosecond(0).unwrap();
     Ok(then)
 }


### PR DESCRIPTION
*Issue #, if available:*
Currently when using `tuftool create` or `tuftool update`, the created metadata will have nanoseconds within the metadata datetime.
As you can see in the official tuf specifications [here](https://theupdateframework.github.io/specification/latest/#file-formats-date-time), ISO 8601 is the current standard by which it is "YYYY-MM-DDTHH:MM:SSZ".

*Description of changes:*
Right now, the concatenated datetime object results in an unwanted nanosecond ending so in this PR any nanosecond result on the datetime object is set to 0, effectively rounding it to the nearest second so it is in line with the tuf specs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
