### PR TITLE
tough: flush file explicitly in cache

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -219,6 +219,11 @@ impl Repository {
             .context(error::TransportSnafu { url })?;
         file.write_all(&root_file_data)
             .await
+            .context(error::CacheFileWriteSnafu {
+                path: outpath.clone(),
+            })?;
+        file.flush()
+            .await
             .context(error::CacheFileWriteSnafu { path: outpath })
     }
 


### PR DESCRIPTION
*Issue #, if available:*

#872 

*Description of changes:*

While tracking down the issues in Github actions observed in #872, @jmt-lab pointed out that a `tokio::fs::File` should be flushed after writing, or the file may not close on exit. See [tokio's docs] on this.

This might be causing the test failures that we're seeing, as after the `tuftool clone` command exits, the write may not have finished for `1.root.json` as it's the last file that we copy.

[tokio's docs]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
