### PR TITLE
tough: condition tap-12 check with feature

### DIFF
--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -50,6 +50,7 @@ tokio-test = "0.4"
 [features]
 fips = ["aws-lc-rs/fips", "rustls/fips"]
 http = ["reqwest"]
+tap-12 = []
 
 # The `integ` feature enables integration tests. These tests require `noxious-server` to be installed on the host.
 integ = []

--- a/tough/src/schema/de.rs
+++ b/tough/src/schema/de.rs
@@ -22,15 +22,18 @@ where
         key: Key,
         map: &mut HashMap<Decoded<Hex>, Key>,
     ) -> Result<(), error::Error> {
-        let calculated = key.key_id()?;
         let keyid_hex = hex::encode(&keyid);
-        ensure!(
-            keyid == calculated,
-            error::InvalidKeyIdSnafu {
-                keyid: &keyid_hex,
-                calculated: hex::encode(&calculated),
-            }
-        );
+        #[cfg(not(feature = "tap-12"))]
+        {
+            let calculated = key.key_id()?;
+            ensure!(
+                keyid == calculated,
+                error::InvalidKeyIdSnafu {
+                    keyid: &keyid_hex,
+                    calculated: hex::encode(&calculated),
+                }
+            );
+        }
         ensure!(
             map.insert(keyid, key).is_none(),
             error::DuplicateKeyIdSnafu { keyid: keyid_hex }


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/tough/issues/766

*Description of changes:*

Conditionally disable the keyid with a feature `tap-12`. The default behavior remain unchanged, but it can be disable easily.
Since the [TAP-12 is accepted](https://github.com/theupdateframework/taps/blob/master/tap12.md), and hopefully should be merged in a near future, the goal is to unblock some TUF repos from being used with tough (like the [GitHub TUF repo](https://tuf-repo.github.com/)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
