### PR TITLE
require `TransportStream` is `Sync`

### DIFF
--- a/tough/src/cache.rs
+++ b/tough/src/cache.rs
@@ -4,10 +4,10 @@ use crate::schema::{RoleType, Target};
 use crate::transport::IntoVec;
 use crate::{encode_filename, Prefix, Repository, TargetName};
 use bytes::Bytes;
-use futures::StreamExt;
-use futures_core::stream::BoxStream;
+use futures::Stream;
 use snafu::{futures::TryStreamExt, OptionExt, ResultExt};
 use std::path::Path;
+use std::pin::Pin;
 use tokio::io::AsyncWriteExt;
 
 impl Repository {
@@ -281,7 +281,7 @@ impl Repository {
         target: &Target,
         digest: &[u8],
         filename: &str,
-    ) -> Result<BoxStream<'static, Result<Bytes>>> {
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + Sync + 'static>>> {
         let url = self
             .targets_base_url
             .join(filename)
@@ -289,15 +289,16 @@ impl Repository {
                 path: filename,
                 url: self.targets_base_url.clone(),
             })?;
-        Ok(fetch_sha256(
-            self.transport.as_ref(),
-            url.clone(),
-            target.length,
-            "targets.json",
-            digest,
-        )
-        .await?
-        .context(error::TransportSnafu { url })
-        .boxed())
+        Ok(Box::pin(
+            fetch_sha256(
+                self.transport.as_ref(),
+                url.clone(),
+                target.length,
+                "targets.json",
+                digest,
+            )
+            .await?
+            .context(error::TransportSnafu { url }),
+        ))
     }
 }

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -3,9 +3,6 @@
 use crate::transport::TransportStream;
 use crate::{Transport, TransportError, TransportErrorKind};
 use async_trait::async_trait;
-use futures::{FutureExt, StreamExt};
-use futures_core::future::BoxFuture;
-use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use log::trace;
 use reqwest::header::{self, HeaderValue, ACCEPT_RANGES};
@@ -15,6 +12,7 @@ use rustls::crypto::{aws_lc_rs, CryptoProvider};
 use snafu::ResultExt;
 use snafu::Snafu;
 use std::cmp::Ordering;
+use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
 use std::time::Duration;
@@ -147,15 +145,15 @@ impl Transport for HttpTransport {
     /// the `ClientSettings`.
     async fn fetch(&self, url: Url) -> Result<TransportStream, TransportError> {
         let r = RetryState::new(self.settings.initial_backoff);
-        Ok(fetch_with_retries(r, &self.settings, &url).boxed())
+        Ok(Box::pin(fetch_with_retries(r, &self.settings, &url)))
     }
 }
 
 enum RequestState {
     /// A response is streaming.
-    Streaming(BoxStream<'static, reqwest::Result<bytes::Bytes>>),
+    Streaming(Pin<Box<dyn Stream<Item = reqwest::Result<bytes::Bytes>> + Send + Sync>>),
     /// A request is pending.
-    Pending(BoxFuture<'static, reqwest::Result<reqwest::Response>>),
+    Pending(Pin<Box<dyn Future<Output = reqwest::Result<reqwest::Response>> + Send + Sync>>),
     /// No ongoing request.
     None,
 }
@@ -272,7 +270,7 @@ impl RetryStream {
                                 }
                             }
                         }
-                        self.request = RequestState::Streaming(response.bytes_stream().boxed());
+                        self.request = RequestState::Streaming(Box::pin(response.bytes_stream()));
                         cx.waker().wake_by_ref();
                         Poll::Pending
                     }
@@ -342,11 +340,10 @@ impl RetryStream {
 
         let backoff = self.retry_state.wait;
 
-        let delayed_request = async move {
+        let delayed_request = Box::pin(async move {
             tokio::time::sleep(backoff).await;
             client.execute(request).await
-        }
-        .boxed();
+        });
 
         self.request = RequestState::Pending(delayed_request);
 

--- a/tough/src/io.rs
+++ b/tough/src/io.rs
@@ -18,13 +18,12 @@ pub(crate) struct DigestAdapter {
 
 impl DigestAdapter {
     pub(crate) fn sha256(stream: TransportStream, hash: &[u8], url: Url) -> TransportStream {
-        Self {
+        Box::pin(Self {
             url,
             stream,
             hash: hash.to_owned(),
             digest: Context::new(&SHA256),
-        }
-        .boxed()
+        })
     }
 }
 
@@ -94,7 +93,7 @@ pub(crate) fn max_size_adapter(
         chunk
     });
 
-    stream.boxed()
+    Box::pin(stream)
 }
 
 /// Async analogue of `std::path::Path::is_file`
@@ -120,7 +119,7 @@ mod tests {
         transport::IntoVec,
     };
     use bytes::Bytes;
-    use futures::{stream, StreamExt};
+    use futures::stream;
     use hex_literal::hex;
     use url::Url;
 
@@ -128,30 +127,30 @@ mod tests {
     async fn test_max_size_adapter() {
         let url = Url::parse("file:///").unwrap();
 
-        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok)).boxed();
-        let stream = max_size_adapter(stream, url.clone(), 5, "test");
+        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok));
+        let stream = max_size_adapter(Box::pin(stream), url.clone(), 5, "test");
         let buf = stream.into_vec().await.expect("consuming entire stream");
         assert_eq!(buf, b"hello");
 
-        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok)).boxed();
-        let stream = max_size_adapter(stream, url, 4, "test");
+        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok));
+        let stream = max_size_adapter(Box::pin(stream), url, 4, "test");
         assert!(stream.into_vec().await.is_err());
     }
 
     #[tokio::test]
     async fn test_digest_adapter() {
-        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok)).boxed();
+        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok));
         let stream = DigestAdapter::sha256(
-            stream,
+            Box::pin(stream),
             &hex!("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
             Url::parse("file:///").unwrap(),
         );
         let buf = stream.into_vec().await.expect("consuming entire stream");
         assert_eq!(buf, b"hello");
 
-        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok)).boxed();
+        let stream = stream::iter("hello".as_bytes().chunks(2).map(Bytes::from).map(Ok));
         let stream = DigestAdapter::sha256(
-            stream,
+            Box::pin(stream),
             &hex!("0ebdc3317b75839f643387d783535adc360ca01f33c75f7c1e7373adcd675c0b"),
             Url::parse("file:///").unwrap(),
         );

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -456,8 +456,9 @@ impl Repository {
     pub async fn read_target(
         &self,
         name: &TargetName,
-    ) -> Result<Option<impl Stream<Item = error::Result<Bytes>> + IntoVec<error::Error> + Send>>
-    {
+    ) -> Result<
+        Option<impl Stream<Item = error::Result<Bytes>> + IntoVec<error::Error> + Send + Sync>,
+    > {
         // Check for repository metadata expiration.
         if self.expiration_enforcement == ExpirationEnforcement::Safe {
             ensure!(

--- a/tough/src/transport.rs
+++ b/tough/src/transport.rs
@@ -4,7 +4,7 @@ use crate::{HttpTransport, HttpTransportBuilder};
 use async_trait::async_trait;
 use bytes::Bytes;
 use dyn_clone::DynClone;
-use futures::{StreamExt, TryStreamExt};
+use futures::TryStreamExt;
 use futures_core::Stream;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
@@ -15,7 +15,7 @@ use tokio_util::io::ReaderStream;
 use url::Url;
 
 /// Type alias for the stream returned by transports
-pub type TransportStream = Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send>>;
+pub type TransportStream = Pin<Box<dyn Stream<Item = Result<Bytes, TransportError>> + Send + Sync>>;
 
 /// Fallible byte streams that collect into a `Vec<u8>`.
 #[async_trait]
@@ -207,10 +207,9 @@ impl Transport for FilesystemTransport {
             };
             TransportError::new_with_cause(kind, url.clone(), e)
         };
-        Ok(stream
-            .map_err(map_io_err.clone())?
-            .map_err(map_io_err)
-            .boxed())
+        Ok(Box::pin(
+            stream.map_err(map_io_err.clone())?.map_err(map_io_err),
+        ))
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #928

*Description of changes:*

Streams returned from tough cannot be shared between threads because they are `!Sync`. As it turns out, all of the transports I'm aware of (the three in tough itself, and the one I've recently written to read from ZIP archives) return streams that are already `Sync`, but they can't be used in other parts of the Rust ecosystem that require `Sync` streams. (In my case I am currently butting up against [`dropshot::Body`](https://docs.rs/dropshot/latest/dropshot/struct.Body.html) requiring `Sync` for a service that is proxying targets from a TUF repository.)

This stems from the use of `futures::stream::BoxStream` internally, whose type does not specify `Send`. Replacing `.boxed()` with `Box::pin` is sufficient.

This is a breaking change, but not one I expect most consumers will need to be concerned with.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
