### PR TITLE
fix: re-export TransportStream type alias

### DIFF
--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -59,6 +59,7 @@ pub use crate::target_name::TargetName;
 pub use crate::transport::IntoVec;
 pub use crate::transport::{
     DefaultTransport, FilesystemTransport, Transport, TransportError, TransportErrorKind,
+    TransportStream,
 };
 pub use crate::urlpath::SafeUrlPath;
 use async_recursion::async_recursion;

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -14,6 +14,7 @@ use std::pin::Pin;
 use tokio_util::io::ReaderStream;
 use url::Url;
 
+/// Type alias for the stream returned by transports
 pub type TransportStream = Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>;
 
 /// Fallible byte streams that collect into a `Vec<u8>`.
@@ -157,7 +158,7 @@ impl Display for TransportError {
 
 impl Error for TransportError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        self.source.as_ref().map(|e| e.as_ref() as &(dyn Error))
+        self.source.as_ref().map(|e| e.as_ref() as &dyn Error)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* #908

*Description of changes:*
Re-export the TransportStream type alias so customers do not need to redefine it themselves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
