### PR TITLE
Pin tokio to its LTS version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3055,9 +3055,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",

--- a/tough-kms/Cargo.toml
+++ b/tough-kms/Cargo.toml
@@ -22,7 +22,7 @@ aws-lc-rs = "1"
 aws-sdk-kms = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
-tokio = { version = "1", features = ["fs", "io-util", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["fs", "io-util", "time", "macros", "rt-multi-thread"] }
 pem = "3"
 
 [dev-dependencies]

--- a/tough-ssm/Cargo.toml
+++ b/tough-ssm/Cargo.toml
@@ -21,4 +21,4 @@ aws-sdk-ssm = { version = "1", default-features = false, features = ["default-ht
 aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio"] }
 aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
-tokio = { version = "1", features = ["fs", "io-util", "time", "macros", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["fs", "io-util", "time", "macros", "rt-multi-thread"] }

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -44,7 +44,7 @@ failure-server = { path = "../integ/failure-server" }
 hex-literal = "0.4"
 httptest = "0.16"
 maplit = "1"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-test = "0.4"
 
 [features]

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1"
 simplelog = "0.12"
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.43", features = ["macros", "rt", "rt-multi-thread"] }
 tough = { version = "0.20", path = "../tough", features = ["http"] }
 tough-kms = { version = "0.12", path = "../tough-kms" }
 tough-ssm = { version = "0.15", path = "../tough-ssm" }


### PR DESCRIPTION
*Issue #, if available:*

#872 

*Description of changes:*

In #868, we bumped `tokio` from `1.42.x` to `1.44.x`. Since the failing tests in #872 are using async file read, I believe our code may be incompatible with the new `tokio` version. Given that `1.43` is the latest LTS version [listed on tokio's repo](https://github.com/tokio-rs/tokio/tree/master/tokio#bug-patching-policy), I'm pinning to that version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
