### PR TITLE
Fix: `max_targets_size` in `load_targets`

### DIFF
--- a/olpc-cjson/src/lib.rs
+++ b/olpc-cjson/src/lib.rs
@@ -105,10 +105,7 @@ impl CanonicalFormatter {
     /// Returns a mutable reference to the top of the object stack.
     fn obj_mut(&mut self) -> Result<&mut Object> {
         self.object_stack.last_mut().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
-                "serde_json called an object method without calling begin_object first",
-            )
+            Error::other("serde_json called an object method without calling begin_object first")
         })
     }
 }
@@ -229,8 +226,7 @@ impl Formatter for CanonicalFormatter {
 
     fn end_object<W: Write + ?Sized>(&mut self, writer: &mut W) -> Result<()> {
         let object = self.object_stack.pop().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
+            Error::other(
                 "serde_json called Formatter::end_object object method
                  without calling begin_object first",
             )

--- a/tough-kms/src/error.rs
+++ b/tough-kms/src/error.rs
@@ -27,8 +27,10 @@ pub enum Error {
     KmsGetPublicKey {
         profile: Option<String>,
         key_id: String,
-        source:
+        #[snafu(source(from(aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::get_public_key::GetPublicKeyError>, Box::new)))]
+        source: Box<
             aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::get_public_key::GetPublicKeyError>,
+        >,
         backtrace: Backtrace,
     },
 
@@ -49,7 +51,8 @@ pub enum Error {
     KmsSignMessage {
         key_id: String,
         profile: Option<String>,
-        source: aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::sign::SignError>,
+        #[snafu(source(from(aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::sign::SignError>, Box::new)))]
+        source: Box<aws_sdk_kms::error::SdkError<aws_sdk_kms::operation::sign::SignError>>,
         backtrace: Backtrace,
     },
 

--- a/tough-ssm/src/error.rs
+++ b/tough-ssm/src/error.rs
@@ -35,8 +35,10 @@ pub enum Error {
     SsmGetParameter {
         profile: Option<String>,
         parameter_name: String,
-        source:
+        #[snafu(source(from(aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::GetParameterError>, Box::new)))]
+        source: Box<
             aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::get_parameter::GetParameterError>,
+        >,
         backtrace: Backtrace,
     },
 
@@ -60,8 +62,10 @@ pub enum Error {
     SsmPutParameter {
         profile: Option<String>,
         parameter_name: String,
-        source:
+        #[snafu(source(from(aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::put_parameter::PutParameterError>, Box::new)))]
+        source: Box<
             aws_sdk_ssm::error::SdkError<aws_sdk_ssm::operation::put_parameter::PutParameterError>,
+        >,
         backtrace: Backtrace,
     },
 }

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -1197,7 +1197,7 @@ async fn load_targets(
             path,
             url: metadata_base_url.clone(),
         })?;
-    let (max_targets_size, specifier) = match targets_meta.length {
+    let (max_targets_file_size, specifier) = match targets_meta.length {
         Some(length) => (length, "snapshot.json"),
         None => (max_targets_size, "max_targets_size parameter"),
     };
@@ -1207,13 +1207,19 @@ async fn load_targets(
         fetch_sha256(
             transport,
             targets_url.clone(),
-            max_targets_size,
+            max_targets_file_size,
             specifier,
             &hashes.sha256,
         )
         .await?
     } else {
-        fetch_max_size(transport, targets_url.clone(), max_targets_size, specifier).await?
+        fetch_max_size(
+            transport,
+            targets_url.clone(),
+            max_targets_file_size,
+            specifier,
+        )
+        .await?
     };
     let data = stream
         .into_vec()

--- a/tuftool/src/clone.rs
+++ b/tuftool/src/clone.rs
@@ -108,7 +108,10 @@ impl CloneArgs {
 
         // Clone the repository, downloading none, all, or a subset of targets
         if self.metadata_only {
-            println!("Cloning repository metadata to {:?}", self.metadata_dir);
+            println!(
+                "Cloning repository metadata to {}",
+                self.metadata_dir.display()
+            );
             repository
                 .cache_metadata(&self.metadata_dir, true)
                 .await
@@ -122,8 +125,9 @@ impl CloneArgs {
             );
 
             println!(
-                "Cloning repository:\n\tmetadata location: {:?}\n\ttargets location: {targets_dir:?}",
-                self.metadata_dir
+                "Cloning repository:\n\tmetadata location: {}\n\ttargets location: {}",
+                self.metadata_dir.display(),
+                targets_dir.display()
             );
             if self.target_names.is_empty() {
                 repository

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -129,7 +129,7 @@ async fn handle_download(
         target_names
     };
 
-    println!("Downloading targets to {outdir:?}");
+    println!("Downloading targets to {}", outdir.display());
     tokio::fs::create_dir_all(outdir)
         .await
         .context(error::DirCreateSnafu { path: outdir })?;


### PR DESCRIPTION
*Issue #, if available:*
#883 
*Description of changes:*
I changed the `max_targets_size` that is used for loading the top level `targets.json` metadata file to `max_targets_file_size`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
