### PR TITLE
tough: make rustls optional via http-rustls-tls / http-native-tls features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,8 +1290,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1295,9 +1303,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1600,6 +1610,22 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1931,6 +1957,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maplit"
@@ -2340,6 +2372,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,7 +2594,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -2546,16 +2634,20 @@ dependencies = [
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util 0.7.18",
  "tower 0.5.3",
@@ -2667,6 +2759,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3309,7 +3402,6 @@ dependencies = [
  "pem",
  "percent-encoding",
  "reqwest 0.13.3",
- "rustls",
  "serde",
  "serde_json",
  "serde_plain",
@@ -3797,6 +3889,16 @@ name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -24,7 +24,6 @@ olpc-cjson = { version = "0.1", path = "../olpc-cjson" }
 pem = "3"
 percent-encoding = "2"
 reqwest = { version = "0.13", optional = true, default-features = false, features = ["stream"] }
-rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_plain = "1"
@@ -48,8 +47,19 @@ tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-test = "0.4"
 
 [features]
-fips = ["aws-lc-rs/fips", "rustls/fips"]
-http = ["reqwest"]
+fips = ["aws-lc-rs/fips"]
+# Enables `HttpTransport` (and pulls in `reqwest`). Does NOT pick a TLS
+# backend on its own — enable `http-rustls-tls` or `http-native-tls` to
+# get TLS, or let another crate in the dep graph configure `reqwest`.
+http = ["dep:reqwest"]
+# Use `rustls` (with `aws-lc-rs` as the crypto provider) for HTTPS via
+# `reqwest`. Note: in reqwest 0.13 the feature was renamed from
+# `rustls-tls` to `rustls`; reqwest installs the `aws-lc-rs` provider
+# on its own when this feature is enabled.
+http-rustls-tls = ["http", "reqwest/rustls"]
+# Use the platform's native TLS stack (OpenSSL / Secure Transport /
+# SChannel) for HTTPS via `reqwest`. Avoids pulling in `rustls`.
+http-native-tls = ["http", "reqwest/native-tls"]
 
 # The `integ` feature enables integration tests. These tests require `noxious-server` to be installed on the host.
 integ = []

--- a/tough/src/http.rs
+++ b/tough/src/http.rs
@@ -8,7 +8,6 @@ use log::trace;
 use reqwest::header::{self, HeaderValue, ACCEPT_RANGES};
 use reqwest::{Client, ClientBuilder, Request, Response};
 use reqwest::{Error, Method};
-use rustls::crypto::{aws_lc_rs, CryptoProvider};
 use snafu::ResultExt;
 use snafu::Snafu;
 use std::cmp::Ordering;
@@ -44,14 +43,6 @@ pub struct HttpTransportBuilder {
 
 impl Default for HttpTransportBuilder {
     fn default() -> Self {
-        // Set the aws_lc_rs CryptoProvider for rustls. This is to ensure that the reqwest client
-        // is using a FIPS enabled aws_lc_rs when creating a client. Otherwise, ring is used:
-        // https://github.com/seanmonstar/reqwest/blob/d85f44b217f36f8bef065fe95877eab98c52c2e5/src/async_impl/client.rs#L577-L587
-        // This can be called successfully at most once in any process execution: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#method.install_default
-        // The return type is Result<(), Arc<Self>>, which can be dropped.
-        if CryptoProvider::get_default().is_none() {
-            let _ = aws_lc_rs::default_provider().install_default();
-        }
         Self {
             timeout: std::time::Duration::from_secs(30),
             connect_timeout: std::time::Duration::from_secs(10),


### PR DESCRIPTION
## Summary

`tough` currently has `rustls = \"0.23\"` as an unconditional, non-optional
dependency, even though `rustls` is only used in `src/http.rs` — which is
already gated behind `#[cfg(feature = \"http\")]` in `lib.rs`. The single use
site is `HttpTransportBuilder::default()`, which calls
`aws_lc_rs::default_provider().install_default()` to set rustls' process-wide
crypto provider.

This forces `rustls` (and aws-lc-rs's full compile cost) on every consumer of
`tough`, including consumers using `reqwest/native-tls` who have no use for
rustls at all. For example, [rattler](https://github.com/conda/rattler) hits
this through the sigstore-rs dependency chain when building with `native-tls`.

### Why we can drop `rustls` entirely

reqwest 0.13 changed how the rustls crypto provider is selected.

- **reqwest 0.12** read `CryptoProvider::get_default()` and fell back to
  `ring` if nothing was installed
  ([client.rs#L763-L771](https://github.com/seanmonstar/reqwest/blob/v0.12.28/src/async_impl/client.rs#L763-L771)).
  Tough's pre-install was needed so reqwest would pick `aws-lc-rs` over `ring`.
- **reqwest 0.13** constructs `aws_lc_rs::default_provider()` directly when
  the `rustls` feature is enabled
  ([client.rs#L2458-L2465](https://github.com/seanmonstar/reqwest/blob/v0.13.3/src/async_impl/client.rs#L2458-L2465)).
  It no longer reads from `CryptoProvider::get_default()`, so tough's
  pre-install is dead code as of the 0.13 bump.

`tuftool` already installs its own `aws_lc_rs::default_provider()` provider
in `main.rs:74-78`, so it is unaffected.

## Changes

- Drop `rustls` from `tough/Cargo.toml`'s `[dependencies]`.
- Remove the `use rustls::crypto::{aws_lc_rs, CryptoProvider};` import and
  the `install_default()` block in `HttpTransportBuilder::default()`.
- Add new features mirroring reqwest's TLS naming:
  - `http-rustls-tls = [\"http\", \"reqwest/rustls\"]`
  - `http-native-tls = [\"http\", \"reqwest/native-tls\"]`
  - `http` itself no longer enables any TLS backend (matches the previous
    behavior where `reqwest = { default-features = false, features = [\"stream\"] }`
    already didn't pick a backend).
- `fips` drops the `rustls/fips` half — tough no longer depends on rustls,
  so downstream crates that bring in rustls themselves should enable
  `rustls/fips` from their own manifest.

> Note: in reqwest 0.13 the rustls feature was renamed from `rustls-tls`
> to `rustls`. The Cargo.toml comment flags this for anyone migrating.

## Migration

- Users on `features = [\"http\"]` who relied on tough configuring rustls
  for them should switch to `features = [\"http-rustls-tls\"]`.
- Users with TLS already configured elsewhere (e.g., their own
  `reqwest` dep with `rustls`/`native-tls`) need no changes — `\"http\"`
  alone is sufficient, just like before.

## Test plan

- [x] `cargo check -p tough` with each of: default, `http`, `http-rustls-tls`,
      `http-native-tls`, `fips` — all pass
- [x] `cargo tree -i rustls --features http-native-tls` confirms no rustls
      in the tree
- [x] Full workspace builds (`cargo build --workspace`)
- [x] `cargo test -p tough --features http-rustls-tls` — all tests pass