### PR TITLE
tuftool: add manual testing steps for FIPS tuf repos

### DIFF
--- a/tuftool/fips-test/.gitignore
+++ b/tuftool/fips-test/.gitignore
@@ -1,0 +1,4 @@
+# Ignore artifacts created during test.
+test-fips-tough/
+test-keys/
+test-tuf-repo/

--- a/tuftool/fips-test/Dockerfile
+++ b/tuftool/fips-test/Dockerfile
@@ -1,0 +1,5 @@
+FROM public.ecr.aws/nginx/nginx:latest
+
+RUN apt update && apt upgrade -y
+RUN mkdir -p /etc/pki/tls/certs 
+RUN mkdir -p /etc/pki/tls/private 

--- a/tuftool/fips-test/README.md
+++ b/tuftool/fips-test/README.md
@@ -1,0 +1,126 @@
+# Testing tough FIPS feature
+
+The following are steps to take to test FIPS support with `tough` and `tuftool`.
+Steps will walk through creating a TUF repo, hosting the repo via Docker containers running nginx, and testing `tuftool download` against servers using FIPS and non-FIPS ciphers.
+Note that these steps are assumed to be run on Linux.
+
+## Install tuftool
+
+```sh
+# From latest release
+$ cargo install --force tuftool --all-features
+```
+
+```sh
+# From local changes
+$ cargo install --path ../../tuftool --all-features
+```
+
+## Create TUF repo
+
+```sh
+$ mkdir -p test-tuf-repo test-keys
+$ ./scripts/create-tuf-repo.sh
+```
+
+This will create the repo under the "test-tuf-repo" directory and a key for signing the TUF repo under "test-keys".
+
+## Create keys
+
+```sh
+$ ./scripts/create-server-keys.sh
+```
+
+Trust the generated server Certificate Authority on your host:
+
+```sh
+sudo trust anchor --store ./test-keys/ca.crt
+```
+
+## Build the tough-fips-testing container
+
+```sh
+docker build . -t tough-fips-testing:latest
+```
+
+## Run the server with FIPS 
+
+```sh
+docker run --rm -p 8080:443 \
+  -v ./configs/nginx-fips.conf:/etc/nginx/nginx.conf \
+  -v ./test-tuf-repo/out/metadata:/usr/share/nginx/html/metadata \
+  -v ./test-tuf-repo/out/targets:/usr/share/nginx/html/targets \
+  --mount type=bind,src=./test-keys/server.crt,dst=/etc/pki/tls/certs/domain.crt \
+  --mount type=bind,src=./test-keys/server.key,dst=/etc/pki/tls/private/domain.key \
+  -d --name "tuf-repo-fips" \
+  tough-fips-testing:latest
+```
+
+Test repo download:
+
+```sh
+tuftool download -r ./test-tuf-repo/1.root.json \
+  --targets-url https://localhost:8080/targets  \
+  --metadata-url https://localhost:8080/metadata \
+  test-fips-tough
+```
+
+Should succeed with:
+
+```
+Downloading targets to "test-fips-tough"
+```
+
+Clean up the downloaded repo:
+
+```sh
+rm -rf test-fips-tough/
+```
+
+Stop the container:
+
+```
+docker stop tuf-repo-fips
+```
+
+## Run the server with non-FIPS ciphers
+
+```sh
+docker run --rm -p 8080:443 \
+  -v ./configs/nginx.conf:/etc/nginx/nginx.conf \
+  -v ./test-tuf-repo/out/metadata:/usr/share/nginx/html/metadata \
+  -v ./test-tuf-repo/out/targets:/usr/share/nginx/html/targets \
+  --mount type=bind,src=./test-keys/server.crt,dst=/etc/pki/tls/certs/domain.crt \
+  --mount type=bind,src=./test-keys/server.key,dst=/etc/pki/tls/private/domain.key \
+  -d --name "tuf-repo" \
+  tough-fips-testing:latest
+```
+
+Test repo download:
+
+```sh
+tuftool download -r ./test-tuf-repo/1.root.json \
+  --targets-url https://localhost:8080/targets  \
+  --metadata-url https://localhost:8080/metadata \
+  test-fips-tough
+```
+
+Expect failure:
+
+```
+Failed to load repository: Failed to fetch https://localhost:8080/metadata/2.root.json: Transport 'other' error fetching 'https://localhost:8080/metadata/2.root.json': error sending request for url (https://localhost:8080/metadata/2.root.json)
+```
+
+Stop the container:
+
+```
+docker stop tuf-repo
+```
+
+# Clean up
+
+```
+rm -rf test-tuf-repo/
+rm -rf test-keys/
+rm -rf test-fips-tough/
+```

--- a/tuftool/fips-test/configs/csr.conf.in
+++ b/tuftool/fips-test/configs/csr.conf.in
@@ -1,0 +1,19 @@
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = req_ext
+
+[ dn ]
+C = US
+ST = WASHINGTON
+L = Seattle
+O = Bottlerocket
+OU = Bottlerocket Dev
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = localhost

--- a/tuftool/fips-test/configs/nginx-fips.conf
+++ b/tuftool/fips-test/configs/nginx-fips.conf
@@ -1,0 +1,69 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /dev/stdout debug;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80;
+        listen       [::]:80;
+        server_name  localhost;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+    }
+
+# Settings for a TLS enabled server.
+
+    server {
+         listen       443 ssl;
+         listen       [::]:443 ssl;
+         http2        on;
+         server_name  localhost;
+         root         /usr/share/nginx/html;
+
+        ssl_certificate "/etc/pki/tls/certs/domain.crt";
+        ssl_certificate_key "/etc/pki/tls/private/domain.key";
+        ssl_session_cache shared:SSL:1m;
+        ssl_session_timeout  10m;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        
+        ssl_ciphers 'TLSv1.2+FIPS:kRSA+FIPS:!eNULL:!aNULL';
+        
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+     }
+
+}

--- a/tuftool/fips-test/configs/nginx.conf
+++ b/tuftool/fips-test/configs/nginx.conf
@@ -1,0 +1,69 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+
+user nginx;
+worker_processes auto;
+error_log /dev/stdout debug;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    keepalive_timeout   65;
+    types_hash_max_size 4096;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       80;
+        listen       [::]:80;
+        server_name  localhost;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+    }
+
+# Settings for a TLS enabled server.
+
+    server {
+         listen       443 ssl;
+         listen       [::]:443 ssl;
+         http2        on;
+         server_name  localhost;
+         root         /usr/share/nginx/html;
+
+        ssl_certificate "/etc/pki/tls/certs/domain.crt";
+        ssl_certificate_key "/etc/pki/tls/private/domain.key";
+        ssl_session_cache shared:SSL:1m;
+        ssl_session_timeout  10m;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        
+        ssl_conf_command Ciphersuites TLS_CHACHA20_POLY1305_SHA256;
+        
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+     }
+
+}

--- a/tuftool/fips-test/scripts/create-server-keys.sh
+++ b/tuftool/fips-test/scripts/create-server-keys.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p test-keys
+
+openssl genrsa -out test-keys/server.key 2048
+openssl req -new -key test-keys/server.key -out test-keys/server.csr -config ./configs/csr.conf.in
+
+# Generate CA certificate
+openssl genrsa -out test-keys/ca.key 2048 \
+  && openssl req -x509 -new -nodes -key test-keys/ca.key \
+    -subj "/CN=bottlerocket/C=US/L=WASHINGTON" -days 1825 -out test-keys/ca.crt
+
+openssl dhparam -out test-keys/dhparam.pem 2098
+
+openssl x509 -req -in test-keys/server.csr -CA test-keys/ca.crt -CAkey test-keys/ca.key \
+  -CAcreateserial -out test-keys/server.crt -days 10000 -extensions req_ext \
+  -extfile ./configs/csr.conf.in

--- a/tuftool/fips-test/scripts/create-tuf-repo.sh
+++ b/tuftool/fips-test/scripts/create-tuf-repo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+ALIAS_SUFFIX=$(date "+%Y-%m-%d")
+TEST_TUF_REPO_PATH="./test-tuf-repo"
+TEST_KEYS_PATH="test-keys"
+
+tuftool root init --version 1 "${TEST_TUF_REPO_PATH}/1.root.json"
+
+tuftool root gen-rsa-key "${TEST_TUF_REPO_PATH}/1.root.json" "${TEST_KEYS_PATH}/root.pem" --role root
+
+expiration_date=$(date -d "${ALIAS_SUFFIX} + 2 weeks" --iso-8601=date -u)T00:00:00+00:00
+
+tuftool root expire "${TEST_TUF_REPO_PATH}/1.root.json" "${expiration_date}"
+
+tuftool root set-threshold "${TEST_TUF_REPO_PATH}/1.root.json" root 1
+tuftool root set-threshold "${TEST_TUF_REPO_PATH}/1.root.json" snapshot 1
+tuftool root set-threshold "${TEST_TUF_REPO_PATH}/1.root.json" targets 1
+tuftool root set-threshold "${TEST_TUF_REPO_PATH}/1.root.json" timestamp 1
+
+# Add keys                                                                                                                                                                                                                                                     
+tuftool root add-key "${TEST_TUF_REPO_PATH}/1.root.json" \
+  -k "${TEST_KEYS_PATH}/root.pem" \
+  -r root
+
+tuftool root add-key "${TEST_TUF_REPO_PATH}/1.root.json" \
+  -k "${TEST_KEYS_PATH}/root.pem" \
+   -r snapshot -r targets -r timestamp
+
+tuftool root add-key "${TEST_TUF_REPO_PATH}/1.root.json" \
+  -k "${TEST_KEYS_PATH}/root.pem" \
+  -r timestamp
+
+# Sign
+tuftool root sign "${TEST_TUF_REPO_PATH}/1.root.json" \
+  -k "${TEST_KEYS_PATH}/root.pem"
+
+mkdir -p "${TEST_TUF_REPO_PATH}/empty"
+tuftool create \
+    -t "${TEST_TUF_REPO_PATH}/empty" --outdir "${TEST_TUF_REPO_PATH}/out" --root "${TEST_TUF_REPO_PATH}/1.root.json" \
+    -k "${TEST_KEYS_PATH}/root.pem" \
+    --snapshot-expires 'in 7 days' --snapshot-version "$(date +%s)" \
+    --targets-expires 'in 7 days' --targets-version "$(date +%s)" \
+    --timestamp-expires 'in 7 days' --timestamp-version "$(date +%s)"


### PR DESCRIPTION


*Issue #, if available:*

Related: #866 

*Description of changes:*

Add instructions and resources for manually testing tuftool's FIPS feature to allow for easily repeatable testing. The instructions walk through creating a local TUF repo, serving the TUF repo via a Docker container, and downloading the repo via tuftool.

*Testing:*

Ran the testing instructions on a clean checkout of `tough`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
