### PR TITLE
ci: allow dispatching ci builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
       - "**.md"
       - ".github/dependabot.yml"
     branches: [develop]
+  workflow_dispatch:
 
 env:
   # From-scratch builds with incremental compilation enabled adds unneeded performance and disk overhead.


### PR DESCRIPTION
*Description of changes:*

This allows executing the build workflow via manual dispatch.

This should help to debug issues causing builds to occasionally fail on the macos runners ([e.g.](https://github.com/awslabs/tough/actions/runs/14539057318/job/40793241083))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
