### PR TITLE
Fix/replace openssl shellout with aws lc rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "aws-lc-rs",
  "aws-sdk-kms",
  "aws-sdk-ssm",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "futures",

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -21,6 +21,7 @@ aws-config = { version = "1", default-features = false, features = ["credentials
 aws-lc-rs = "1"
 aws-sdk-kms = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-ssm = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
+base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -1,9 +1,5 @@
 **tuftool** is a Rust command-line utility for generating and signing TUF repositories.
 
-## Dependencies
-
-Make sure you have the following dependencies present on your system before installing `tuftool`:
-
 ## Installing
 
 To install the latest version of `tuftool`:

--- a/tuftool/README.md
+++ b/tuftool/README.md
@@ -4,8 +4,6 @@
 
 Make sure you have the following dependencies present on your system before installing `tuftool`:
 
-- OpenSSL: install `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.
-
 ## Installing
 
 To install the latest version of `tuftool`:
@@ -52,7 +50,6 @@ tuftool root set-threshold "${ROOT}" snapshot 1
 tuftool root set-threshold "${ROOT}" targets 1
 tuftool root set-threshold "${ROOT}" timestamp 1
 
-# create an RSA key and store it as a file. this requires openssl on your system
 # this command both creates the key and adds it to root.json for the root role
 tuftool root gen-rsa-key "${ROOT}" "${WRK}/keys/root.pem" --role root
 

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -19,27 +19,6 @@ pub(crate) enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to run {}: {}", command_str, source))]
-    CommandExec {
-        command_str: String,
-        source: std::io::Error,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Command {} failed with {}", command_str, status))]
-    CommandStatus {
-        command_str: String,
-        status: std::process::ExitStatus,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display("Command {} output is not valid UTF-8: {}", command_str, source))]
-    CommandUtf8 {
-        command_str: String,
-        source: std::string::FromUtf8Error,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Cannot determine current directory: {}", source))]
     CurrentDir {
         source: std::io::Error,
@@ -328,6 +307,15 @@ pub(crate) enum Error {
     WalkDir {
         directory: PathBuf,
         source: walkdir::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Unsupported RSA key size: {bits} bits. Supported: 2048, 3072, 4096"))]
+    UnsupportedRsaKeySize { bits: u16 },
+
+    #[snafu(display("Failed to generate RSA key: {}", source))]
+    RsaKeyGenerate {
+        source: aws_lc_rs::error::Unspecified,
         backtrace: Backtrace,
     },
 

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -5,8 +5,8 @@ use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use crate::{load_file, write_file};
-use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::encoding::{AsDer, Pkcs8V1Der};
+use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::rsa::{KeySize, PrivateDecryptingKey};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{DateTime, Timelike, Utc};
@@ -313,7 +313,8 @@ impl Command {
             AsDer::<Pkcs8V1Der<'_>>::as_der(&private_key).context(error::RsaKeyGenerateSnafu)?;
         let pem = format!(
             "-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----\n",
-            BASE64.encode(der.as_ref())
+            BASE64
+                .encode(der.as_ref())
                 .as_bytes()
                 .chunks(64)
                 .map(|c| std::str::from_utf8(c).unwrap())

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -6,6 +6,9 @@ use crate::error::{self, Result};
 use crate::source::parse_key_source;
 use crate::{load_file, write_file};
 use aws_lc_rs::rand::SystemRandom;
+use aws_lc_rs::encoding::{AsDer, Pkcs8V1Der};
+use aws_lc_rs::rsa::{KeySize, PrivateDecryptingKey};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{DateTime, Timelike, Utc};
 use clap::Parser;
 use log::warn;
@@ -295,32 +298,32 @@ impl Command {
     ) -> Result<()> {
         let mut root: Signed<Root> = load_file(path).await?;
 
-        // ring doesn't support RSA key generation yet
-        // https://github.com/briansmith/ring/issues/219
-        let mut command = std::process::Command::new("openssl");
-        command.args(["genpkey", "-algorithm", "RSA", "-pkeyopt"]);
-        command.arg(format!("rsa_keygen_bits:{bits}"));
-        command.arg("-pkeyopt");
-        command.arg(format!("rsa_keygen_pubexp:{exponent}"));
-
-        let command_str = format!("{command:?}");
-        let output = command.output().context(error::CommandExecSnafu {
-            command_str: &command_str,
-        })?;
-        ensure!(
-            output.status.success(),
-            error::CommandStatusSnafu {
-                command_str: &command_str,
-                status: output.status
-            }
+        if exponent != 65537 {
+            warn!("--exp {exponent} ignored; aws-lc-rs uses the standard public exponent 65537");
+        }
+        let key_size = match bits {
+            2048 => KeySize::Rsa2048,
+            3072 => KeySize::Rsa3072,
+            4096 => KeySize::Rsa4096,
+            _ => return Err(error::Error::UnsupportedRsaKeySize { bits }),
+        };
+        let private_key =
+            PrivateDecryptingKey::generate(key_size).context(error::RsaKeyGenerateSnafu)?;
+        let der =
+            AsDer::<Pkcs8V1Der<'_>>::as_der(&private_key).context(error::RsaKeyGenerateSnafu)?;
+        let pem = format!(
+            "-----BEGIN PRIVATE KEY-----\n{}\n-----END PRIVATE KEY-----\n",
+            BASE64.encode(der.as_ref())
+                .as_bytes()
+                .chunks(64)
+                .map(|c| std::str::from_utf8(c).unwrap())
+                .collect::<Vec<_>>()
+                .join("\n")
         );
-        let stdout =
-            String::from_utf8(output.stdout).context(error::CommandUtf8Snafu { command_str })?;
-
-        let key_pair = parse_keypair(stdout.as_bytes()).context(error::KeyPairParseSnafu)?;
+        let key_pair = parse_keypair(pem.as_bytes()).context(error::KeyPairParseSnafu)?;
         let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.tuf_key())?);
         let key = parse_key_source(key_source)?;
-        key.write(&stdout, &key_id)
+        key.write(&pem, &key_id)
             .await
             .context(error::WriteKeySourceSnafu)?;
         clear_sigs(&mut root);

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -443,10 +443,14 @@ fn gen_rsa_key_and_sign_root() {
             "gen-rsa-key",
             root_json.to_str().unwrap(),
             key_path.to_str().unwrap(),
-            "--role", "root",
-            "--role", "snapshot",
-            "--role", "targets",
-            "--role", "timestamp",
+            "--role",
+            "root",
+            "--role",
+            "snapshot",
+            "--role",
+            "targets",
+            "--role",
+            "timestamp",
         ])
         .assert()
         .success();

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -417,3 +417,73 @@ fn set_version_root() {
     // validate version number
     assert_eq!(get_version(root_json.to_str().unwrap()), version);
 }
+
+#[test]
+fn gen_rsa_key_and_sign_root() {
+    let out_dir = TempDir::new().unwrap();
+    let root_json = out_dir.path().join("root.json");
+    let key_path = out_dir.path().join("generated.pem");
+
+    initialize_root_json(root_json.to_str().unwrap());
+
+    cargo_bin_cmd!("tuftool")
+        .args([
+            "root",
+            "set-threshold",
+            root_json.to_str().unwrap(),
+            "root",
+            "1",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("tuftool")
+        .args([
+            "root",
+            "gen-rsa-key",
+            root_json.to_str().unwrap(),
+            key_path.to_str().unwrap(),
+            "--role", "root",
+            "--role", "snapshot",
+            "--role", "targets",
+            "--role", "timestamp",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("tuftool")
+        .args([
+            "root",
+            "sign",
+            root_json.to_str().unwrap(),
+            "-k",
+            key_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(get_sign_len(root_json.to_str().unwrap()), 1);
+}
+
+#[test]
+fn gen_rsa_key_unsupported_size_fails() {
+    let out_dir = TempDir::new().unwrap();
+    let root_json = out_dir.path().join("root.json");
+    let key_path = out_dir.path().join("generated.pem");
+
+    initialize_root_json(root_json.to_str().unwrap());
+
+    cargo_bin_cmd!("tuftool")
+        .args([
+            "root",
+            "gen-rsa-key",
+            root_json.to_str().unwrap(),
+            key_path.to_str().unwrap(),
+            "--role",
+            "root",
+            "--bits",
+            "1024",
+        ])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
Issue: #627

`gen-rsa-key` was shelling out to the system `openssl` binary to generate RSA keys. When #825 migrated the crypto backend from `ring` to `aws-lc-rs`, this shell-out was not addressed — RSA key generation via `aws-lc-rs` may not have been available at the time.

This PR replaces the `std::process::Command` openssl shell-out with `aws-lc-rs`, which is already a dependency.

Changes:
- `gen_rsa_key` now uses `aws_lc_rs::rsa::PrivateDecryptingKey` for key generation
- `--bits` restricted to 2048, 3072, 4096 — other values return a clear error
- `--exp` retained for CLI compatibility but ignored if non-65537, with a warning
- Removes dead error variants `CommandExec`, `CommandStatus`, `CommandUtf8`
- Removes OpenSSL installation requirement from README
- Adds `base64 = "0.22"` as a new dependency for DER-to-PEM encoding
- Adds two new tests: `gen_rsa_key_and_sign_root` and `gen_rsa_key_unsupported_size_fails`

Testing: `cargo test` passes (full workspace).

Note: the snakeoil test fixtures in `tests/data/` could be regenerated using  the new code path to provide additional coverage, if the maintainers wish to do so in a follow-up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.