### PR TITLE
Add S3 transport support for TUF repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +270,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -301,6 +308,41 @@ dependencies = [
  "once_cell",
  "regex-lite",
  "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.82.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6eab2900764411ab01c8e91a76fd11a63b4e12bc3da97d9e14a0ce1343d86d3"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "lru",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "sha2",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -357,6 +399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -385,11 +428,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.63.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d21e1ba6f2cdec92044f904356a19f5ad86961acf015741106cdfafd747c0"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "crc64fast-nvme",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c45d3dddac16c5c59d553ece225a88870cf81b7b813c9cc17b78cf4685eac7a"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -943,6 +1020,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crc64fast-nvme"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38fe9239af6a04e140c7424d36d1615f37f1804700c17d5339af162add9022e0"
+dependencies = [
+ "crc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1243,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1368,6 +1493,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1887,6 +2017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,6 +2036,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2768,6 +2917,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +3377,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tough-s3"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "aws-config",
+ "aws-lc-rs",
+ "aws-sdk-s3",
+ "aws-smithy-http-client",
+ "aws-smithy-types",
+ "bytes",
+ "futures",
+ "http 1.3.1",
+ "snafu",
+ "tokio",
+ "tough",
+ "url",
+]
+
+[[package]]
 name = "tough-ssm"
 version = "0.16.0"
 dependencies = [
@@ -3375,6 +3554,7 @@ dependencies = [
  "tokio",
  "tough",
  "tough-kms",
+ "tough-s3",
  "tough-ssm",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "tough",
     "tough-ssm",
     "tough-kms",
+    "tough-s3",
     "tuftool",
 ]

--- a/tough-s3/Cargo.toml
+++ b/tough-s3/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "tough-s3"
+version = "0.1.0"
+description = "Implements AWS S3 as a transport for TUF repositories"
+authors = ["AWS"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/awslabs/tough"
+keywords = ["TUF", "S3"]
+edition = "2018"
+
+[features]
+default = ["aws-sdk-rust"]
+aws-sdk-rust = ["aws-sdk-rust-rustls"]
+aws-sdk-rust-rustls = []
+fips = ["aws-lc-rs/fips", "tough/fips"]
+
+[dependencies]
+tough = { version = "0.21", path = "../tough" }
+aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio"] }
+aws-lc-rs = "1"
+aws-sdk-s3 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-smithy-http-client = { version = "1", features = ["rustls-aws-lc"] }
+async-trait = "0.1"
+bytes = "1"
+futures = "0.3"
+snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
+tokio = { version = "1", features = ["rt"] }
+url = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+aws-smithy-http-client = { version = "1", features = ["test-util"] }
+aws-smithy-types = "1"
+http = "1"

--- a/tough-s3/src/error.rs
+++ b/tough-s3/src/error.rs
@@ -1,0 +1,38 @@
+//! Error types for the tough-s3 crate.
+//!
+//! This module defines error types that can occur when using S3 as a TUF transport.
+
+use snafu::Snafu;
+
+/// Result type for tough-s3 operations
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors that can occur when using S3 as a transport
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    /// Invalid S3 URL format
+    #[snafu(display("Invalid S3 URL: {}", url))]
+    InvalidS3Url {
+        /// The invalid URL
+        url: String
+    },
+
+    /// Failed to get object from S3
+    #[snafu(display("Failed to get S3 object s3://{}/{}: {}", bucket, key, source))]
+    S3GetObject {
+        /// S3 bucket name
+        bucket: String,
+        /// S3 object key
+        key: String,
+        /// Underlying SDK error
+        source: aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+    },
+
+    /// Failed to read from S3 byte stream
+    #[snafu(display("Failed to read S3 byte stream: {}", source))]
+    S3ByteStream {
+        /// Underlying byte stream error
+        source: aws_sdk_s3::primitives::ByteStreamError,
+    },
+}

--- a/tough-s3/src/lib.rs
+++ b/tough-s3/src/lib.rs
@@ -1,0 +1,201 @@
+//! tough-s3 implements the `Transport` trait for AWS S3.
+//!
+//! This allows TUF repositories to be fetched from S3 buckets using s3:// URLs.
+
+#![forbid(missing_debug_implementations, missing_copy_implementations)]
+#![deny(rust_2018_idioms)]
+#![deny(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc
+)]
+
+/// Error types for tough-s3
+pub mod error;
+
+use async_trait::async_trait;
+use aws_sdk_s3::Client as S3Client;
+use aws_sdk_s3::primitives::ByteStream;
+use bytes::Bytes;
+use futures::stream::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tough::{Transport, TransportError, TransportErrorKind, TransportStream};
+use url::Url;
+
+/// Implements the `Transport` trait for AWS S3
+#[derive(Clone, Debug)]
+pub struct S3Transport {
+    client: S3Client,
+}
+
+impl S3Transport {
+    /// Create a new S3Transport with the default AWS configuration
+    pub async fn new() -> Self {
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest()).load().await;
+        let client = S3Client::new(&config);
+        Self { client }
+    }
+
+    /// Create a new S3Transport with a custom S3 client
+    pub fn new_with_client(client: S3Client) -> Self {
+        Self { client }
+    }
+
+    /// Create a new S3Transport with a specific AWS region
+    pub async fn new_with_region(region: &str) -> Self {
+        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(region.to_string()))
+            .load()
+            .await;
+        Self { client: S3Client::new(&config) }
+    }
+
+    /// Parse an s3:// URL into bucket and key components
+    fn parse_s3_url(url: &Url) -> Result<(String, String), error::Error> {
+        if url.scheme() != "s3" {
+            return Err(error::Error::InvalidS3Url {
+                url: url.to_string(),
+            });
+        }
+
+        let bucket = url
+            .host_str()
+            .ok_or_else(|| error::Error::InvalidS3Url {
+                url: url.to_string(),
+            })?
+            .to_string();
+
+        let key = url.path().trim_start_matches('/').to_string();
+
+        if key.is_empty() {
+            return Err(error::Error::InvalidS3Url {
+                url: url.to_string(),
+            });
+        }
+
+        Ok((bucket, key))
+    }
+}
+
+#[async_trait]
+impl Transport for S3Transport {
+    async fn fetch(&self, url: Url) -> Result<TransportStream, TransportError> {
+        if url.scheme() != "s3" {
+            return Err(TransportError::new(
+                TransportErrorKind::UnsupportedUrlScheme,
+                url,
+            ));
+        }
+
+        let (bucket, key) = S3Transport::parse_s3_url(&url).map_err(|e| {
+            TransportError::new_with_cause(TransportErrorKind::Other, url.clone(), e)
+        })?;
+
+        let result = self
+            .client
+            .get_object()
+            .bucket(&bucket)
+            .key(&key)
+            .send()
+            .await;
+
+        let response = match result {
+            Ok(resp) => resp,
+            Err(e) => {
+                let kind = if is_not_found(&e) {
+                    TransportErrorKind::FileNotFound
+                } else {
+                    TransportErrorKind::Other
+                };
+                return Err(TransportError::new_with_cause(kind, url, e));
+            }
+        };
+
+        let byte_stream = response.body;
+        let stream = ByteStreamAdapter {
+            inner: byte_stream,
+            url: url.clone(),
+        };
+
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Check if an S3 error indicates the object was not found
+fn is_not_found(
+    err: &aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::get_object::GetObjectError>,
+) -> bool {
+    matches!(
+        err,
+        aws_sdk_s3::error::SdkError::ServiceError(err)
+            if err.err().is_no_such_key()
+    )
+}
+
+/// Adapter to convert AWS SDK ByteStream to tough TransportStream
+struct ByteStreamAdapter {
+    inner: ByteStream,
+    url: Url,
+}
+
+impl Stream for ByteStreamAdapter {
+    type Item = Result<Bytes, TransportError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let inner = Pin::new(&mut self.inner);
+        match inner.poll_next(cx) {
+            Poll::Ready(Some(Ok(bytes))) => Poll::Ready(Some(Ok(bytes))),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(TransportError::new_with_cause(
+                TransportErrorKind::Other,
+                self.url.clone(),
+                err,
+            )))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_s3_url_valid() {
+        let url = Url::from_str("s3://my-bucket/path/to/key").unwrap();
+        let (bucket, key) = S3Transport::parse_s3_url(&url).unwrap();
+        assert_eq!(bucket, "my-bucket");
+        assert_eq!(key, "path/to/key");
+    }
+
+    #[test]
+    fn parse_s3_url_single_key() {
+        let url = Url::from_str("s3://bucket/file.txt").unwrap();
+        let (bucket, key) = S3Transport::parse_s3_url(&url).unwrap();
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key, "file.txt");
+    }
+
+    #[test]
+    fn parse_s3_url_invalid_scheme() {
+        let url = Url::from_str("http://bucket/key").unwrap();
+        assert!(S3Transport::parse_s3_url(&url).is_err());
+    }
+
+    #[test]
+    fn parse_s3_url_missing_key() {
+        let url = Url::from_str("s3://bucket/").unwrap();
+        assert!(S3Transport::parse_s3_url(&url).is_err());
+    }
+
+    #[test]
+    fn parse_s3_url_no_path() {
+        let url = Url::from_str("s3://bucket").unwrap();
+        assert!(S3Transport::parse_s3_url(&url).is_err());
+    }
+}

--- a/tough-s3/tests/transport.rs
+++ b/tough-s3/tests/transport.rs
@@ -1,0 +1,54 @@
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::Client;
+use aws_smithy_http_client::test_util::{ReplayEvent, StaticReplayClient};
+use aws_smithy_types::body::SdkBody;
+use std::str::FromStr;
+use tough::{Transport, TransportErrorKind};
+use tough_s3::S3Transport;
+use url::Url;
+
+fn mock_s3_client(status: u16, body: &str) -> Client {
+    let creds = Credentials::new("TEST", "TEST", Some("TEST".into()), None, "");
+    let events = vec![ReplayEvent::new(
+        http::Request::builder().body(SdkBody::from("")).unwrap(),
+        http::Response::builder()
+            .status(status)
+            .body(SdkBody::from(body))
+            .unwrap(),
+    )];
+    let conn = StaticReplayClient::new(events);
+    let conf = aws_sdk_s3::Config::builder()
+        .behavior_version(BehaviorVersion::v2025_01_17())
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .http_client(conn)
+        .build();
+    Client::from_conf(conf)
+}
+
+#[tokio::test]
+async fn fetch_success() {
+    let client = mock_s3_client(200, "test content");
+    let transport = S3Transport::new_with_client(client);
+    let url = Url::from_str("s3://bucket/key.txt").unwrap();
+    let stream = transport.fetch(url).await.unwrap();
+    let bytes: Vec<u8> = futures::StreamExt::collect::<Vec<_>>(stream)
+        .await
+        .into_iter()
+        .filter_map(|r| r.ok())
+        .flat_map(|b| b.to_vec())
+        .collect();
+    assert_eq!(String::from_utf8(bytes).unwrap(), "test content");
+}
+
+#[tokio::test]
+async fn fetch_invalid_scheme() {
+    let client = mock_s3_client(200, "");
+    let transport = S3Transport::new_with_client(client);
+    let url = Url::from_str("http://bucket/key").unwrap();
+    let result = transport.fetch(url).await;
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(matches!(err.kind(), TransportErrorKind::UnsupportedUrlScheme));
+}

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-rust = ["aws-sdk-rust-rustls"]
 # This feature is for backward compatibility but has no effect.
 aws-sdk-rust-rustls = []
 fips = ["tough/fips", "rustls/fips"]
+s3 = ["tough-s3"]
 
 [dependencies]
 aws-config = { version = "1", default-features = false, features = ["credentials-process", "default-https-client", "rt-tokio"] }
@@ -39,6 +40,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tough = { version = "0.21", path = "../tough", features = ["http"] }
 tough-kms = { version = "0.13", path = "../tough-kms" }
+tough-s3 = { version = "0.1", path = "../tough-s3", optional = true }
 tough-ssm = { version = "0.16", path = "../tough-ssm" }
 url = "2"
 walkdir = "2"

--- a/tuftool/src/clone.rs
+++ b/tuftool/src/clone.rs
@@ -11,6 +11,9 @@ use std::path::PathBuf;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
 
+#[cfg(feature = "s3")]
+use tough_s3::S3Transport;
+
 #[derive(Debug, Parser)]
 pub(crate) struct CloneArgs {
     /// Allow repo download for expired metadata (unsafe)
@@ -52,6 +55,11 @@ pub(crate) struct CloneArgs {
     /// Remote root.json version number
     #[arg(short = 'v', long, default_value = "1")]
     root_version: NonZeroU64,
+
+    #[cfg(feature = "s3")]
+    /// AWS region for S3 transport (required for s3:// URLs)
+    #[arg(long)]
+    s3_region: Option<String>,
 }
 
 #[rustfmt::skip]
@@ -94,17 +102,24 @@ impl CloneArgs {
         } else {
             ExpirationEnforcement::Safe
         };
-        let repository = RepositoryLoader::new(
-            &tokio::fs::read(&root_path)
-                .await
-                .context(error::OpenRootSnafu { path: &root_path })?,
+        let root_bytes = tokio::fs::read(&root_path)
+            .await
+            .context(error::OpenRootSnafu { path: &root_path })?;
+        let mut loader = RepositoryLoader::new(
+            &root_bytes,
             self.metadata_base_url.clone(),
-            targets_base_url,
+            targets_base_url.clone(),
         )
-        .expiration_enforcement(expiration_enforcement)
-        .load()
-        .await
-        .context(error::RepoLoadSnafu)?;
+        .expiration_enforcement(expiration_enforcement);
+
+        #[cfg(feature = "s3")]
+        if self.metadata_base_url.scheme() == "s3" || targets_base_url.scheme() == "s3" {
+            if let Some(region) = &self.s3_region {
+                loader = loader.transport(S3Transport::new_with_region(region).await);
+            }
+        }
+
+        let repository = loader.load().await.context(error::RepoLoadSnafu)?;
 
         // Clone the repository, downloading none, all, or a subset of targets
         if self.metadata_only {

--- a/tuftool/src/download.rs
+++ b/tuftool/src/download.rs
@@ -10,6 +10,9 @@ use std::path::{Path, PathBuf};
 use tough::{ExpirationEnforcement, Prefix, Repository, RepositoryLoader, TargetName};
 use url::Url;
 
+#[cfg(feature = "s3")]
+use tough_s3::S3Transport;
+
 #[derive(Debug, Parser)]
 pub(crate) struct DownloadArgs {
     /// Allow repo download for expired metadata
@@ -42,6 +45,11 @@ pub(crate) struct DownloadArgs {
     /// Remote root.json version number
     #[arg(short = 'v', long, default_value = "1")]
     root_version: NonZeroU64,
+
+    #[cfg(feature = "s3")]
+    /// AWS region for S3 transport (required for s3:// URLs)
+    #[arg(long)]
+    s3_region: Option<String>,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(path: P) {
@@ -80,17 +88,24 @@ impl DownloadArgs {
         } else {
             ExpirationEnforcement::Safe
         };
-        let repository = RepositoryLoader::new(
-            &tokio::fs::read(&root_path)
-                .await
-                .context(error::OpenRootSnafu { path: &root_path })?,
+        let root_bytes = tokio::fs::read(&root_path)
+            .await
+            .context(error::OpenRootSnafu { path: &root_path })?;
+        let mut loader = RepositoryLoader::new(
+            &root_bytes,
             self.metadata_base_url.clone(),
             self.targets_base_url.clone(),
         )
-        .expiration_enforcement(expiration_enforcement)
-        .load()
-        .await
-        .context(error::RepoLoadSnafu)?;
+        .expiration_enforcement(expiration_enforcement);
+
+        #[cfg(feature = "s3")]
+        if self.metadata_base_url.scheme() == "s3" || self.targets_base_url.scheme() == "s3" {
+            if let Some(region) = &self.s3_region {
+                loader = loader.transport(S3Transport::new_with_region(region).await);
+            }
+        }
+
+        let repository = loader.load().await.context(error::RepoLoadSnafu)?;
 
         // download targets
         handle_download(&repository, &self.outdir, &self.target_names).await

--- a/tuftool/src/transfer_metadata.rs
+++ b/tuftool/src/transfer_metadata.rs
@@ -13,6 +13,9 @@ use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
 
+#[cfg(feature = "s3")]
+use tough_s3::S3Transport;
+
 #[derive(Debug, Parser)]
 pub(crate) struct TransferMetadataArgs {
     /// Allow repo update from expired metadata
@@ -66,6 +69,11 @@ pub(crate) struct TransferMetadataArgs {
     /// Version of timestamp.json file
     #[arg(long = "timestamp-version")]
     timestamp_version: NonZeroU64,
+
+    #[cfg(feature = "s3")]
+    /// AWS region for S3 transport (required for s3:// URLs)
+    #[arg(long)]
+    s3_region: Option<String>,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(from_path: P, to_path: P) {
@@ -97,19 +105,26 @@ impl TransferMetadataArgs {
         } else {
             ExpirationEnforcement::Safe
         };
-        let current_repo = RepositoryLoader::new(
-            &tokio::fs::read(current_root)
-                .await
-                .context(error::OpenRootSnafu {
-                    path: &current_root,
-                })?,
+        let root_bytes = tokio::fs::read(current_root)
+            .await
+            .context(error::OpenRootSnafu {
+                path: &current_root,
+            })?;
+        let mut loader = RepositoryLoader::new(
+            &root_bytes,
             self.metadata_base_url.clone(),
             self.targets_base_url.clone(),
         )
-        .expiration_enforcement(expiration_enforcement)
-        .load()
-        .await
-        .context(error::RepoLoadSnafu)?;
+        .expiration_enforcement(expiration_enforcement);
+
+        #[cfg(feature = "s3")]
+        if self.metadata_base_url.scheme() == "s3" || self.targets_base_url.scheme() == "s3" {
+            if let Some(region) = &self.s3_region {
+                loader = loader.transport(S3Transport::new_with_region(region).await);
+            }
+        }
+
+        let current_repo = loader.load().await.context(error::RepoLoadSnafu)?;
 
         let mut editor = RepositoryEditor::new(new_root)
             .await

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -16,6 +16,9 @@ use tough::editor::RepositoryEditor;
 use tough::{ExpirationEnforcement, RepositoryLoader};
 use url::Url;
 
+#[cfg(feature = "s3")]
+use tough_s3::S3Transport;
+
 #[derive(Debug, Parser)]
 pub(crate) struct UpdateArgs {
     /// Allow repo download for expired metadata
@@ -94,6 +97,11 @@ pub(crate) struct UpdateArgs {
     /// Version of timestamp.json file
     #[arg(long)]
     timestamp_version: NonZeroU64,
+
+    #[cfg(feature = "s3")]
+    /// AWS region for S3 transport (required for s3:// URLs)
+    #[arg(long)]
+    s3_region: Option<String>,
 }
 
 fn expired_repo_warning<P: AsRef<Path>>(path: P) {
@@ -114,17 +122,25 @@ impl UpdateArgs {
         } else {
             ExpirationEnforcement::Safe
         };
-        let repository = RepositoryLoader::new(
-            &tokio::fs::read(&self.root)
-                .await
-                .context(error::OpenRootSnafu { path: &self.root })?,
+        let targets_url = Url::parse(UNUSED_URL).context(error::UrlParseSnafu { url: UNUSED_URL })?;
+        let root_bytes = tokio::fs::read(&self.root)
+            .await
+            .context(error::OpenRootSnafu { path: &self.root })?;
+        let mut loader = RepositoryLoader::new(
+            &root_bytes,
             self.metadata_base_url.clone(),
-            Url::parse(UNUSED_URL).context(error::UrlParseSnafu { url: UNUSED_URL })?,
+            targets_url.clone(),
         )
-        .expiration_enforcement(expiration_enforcement)
-        .load()
-        .await
-        .context(error::RepoLoadSnafu)?;
+        .expiration_enforcement(expiration_enforcement);
+
+        #[cfg(feature = "s3")]
+        if self.metadata_base_url.scheme() == "s3" || targets_url.scheme() == "s3" {
+            if let Some(region) = &self.s3_region {
+                loader = loader.transport(S3Transport::new_with_region(region).await);
+            }
+        }
+
+        let repository = loader.load().await.context(error::RepoLoadSnafu)?;
         self.update_metadata(
             RepositoryEditor::from_repo(&self.root, repository)
                 .await


### PR DESCRIPTION
*Issue #, if available:* #911

*Description of changes:*
Adds tough-s3 crate providing S3 transport implementation for TUF repositories. Integrates S3 URI support (s3://bucket/path) into tuftool commands: clone,
download, transfer-metadata, and update.

Changes:
- New tough-s3 crate with AWS SDK S3 client transport
- Auto-detection of S3 URIs in tuftool commands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
