### PR TITLE
github-actions: update Mac runners to macos-15

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         make_target: ["check-licenses", "build", "integ", "integ-fips"]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15]
         exclude:
           - os: windows-latest
             make_target: check-licenses
-          - os: macos-latest
+          - os: macos-15
             make_target: check-licenses
-          - os: macos-latest
+          - os: macos-15
             make_target: integ-fips
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I've been observing some strange test failures on the Mac runners on some of my recent PRs. The `tuftool clone` tests fail about 1 in every 10 runs, and every time it's because the `1.root.json` that was copied is actually just an empty file.

This hasn't happened on runners for any other OS, and when I tried to replicate it on my Mac that's running MacOS 15, I wasn't able to. Attempting to bump the runners to macos-15 to see if it resolves this issue, otherwise I will continue investigating this as a potential bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
