### PR TITLE
Implement TAP 12

### DIFF
--- a/tough/src/editor/keys.rs
+++ b/tough/src/editor/keys.rs
@@ -6,6 +6,7 @@ use crate::key_source::KeySource;
 use crate::schema::key::KeyId;
 use crate::schema::{Delegations, KeyHolder, RoleId, RoleKeys, Root, Signed, Targets};
 use crate::sign::Sign;
+use crate::KeyIdFormat;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 
@@ -53,20 +54,24 @@ impl KeyHolder {
     }
 
     /// Verifies the role using `KeyHolder`'s keys
-    pub(crate) fn verify_role(&self, targets: &Signed<Targets>, name: &str) -> Result<()> {
+    pub(crate) fn verify_role(
+        &self,
+        targets: &Signed<Targets>,
+        name: &str,
+        key_id_format: KeyIdFormat,
+    ) -> Result<()> {
         match self {
-            Self::Delegations(delegations) => {
-                delegations
-                    .verify_role(targets, name)
+            Self::Delegations(delegations) => delegations
+                .verify_role(targets, name, key_id_format)
+                .context(error::VerifyRoleMetadataSnafu {
+                    role: name.to_string(),
+                }),
+            Self::Root(root) => {
+                root.verify_role(targets, key_id_format)
                     .context(error::VerifyRoleMetadataSnafu {
                         role: name.to_string(),
                     })
             }
-            Self::Root(root) => root
-                .verify_role(targets)
-                .context(error::VerifyRoleMetadataSnafu {
-                    role: name.to_string(),
-                }),
         }
     }
 }

--- a/tough/src/editor/keys.rs
+++ b/tough/src/editor/keys.rs
@@ -3,14 +3,14 @@
 
 use crate::error::{self, Result};
 use crate::key_source::KeySource;
-use crate::schema::decoded::{Decoded, Hex};
+use crate::schema::key::KeyId;
 use crate::schema::{Delegations, KeyHolder, RoleId, RoleKeys, Root, Signed, Targets};
 use crate::sign::Sign;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::collections::HashMap;
 
 /// A map of key ID (from root.json or the Delegations field of any Targets) to its corresponding signing key
-pub(crate) type KeyList = HashMap<Decoded<Hex>, Box<dyn Sign>>;
+pub(crate) type KeyList = HashMap<KeyId, Box<dyn Sign>>;
 
 impl KeyHolder {
     /// Creates a key list for the provided keys

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -14,8 +14,7 @@ use crate::editor::targets::TargetsEditor;
 use crate::error::{self, Result};
 use crate::fetch::fetch_max_size;
 use crate::key_source::KeySource;
-use crate::schema::decoded::{Decoded, Hex};
-use crate::schema::key::Key;
+use crate::schema::key::{Key, KeyId};
 use crate::schema::{
     Hashes, KeyHolder, Metafile, PathSet, Role, RoleType, Root, Signed, Snapshot, Target, Targets,
     Timestamp,
@@ -669,7 +668,7 @@ impl RepositoryEditor {
         paths: PathSet,
         terminating: bool,
         threshold: NonZeroU64,
-        keys: Option<HashMap<Decoded<Hex>, Key>>,
+        keys: Option<HashMap<KeyId, Key>>,
     ) -> Result<&mut Self> {
         let limits = self.limits.context(error::MissingLimitsSnafu)?;
         let transport = self

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -82,6 +82,8 @@ pub struct RepositoryEditor {
 
     transport: Option<Box<dyn Transport>>,
     limits: Option<Limits>,
+
+    key_id_format: KeyIdFormat,
 }
 
 impl RepositoryEditor {
@@ -136,6 +138,7 @@ impl RepositoryEditor {
             signed_targets: None,
             transport: None,
             limits: None,
+            key_id_format: KeyIdFormat::HashedKey,
         })
     }
 
@@ -153,6 +156,7 @@ impl RepositoryEditor {
         editor.timestamp(repo.timestamp.signed)?;
         editor.transport = Some(repo.transport.clone());
         editor.limits = Some(repo.limits);
+        editor.key_id_format = repo.key_id_format;
         Ok(editor)
     }
 
@@ -561,7 +565,7 @@ impl RepositoryEditor {
                     })?;
             (KeyHolder::Delegations(parent), &mut targets.signed)
         };
-        parent.verify_role(&role, name, KeyIdFormat::Any)?;
+        parent.verify_role(&role, name, self.key_id_format)?;
         // Make sure the version isn't downgraded
         ensure!(
             role.signed.version >= current_targets.version,

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -20,7 +20,7 @@ use crate::schema::{
     Timestamp,
 };
 use crate::transport::{IntoVec, Transport};
-use crate::{encode_filename, Limits};
+use crate::{encode_filename, KeyIdFormat, Limits};
 use crate::{Repository, TargetName};
 use aws_lc_rs::digest::{SHA256, SHA256_OUTPUT_LEN};
 use aws_lc_rs::rand::SystemRandom;
@@ -561,7 +561,7 @@ impl RepositoryEditor {
                     })?;
             (KeyHolder::Delegations(parent), &mut targets.signed)
         };
-        parent.verify_role(&role, name)?;
+        parent.verify_role(&role, name, KeyIdFormat::Any)?;
         // Make sure the version isn't downgraded
         ensure!(
             role.signed.version >= current_targets.version,
@@ -646,7 +646,7 @@ impl RepositoryEditor {
                     role: RoleType::Targets,
                 })?;
             // verify the role
-            key_holder.verify_role(&new_role, &name)?;
+            key_holder.verify_role(&new_role, &name, KeyIdFormat::Any)?;
             // add the new role
             delegations
                 .roles

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -8,8 +8,7 @@ use crate::editor::signed::{SignedDelegatedTargets, SignedRole};
 use crate::error::{self, Result};
 use crate::fetch::fetch_max_size;
 use crate::key_source::KeySource;
-use crate::schema::decoded::{Decoded, Hex};
-use crate::schema::key::Key;
+use crate::schema::key::{Key, KeyId};
 use crate::schema::{
     DelegatedRole, DelegatedTargets, Delegations, KeyHolder, PathSet, RoleType, Signed, Target,
     Targets,
@@ -271,11 +270,7 @@ impl TargetsEditor {
     }
 
     /// Adds a key to delegations keyids, adds the key to `role` if it is provided
-    pub fn add_key(
-        &mut self,
-        keys: HashMap<Decoded<Hex>, Key>,
-        role: Option<&str>,
-    ) -> Result<&mut Self> {
+    pub fn add_key(&mut self, keys: HashMap<KeyId, Key>, role: Option<&str>) -> Result<&mut Self> {
         let delegations = self
             .delegations
             .as_mut()
@@ -311,7 +306,7 @@ impl TargetsEditor {
     }
 
     /// Removes a key from delegations keyids, if a role is specified the key is only removed from the role
-    pub fn remove_key(&mut self, keyid: &Decoded<Hex>, role: Option<&str>) -> Result<&mut Self> {
+    pub fn remove_key(&mut self, keyid: &KeyId, role: Option<&str>) -> Result<&mut Self> {
         let delegations = self
             .delegations
             .as_mut()
@@ -337,8 +332,8 @@ impl TargetsEditor {
         targets: Signed<DelegatedTargets>,
         paths: PathSet,
         terminating: bool,
-        key_pairs: HashMap<Decoded<Hex>, Key>,
-        keyids: Vec<Decoded<Hex>>,
+        key_pairs: HashMap<KeyId, Key>,
+        keyids: Vec<KeyId>,
         threshold: NonZeroU64,
     ) -> Result<&mut Self> {
         self.add_key(key_pairs, None)?;
@@ -391,7 +386,7 @@ impl TargetsEditor {
         paths: PathSet,
         terminating: bool,
         threshold: NonZeroU64,
-        keys: Option<HashMap<Decoded<Hex>, Key>>,
+        keys: Option<HashMap<KeyId, Key>>,
     ) -> Result<&mut Self> {
         let limits = self.limits.context(error::MissingLimitsSnafu)?;
         let transport: &dyn Transport = self

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -115,6 +115,21 @@ impl From<ExpirationEnforcement> for bool {
     }
 }
 
+/// Define the validation performed on Key IDs when verifying roles.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyIdFormat {
+    /// Key IDs must be the hexdigest of the SHA-256 hash of the canonical JSON form of the key.
+    /// Attempting to load a key with an unexpected ID will result in an error.
+    ///
+    /// This is the behavior defined in TUF version 1.0.0.
+    #[default]
+    HashedKey,
+    /// Key IDs can be any arbitrary string, and no validation is performed on them.
+    ///
+    /// This is the behavior defined in TAP 12.
+    Any,
+}
+
 /// A builder for settings with which to load a [`Repository`]. Required settings are provided in
 /// the [`RepositoryLoader::new`] function. Optional parameters can be added after calling new.
 /// Finally, call [`RepositoryLoader::load`] to load the [`Repository`].
@@ -179,6 +194,7 @@ pub struct RepositoryLoader<'a> {
     limits: Option<Limits>,
     datastore: Option<PathBuf>,
     expiration_enforcement: Option<ExpirationEnforcement>,
+    key_id_format: Option<KeyIdFormat>,
 }
 
 impl<'a> RepositoryLoader<'a> {
@@ -200,6 +216,7 @@ impl<'a> RepositoryLoader<'a> {
             limits: None,
             datastore: None,
             expiration_enforcement: None,
+            key_id_format: None,
         }
     }
 
@@ -243,6 +260,13 @@ impl<'a> RepositoryLoader<'a> {
     #[must_use]
     pub fn expiration_enforcement(mut self, exp: ExpirationEnforcement) -> Self {
         self.expiration_enforcement = Some(exp);
+        self
+    }
+
+    /// Set the [`KeyIdFormat`] to configure how Key IDs are validated.
+    #[must_use]
+    pub fn key_id_format(mut self, format: KeyIdFormat) -> Self {
+        self.key_id_format = Some(format);
         self
     }
 }
@@ -338,6 +362,7 @@ impl Repository {
             .unwrap_or_else(|| Box::new(DefaultTransport::new()));
         let limits = loader.limits.unwrap_or_default();
         let expiration_enforcement = loader.expiration_enforcement.unwrap_or_default();
+        let key_id_format = loader.key_id_format.unwrap_or_default();
         let metadata_base_url = parse_url(loader.metadata_base_url)?;
         let targets_base_url = parse_url(loader.targets_base_url)?;
         let update_start = datastore.system_time().await?;
@@ -351,6 +376,7 @@ impl Repository {
             limits.max_root_updates,
             &metadata_base_url,
             expiration_enforcement,
+            key_id_format,
             &update_start,
         )
         .await?;
@@ -363,6 +389,7 @@ impl Repository {
             limits.max_timestamp_size,
             &metadata_base_url,
             expiration_enforcement,
+            key_id_format,
             &update_start,
         )
         .await?;
@@ -376,6 +403,7 @@ impl Repository {
             &datastore,
             &metadata_base_url,
             expiration_enforcement,
+            key_id_format,
             &update_start,
         )
         .await?;
@@ -389,6 +417,7 @@ impl Repository {
             limits.max_targets_size,
             &metadata_base_url,
             expiration_enforcement,
+            key_id_format,
             &update_start,
         )
         .await?;
@@ -695,6 +724,7 @@ async fn load_root<R: AsRef<[u8]>>(
     max_root_updates: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     update_start: &JiffTimestamp,
 ) -> Result<Signed<Root>> {
     // 5.2. Load the trusted root metadata file. We assume that a good, trusted copy of this file was
@@ -704,7 +734,7 @@ async fn load_root<R: AsRef<[u8]>>(
     let mut root: Signed<Root> =
         serde_json::from_slice(root.as_ref()).context(error::ParseTrustedMetadataSnafu)?;
     root.signed
-        .verify_role(&root)
+        .verify_role(&root, key_id_format)
         .context(error::VerifyTrustedMetadataSnafu)?;
 
     // Used in step 5.3
@@ -775,14 +805,14 @@ async fn load_root<R: AsRef<[u8]>>(
                 //   file being validated (version N+1). If version N+1 is not signed as required,
                 //   discard it, abort the update cycle, and report the signature failure. On the
                 //   next update cycle, begin at step 0 and version N of the root metadata file.
-                root.signed
-                    .verify_role(&new_root)
-                    .context(error::VerifyMetadataSnafu {
+                root.signed.verify_role(&new_root, key_id_format).context(
+                    error::VerifyMetadataSnafu {
                         role: RoleType::Root,
-                    })?;
+                    },
+                )?;
                 new_root
                     .signed
-                    .verify_role(&new_root)
+                    .verify_role(&new_root, key_id_format)
                     .context(error::VerifyMetadataSnafu {
                         role: RoleType::Root,
                     })?;
@@ -860,6 +890,7 @@ async fn load_root<R: AsRef<[u8]>>(
 }
 
 /// Step 2 of the client application, which loads the timestamp metadata file.
+#[expect(clippy::too_many_arguments)]
 async fn load_timestamp(
     transport: &dyn Transport,
     root: &Signed<Root>,
@@ -867,6 +898,7 @@ async fn load_timestamp(
     max_timestamp_size: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     update_start: &JiffTimestamp,
 ) -> Result<Signed<Timestamp>> {
     // 2. Download the timestamp metadata file, up to Y number of bytes (because the size is
@@ -900,7 +932,7 @@ async fn load_timestamp(
     //   of keys specified in the trusted root metadata file. If the new timestamp metadata file is
     //   not properly signed, discard it, abort the update cycle, and report the signature failure.
     root.signed
-        .verify_role(&timestamp)
+        .verify_role(&timestamp, key_id_format)
         .context(error::VerifyMetadataSnafu {
             role: RoleType::Timestamp,
         })?;
@@ -931,7 +963,11 @@ async fn load_timestamp(
         .await?
         .map(|b| serde_json::from_slice::<Signed<Timestamp>>(&b))
     {
-        if root.signed.verify_role(&old_timestamp).is_ok() {
+        if root
+            .signed
+            .verify_role(&old_timestamp, key_id_format)
+            .is_ok()
+        {
             ensure!(
                 old_timestamp.signed.version <= timestamp.signed.version,
                 error::OlderMetadataSnafu {
@@ -991,6 +1027,7 @@ async fn load_snapshot(
     datastore: &Datastore,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     update_start: &JiffTimestamp,
 ) -> Result<Signed<Snapshot>> {
     // 3. Download snapshot metadata file, up to the number of bytes specified in the timestamp
@@ -1068,7 +1105,7 @@ async fn load_snapshot(
     //   not signed as required, discard it, abort the update cycle, and report the signature
     //   failure.
     root.signed
-        .verify_role(&snapshot)
+        .verify_role(&snapshot, key_id_format)
         .context(error::VerifyMetadataSnafu {
             role: RoleType::Snapshot,
         })?;
@@ -1093,7 +1130,11 @@ async fn load_snapshot(
         //   than or equal to the version number of the new snapshot metadata file. If the new
         //   snapshot metadata file is older than the trusted metadata file, discard it, abort the
         //   update cycle, and report the potential rollback attack.
-        if root.signed.verify_role(&old_snapshot).is_ok() {
+        if root
+            .signed
+            .verify_role(&old_snapshot, key_id_format)
+            .is_ok()
+        {
             ensure!(
                 old_snapshot.signed.version <= snapshot.signed.version,
                 error::OlderMetadataSnafu {
@@ -1185,6 +1226,7 @@ async fn load_targets(
     max_targets_size: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     update_start: &JiffTimestamp,
 ) -> Result<(
     Signed<crate::schema::Targets>,
@@ -1257,7 +1299,7 @@ async fn load_targets(
     //   targets metadata file is not signed as required, discard it, abort the update cycle, and
     //   report the failure.
     root.signed
-        .verify_role(&targets)
+        .verify_role(&targets, key_id_format)
         .context(error::VerifyMetadataSnafu {
             role: RoleType::Targets,
         })?;
@@ -1299,6 +1341,7 @@ async fn load_targets(
             &mut loaded_roles,
             update_start,
             expiration_enforcement,
+            key_id_format,
             &mut delegated_metadata_bytes,
         )
         .await?;
@@ -1325,6 +1368,7 @@ async fn load_delegations(
     loaded_roles: &mut BTreeSet<String>,
     update_start: &JiffTimestamp,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     delegated_metadata_bytes: &mut std::collections::HashMap<String, Vec<u8>>,
 ) -> Result<()> {
     let mut delegated_roles: HashMap<String, Option<Signed<crate::schema::Targets>>> =
@@ -1397,7 +1441,7 @@ async fn load_delegations(
             })?;
         // verify each role with the delegation
         delegation
-            .verify_role(&role, &delegated_role.name)
+            .verify_role(&role, &delegated_role.name, key_id_format)
             .context(error::VerifyMetadataSnafu {
                 role: RoleType::Targets,
             })?;
@@ -1442,6 +1486,7 @@ async fn load_delegations(
                     loaded_roles,
                     update_start,
                     expiration_enforcement,
+                    key_id_format,
                     delegated_metadata_bytes,
                 )
                 .await?;

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -350,6 +350,7 @@ pub struct Repository {
     metadata_base_url: Url,
     targets_base_url: Url,
     expiration_enforcement: ExpirationEnforcement,
+    key_id_format: KeyIdFormat,
     delegated_metadata_bytes: std::collections::HashMap<String, Vec<u8>>,
 }
 
@@ -445,6 +446,7 @@ impl Repository {
             metadata_base_url,
             targets_base_url,
             expiration_enforcement,
+            key_id_format,
             delegated_metadata_bytes,
         })
     }

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -1384,7 +1384,7 @@ async fn load_delegations(
         let role_meta = snapshot
             .signed
             .meta
-            .get(&format!("{}.json", &delegated_role.name));
+            .get(&format!("{}.json", delegated_role.name));
 
         if role_meta.is_none() {
             // 5.6.7: If any metadata requested in steps 5.6.7.1 - 5.6.7.2 cannot be downloaded nor validated, end the search and report that the target cannot be found.
@@ -1395,7 +1395,7 @@ async fn load_delegations(
         let path = if consistent_snapshot {
             format!(
                 "{}.{}.json",
-                &role_meta.version,
+                role_meta.version,
                 encode_filename(&delegated_role.name)
             )
         } else {

--- a/tough/src/schema/de.rs
+++ b/tough/src/schema/de.rs
@@ -19,14 +19,6 @@ where
         key: Key,
         map: &mut HashMap<KeyId, Key>,
     ) -> Result<(), error::Error> {
-        let calculated = key.key_id()?;
-        ensure!(
-            keyid == calculated,
-            error::InvalidKeyIdSnafu {
-                keyid: keyid,
-                calculated: calculated,
-            }
-        );
         ensure!(
             map.insert(keyid.clone(), key).is_none(),
             error::DuplicateKeyIdSnafu { keyid }

--- a/tough/src/schema/de.rs
+++ b/tough/src/schema/de.rs
@@ -1,15 +1,12 @@
-use crate::schema::decoded::{Decoded, Hex};
 use crate::schema::error;
-use crate::schema::key::Key;
+use crate::schema::key::{Key, KeyId};
 use serde::{de::Error as _, Deserialize, Deserializer};
 use snafu::ensure;
 use std::collections::HashMap;
 use std::fmt;
 
 /// Validates the key ID for each key during deserialization and fails if any don't match.
-pub(super) fn deserialize_keys<'de, D>(
-    deserializer: D,
-) -> Result<HashMap<Decoded<Hex>, Key>, D::Error>
+pub(super) fn deserialize_keys<'de, D>(deserializer: D) -> Result<HashMap<KeyId, Key>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -18,22 +15,21 @@ where
     // * fails if there is a duplicate key ID
     // If this passes we insert the entry.
     fn validate_and_insert_entry(
-        keyid: Decoded<Hex>,
+        keyid: KeyId,
         key: Key,
-        map: &mut HashMap<Decoded<Hex>, Key>,
+        map: &mut HashMap<KeyId, Key>,
     ) -> Result<(), error::Error> {
         let calculated = key.key_id()?;
-        let keyid_hex = hex::encode(&keyid);
         ensure!(
             keyid == calculated,
             error::InvalidKeyIdSnafu {
-                keyid: &keyid_hex,
-                calculated: hex::encode(&calculated),
+                keyid: keyid,
+                calculated: calculated,
             }
         );
         ensure!(
-            map.insert(keyid, key).is_none(),
-            error::DuplicateKeyIdSnafu { keyid: keyid_hex }
+            map.insert(keyid.clone(), key).is_none(),
+            error::DuplicateKeyIdSnafu { keyid }
         );
         Ok(())
     }
@@ -42,7 +38,7 @@ where
     struct Visitor;
 
     impl<'de> serde::de::Visitor<'de> for Visitor {
-        type Value = HashMap<Decoded<Hex>, Key>;
+        type Value = HashMap<KeyId, Key>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("a map")

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -58,6 +58,9 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Key IDs {} and {} point to the same key", lhs, rhs))]
+    MultipleKeyIdsForOneKey { lhs: KeyId, rhs: KeyId },
+
     /// Failed to decode a hexadecimal-encoded string.
     #[snafu(display("Invalid hex string: {}", source))]
     HexDecode {

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -58,9 +58,6 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Key IDs {} and {} point to the same key", lhs, rhs))]
-    MultipleKeyIdsForOneKey { lhs: KeyId, rhs: KeyId },
-
     /// Failed to decode a hexadecimal-encoded string.
     #[snafu(display("Invalid hex string: {}", source))]
     HexDecode {

--- a/tough/src/schema/error.rs
+++ b/tough/src/schema/error.rs
@@ -2,6 +2,7 @@
 
 #![allow(clippy::default_trait_access)]
 
+use crate::schema::key::KeyId;
 use crate::schema::RoleType;
 use crate::TargetName;
 use snafu::{Backtrace, Snafu};
@@ -19,7 +20,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     /// A duplicate key ID was present in the root metadata.
     #[snafu(display("Duplicate key ID: {}", keyid))]
-    DuplicateKeyId { keyid: String },
+    DuplicateKeyId { keyid: KeyId },
 
     /// A duplicate role was present in the delegations metadata.
     #[snafu(display("Duplicate role name: {}", name))]
@@ -52,8 +53,8 @@ pub enum Error {
     /// metadata.
     #[snafu(display("Invalid key ID {}: calculated {}", keyid, calculated))]
     InvalidKeyId {
-        keyid: String,
-        calculated: String,
+        keyid: KeyId,
+        calculated: KeyId,
         backtrace: Backtrace,
     },
 

--- a/tough/src/schema/iter.rs
+++ b/tough/src/schema/iter.rs
@@ -1,5 +1,4 @@
-use crate::schema::decoded::{Decoded, Hex};
-use crate::schema::key::Key;
+use crate::schema::key::{Key, KeyId};
 use std::collections::HashMap;
 
 /// The iterator produced by `Root::keys`.
@@ -8,9 +7,9 @@ use std::collections::HashMap;
 // fine otherwise.
 pub(super) struct KeysIter<'a> {
     /// The key IDs permitted to sign a role.
-    pub(super) keyids_iter: std::slice::Iter<'a, Decoded<Hex>>,
+    pub(super) keyids_iter: std::slice::Iter<'a, KeyId>,
     /// The `keys` field of `Root`, so that we can look up the `Key` by its key ID.
-    pub(super) keys: &'a HashMap<Decoded<Hex>, Key>,
+    pub(super) keys: &'a HashMap<KeyId, Key>,
 }
 
 impl<'a> Iterator for KeysIter<'a> {

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -81,7 +81,7 @@ pub enum Key {
 }
 
 /// Used to identify the RSA signature scheme in use.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum RsaScheme {
     /// `rsassa-pss-sha256`: RSA Probabilistic signature scheme with appendix.
@@ -100,7 +100,7 @@ pub struct RsaKey {
 }
 
 /// Used to identify the `EdDSA` signature scheme in use.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum Ed25519Scheme {
     /// 'ed25519': Elliptic curve digital signature algorithm based on Twisted Edwards curves.
@@ -119,7 +119,7 @@ pub struct Ed25519Key {
 }
 
 /// Used to identify the ECDSA signature scheme in use.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum EcdsaScheme {
     /// `ecdsa-sha2-nistp256`: Elliptic Curve Digital Signature Algorithm with NIST P-256 curve
@@ -187,6 +187,39 @@ impl Key {
         alg.verify_sig(public_key.as_slice_less_safe(), msg, signature)
             .is_ok()
     }
+
+    /// Return the underlying key material, without any attached metadata. This is meant to be used
+    /// to check whether two keys point to the same underlying key material: it doesn't contain any
+    /// arbitrary metadata.
+    pub(super) fn material(&self) -> KeyMaterial {
+        // It's intentional that we explicitly match over every field of the struct (and nested
+        // structs too). Whenever a new field is added we want a compiler error to be triggered
+        // here, to evaluate whether the new field needs to be added to the key material.
+        match self.clone() {
+            Key::Rsa {
+                keyval: RsaKey { public, _extra: _ },
+                scheme,
+                _extra: _,
+            } => KeyMaterial::Rsa { scheme, public },
+
+            Key::Ed25519 {
+                keyval: Ed25519Key { public, _extra: _ },
+                scheme,
+                _extra: _,
+            } => KeyMaterial::Ed25519 { scheme, public },
+
+            Key::Ecdsa {
+                keyval: EcdsaKey { public, _extra: _ },
+                scheme,
+                _extra: _,
+            }
+            | Key::EcdsaOld {
+                keyval: EcdsaKey { public, _extra: _ },
+                scheme,
+                _extra: _,
+            } => KeyMaterial::Ecdsa { scheme, public },
+        }
+    }
 }
 
 impl FromStr for Key {
@@ -228,6 +261,22 @@ impl FromStr for Key {
             Err(KeyParseError(()))
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum KeyMaterial {
+    Rsa {
+        scheme: RsaScheme,
+        public: Decoded<RsaPem>,
+    },
+    Ed25519 {
+        scheme: Ed25519Scheme,
+        public: Decoded<Hex>,
+    },
+    Ecdsa {
+        scheme: EcdsaScheme,
+        public: Decoded<EcdsaFlex>,
+    },
 }
 
 /// Unique identifier representing a key.

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -288,6 +288,12 @@ pub(super) enum KeyMaterial {
 #[serde(transparent)]
 pub struct KeyId(String);
 
+impl KeyId {
+    pub(super) fn lowercase(&self) -> KeyId {
+        KeyId(self.0.to_lowercase())
+    }
+}
+
 impl std::fmt::Display for KeyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <String as std::fmt::Display>::fmt(&self.0, f)

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -140,14 +140,14 @@ pub struct EcdsaKey {
 
 impl Key {
     /// Calculate the key ID for this key.
-    pub fn key_id(&self) -> Result<Decoded<Hex>> {
+    pub fn key_id(&self) -> Result<KeyId> {
         let mut buf = Vec::new();
         let mut ser = serde_json::Serializer::with_formatter(&mut buf, CanonicalFormatter::new());
         self.serialize(&mut ser)
             .context(error::JsonSerializationSnafu {
                 what: "key".to_owned(),
             })?;
-        Ok(digest(&SHA256, &buf).as_ref().to_vec().into())
+        Ok(KeyId(hex::encode(digest(&SHA256, &buf))))
     }
 
     /// Verify a signature of an object made with this key.
@@ -227,6 +227,29 @@ impl FromStr for Key {
         } else {
             Err(KeyParseError(()))
         }
+    }
+}
+
+/// Unique identifier representing a key.
+///
+/// TUF version 1.0.0 (section 4.2) mandates that KEYID must be hexdigest of the SHA-256 hash of
+/// the canonical JSON form of the key. TAP 12 changes the definition to allow arbitrary strings to
+/// be key IDs.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct KeyId(String);
+
+impl std::fmt::Display for KeyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <String as std::fmt::Display>::fmt(&self.0, f)
+    }
+}
+
+impl std::str::FromStr for KeyId {
+    type Err = KeyParseError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(KeyId(s.into()))
     }
 }
 

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -14,7 +14,7 @@ mod verify;
 use crate::schema::decoded::{Decoded, Hex};
 pub use crate::schema::error::{Error, Result};
 use crate::schema::iter::KeysIter;
-use crate::schema::key::Key;
+use crate::schema::key::{Key, KeyId};
 use crate::sign::Sign;
 pub use crate::transport::{FilesystemTransport, Transport};
 use crate::{encode_filename, TargetName};
@@ -111,7 +111,7 @@ pub struct Signed<T> {
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Signature {
     /// The key ID (listed in root.json) that made this signature.
-    pub keyid: Decoded<Hex>,
+    pub keyid: KeyId,
     /// A hex-encoded signature of the canonical JSON form of a role.
     pub sig: Decoded<Hex>,
 }
@@ -157,7 +157,7 @@ pub struct Root {
     /// this is correct for the associated key. Clients MUST ensure that for any KEYID represented
     /// in this key list and in other files, only one unique key has that KEYID.
     #[serde(deserialize_with = "de::deserialize_keys")]
-    pub keys: HashMap<Decoded<Hex>, Key>,
+    pub keys: HashMap<KeyId, Key>,
 
     /// A list of roles, the keys associated with each role, and the threshold of signatures used
     /// for each role.
@@ -183,7 +183,7 @@ pub struct Root {
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub struct RoleKeys {
     /// The key IDs used for the role.
-    pub keyids: Vec<Decoded<Hex>>,
+    pub keyids: Vec<KeyId>,
 
     /// The threshold of signatures required to validate the role.
     pub threshold: NonZeroU64,
@@ -211,7 +211,7 @@ impl Root {
 
     /// Given an object/key that impls Sign, return the corresponding
     /// key ID from Root
-    pub fn key_id(&self, key_pair: &dyn Sign) -> Option<Decoded<Hex>> {
+    pub fn key_id(&self, key_pair: &dyn Sign) -> Option<KeyId> {
         for (key_id, key) in &self.keys {
             if key_pair.tuf_key() == *key {
                 return Some(key_id.clone());
@@ -888,7 +888,7 @@ pub struct Delegations {
     /// replacement of delegated targets roles keys is done by changing the keys in this field in
     /// the delegating role's metadata.
     #[serde(deserialize_with = "de::deserialize_keys")]
-    pub keys: HashMap<Decoded<Hex>, Key>,
+    pub keys: HashMap<KeyId, Key>,
 
     /// The list of delegated roles.
     pub roles: Vec<DelegatedRole>,
@@ -901,7 +901,7 @@ pub struct DelegatedRole {
     pub name: String,
 
     /// The key IDs used by this role.
-    pub keyids: Vec<Decoded<Hex>>,
+    pub keyids: Vec<KeyId>,
 
     /// The threshold of signatures required to validate the role.
     pub threshold: NonZeroU64,
@@ -1105,7 +1105,7 @@ impl Delegations {
 
     /// Given an object/key that impls Sign, return the corresponding
     /// key ID from Delegation
-    pub fn key_id(&self, key_pair: &dyn Sign) -> Option<Decoded<Hex>> {
+    pub fn key_id(&self, key_pair: &dyn Sign) -> Option<KeyId> {
         for (key_id, key) in &self.keys {
             if key_pair.tuf_key() == *key {
                 return Some(key_id.clone());

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -112,7 +112,9 @@ fn verify_common<T: Role + Serialize>(
                     KeyIdFormat::HashedKey => {
                         let canonical_keyid = key.key_id()?;
                         ensure!(
-                            *keyid == canonical_keyid,
+                            // Canonical key IDs are hex-encoded, so it's valid for them to be
+                            // represented using both upper and lower case letters.
+                            keyid.lowercase() == canonical_keyid.lowercase(),
                             error::InvalidKeyIdSnafu {
                                 keyid: keyid.clone(),
                                 calculated: canonical_keyid,

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -29,7 +29,7 @@ impl Root {
             ensure!(
                 !contained_keyids.contains(&signature.keyid),
                 error::DuplicateKeyIdSnafu {
-                    keyid: format!("{:?}", signature.keyid),
+                    keyid: signature.keyid.clone(),
                 }
             );
             contained_keyids.insert(&signature.keyid);
@@ -85,7 +85,7 @@ impl Delegations {
             ensure!(
                 !contained_keyids.contains(&signature.keyid),
                 error::DuplicateKeyIdSnafu {
-                    keyid: format!("{:?}", signature.keyid),
+                    keyid: signature.keyid.clone(),
                 }
             );
             contained_keyids.insert(&signature.keyid);

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -1,9 +1,11 @@
 use super::error::{self, Result};
-use super::{Delegations, Role, RoleType, Root, Signed, Targets};
+use super::{Delegations, Role, Root, Signed, Targets};
+use crate::schema::key::{Key, KeyId};
 use olpc_cjson::CanonicalFormatter;
 use serde::Serialize;
 use snafu::{ensure, OptionExt, ResultExt};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU64;
 
 impl Root {
     /// Checks that the given metadata role is valid based on a threshold of key signatures.
@@ -12,49 +14,14 @@ impl Root {
             .roles
             .get(&T::TYPE)
             .context(error::MissingRoleSnafu { role: T::TYPE })?;
-        let mut valid = 0;
 
-        let mut data = Vec::new();
-        let mut ser = serde_json::Serializer::with_formatter(&mut data, CanonicalFormatter::new());
-        role.signed
-            .serialize(&mut ser)
-            .context(error::JsonSerializationSnafu {
-                what: format!("{} role", T::TYPE),
-            })?;
-
-        let mut valid_keyids = HashSet::new();
-        let mut contained_keyids = HashSet::new();
-
-        for signature in &role.signatures {
-            ensure!(
-                !contained_keyids.contains(&signature.keyid),
-                error::DuplicateKeyIdSnafu {
-                    keyid: signature.keyid.clone(),
-                }
-            );
-            contained_keyids.insert(&signature.keyid);
-            if role_keys.keyids.contains(&signature.keyid) {
-                if let Some(key) = self.keys.get(&signature.keyid) {
-                    if key.verify(&data, &signature.sig) {
-                        // we have ensured that this keyid is not already
-                        // present in valid_keyids with the test on
-                        // contained_keyids.
-                        valid_keyids.insert(&signature.keyid);
-                        valid += 1;
-                    }
-                }
-            }
-        }
-
-        ensure!(
-            valid >= u64::from(role_keys.threshold),
-            error::SignatureThresholdSnafu {
-                role: T::TYPE,
-                threshold: role_keys.threshold,
-                valid,
-            }
-        );
-        Ok(())
+        verify_common(
+            &self.keys,
+            role,
+            &T::TYPE.to_string(),
+            &role_keys.keyids,
+            role_keys.threshold,
+        )
     }
 }
 
@@ -68,50 +35,71 @@ impl Delegations {
                 .ok_or(error::Error::RoleNotFound {
                     name: name.to_string(),
                 })?;
-        let mut valid = 0;
 
-        // serialize the role to verify the key ID by using the JSON representation
-        let mut data = Vec::new();
-        let mut ser = serde_json::Serializer::with_formatter(&mut data, CanonicalFormatter::new());
-        role.signed
-            .serialize(&mut ser)
-            .context(error::JsonSerializationSnafu {
-                what: format!("{name} role"),
-            })?;
-        let mut valid_keyids = HashSet::new();
-        let mut contained_keyids = HashSet::new();
+        verify_common(
+            &self.keys,
+            role,
+            name,
+            &role_keys.keyids,
+            role_keys.threshold,
+        )
+    }
+}
 
-        for signature in &role.signatures {
-            ensure!(
-                !contained_keyids.contains(&signature.keyid),
-                error::DuplicateKeyIdSnafu {
-                    keyid: signature.keyid.clone(),
-                }
-            );
-            contained_keyids.insert(&signature.keyid);
-            if role_keys.keyids.contains(&signature.keyid) {
-                if let Some(key) = self.keys.get(&signature.keyid) {
-                    if key.verify(&data, &signature.sig) {
-                        // we have ensured that this keyid is not already
-                        // present in valid_keyids with the test on
-                        // contained_keyids.
-                        valid_keyids.insert(&signature.keyid);
-                        valid += 1;
-                    }
+fn verify_common<T: Role + Serialize>(
+    keys: &HashMap<KeyId, Key>,
+    role: &Signed<T>,
+    role_name: &str,
+    role_keys: &[KeyId],
+    threshold: NonZeroU64,
+) -> Result<()> {
+    let mut valid = 0;
+
+    let mut data = Vec::new();
+    let mut ser = serde_json::Serializer::with_formatter(&mut data, CanonicalFormatter::new());
+    role.signed
+        .serialize(&mut ser)
+        .context(error::JsonSerializationSnafu {
+            what: format!("{role_name} role"),
+        })?;
+
+    let mut valid_keyids = HashSet::new();
+    let mut contained_keyids = HashSet::new();
+
+    for signature in &role.signatures {
+        let keyid = &signature.keyid;
+
+        ensure!(
+            !contained_keyids.contains(keyid),
+            error::DuplicateKeyIdSnafu {
+                keyid: keyid.clone(),
+            }
+        );
+        contained_keyids.insert(keyid);
+
+        if role_keys.contains(keyid) {
+            if let Some(key) = keys.get(keyid) {
+                if key.verify(&data, &signature.sig) {
+                    // we have ensured that this keyid is not already
+                    // present in valid_keyids with the test on
+                    // contained_keyids.
+                    valid_keyids.insert(keyid);
+                    valid += 1;
                 }
             }
         }
-
-        ensure!(
-            valid >= u64::from(role_keys.threshold),
-            error::SignatureThresholdSnafu {
-                role: RoleType::Targets,
-                threshold: role_keys.threshold,
-                valid,
-            }
-        );
-        Ok(())
     }
+
+    ensure!(
+        valid >= u64::from(threshold),
+        error::SignatureThresholdSnafu {
+            role: T::TYPE,
+            threshold,
+            valid,
+        }
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -78,7 +78,7 @@ fn verify_common<T: Role + Serialize>(
 
     let mut valid_keyids = HashSet::new();
     let mut contained_keyids = HashSet::new();
-    let mut contained_canonical_keyids = HashMap::new();
+    let mut contained_materials = HashMap::new();
 
     for signature in &role.signatures {
         let keyid = &signature.keyid;
@@ -93,32 +93,33 @@ fn verify_common<T: Role + Serialize>(
 
         if role_keys.contains(keyid) {
             if let Some(key) = keys.get(keyid) {
-                let canonical_key_id = key.key_id()?;
+                // TAP 12 proposes the wording "Clients MUST use each key only once during a
+                // given signature verification". We thus check whether the underlying key material
+                // was already used to verify a signature.
+                //
+                // Note that we cannot use the canonical key ID for this, as it contains arbitrary
+                // user-defined fields. That'd allow a malformed root manifest to define multiple
+                // keys (with unique canonical key IDs) pointing to the same key material.
+                if let Some(rhs) = contained_materials.insert(key.material(), keyid.clone()) {
+                    return error::MultipleKeyIdsForOneKeySnafu {
+                        lhs: keyid.clone(),
+                        rhs,
+                    }
+                    .fail();
+                }
+
                 match key_id_format {
                     KeyIdFormat::HashedKey => {
+                        let canonical_keyid = key.key_id()?;
                         ensure!(
-                            *keyid == canonical_key_id,
+                            *keyid == canonical_keyid,
                             error::InvalidKeyIdSnafu {
                                 keyid: keyid.clone(),
-                                calculated: canonical_key_id,
+                                calculated: canonical_keyid,
                             }
                         );
                     }
-                    KeyIdFormat::Any => {
-                        // TAP 12 proposes the wording "Clients MUST use each key only once during a
-                        // given signature verification". As the canonical key ID returned by the
-                        // key_id() method is a hash of the underlying key, we can check that no
-                        // other role has the same canonical key ID.
-                        if let Some(rhs) = contained_canonical_keyids
-                            .insert(canonical_key_id.clone(), keyid.clone())
-                        {
-                            return error::MultipleKeyIdsForOneKeySnafu {
-                                lhs: keyid.clone(),
-                                rhs,
-                            }
-                            .fail();
-                        }
-                    }
+                    KeyIdFormat::Any => {}
                 }
 
                 if key.verify(&data, &signature.sig) {

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -1,6 +1,7 @@
 use super::error::{self, Result};
 use super::{Delegations, Role, Root, Signed, Targets};
 use crate::schema::key::{Key, KeyId};
+use crate::KeyIdFormat;
 use olpc_cjson::CanonicalFormatter;
 use serde::Serialize;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -9,7 +10,11 @@ use std::num::NonZeroU64;
 
 impl Root {
     /// Checks that the given metadata role is valid based on a threshold of key signatures.
-    pub fn verify_role<T: Role + Serialize>(&self, role: &Signed<T>) -> Result<()> {
+    pub fn verify_role<T: Role + Serialize>(
+        &self,
+        role: &Signed<T>,
+        key_id_format: KeyIdFormat,
+    ) -> Result<()> {
         let role_keys = self
             .roles
             .get(&T::TYPE)
@@ -17,6 +22,7 @@ impl Root {
 
         verify_common(
             &self.keys,
+            key_id_format,
             role,
             &T::TYPE.to_string(),
             &role_keys.keyids,
@@ -27,7 +33,12 @@ impl Root {
 
 impl Delegations {
     /// Verifies that roles matches contain valid keys
-    pub fn verify_role(&self, role: &Signed<Targets>, name: &str) -> Result<()> {
+    pub fn verify_role(
+        &self,
+        role: &Signed<Targets>,
+        name: &str,
+        key_id_format: KeyIdFormat,
+    ) -> Result<()> {
         let role_keys =
             self.roles
                 .iter()
@@ -38,6 +49,7 @@ impl Delegations {
 
         verify_common(
             &self.keys,
+            key_id_format,
             role,
             name,
             &role_keys.keyids,
@@ -48,6 +60,7 @@ impl Delegations {
 
 fn verify_common<T: Role + Serialize>(
     keys: &HashMap<KeyId, Key>,
+    key_id_format: KeyIdFormat,
     role: &Signed<T>,
     role_name: &str,
     role_keys: &[KeyId],
@@ -65,6 +78,7 @@ fn verify_common<T: Role + Serialize>(
 
     let mut valid_keyids = HashSet::new();
     let mut contained_keyids = HashSet::new();
+    let mut contained_canonical_keyids = HashMap::new();
 
     for signature in &role.signatures {
         let keyid = &signature.keyid;
@@ -79,6 +93,34 @@ fn verify_common<T: Role + Serialize>(
 
         if role_keys.contains(keyid) {
             if let Some(key) = keys.get(keyid) {
+                let canonical_key_id = key.key_id()?;
+                match key_id_format {
+                    KeyIdFormat::HashedKey => {
+                        ensure!(
+                            *keyid == canonical_key_id,
+                            error::InvalidKeyIdSnafu {
+                                keyid: keyid.clone(),
+                                calculated: canonical_key_id,
+                            }
+                        );
+                    }
+                    KeyIdFormat::Any => {
+                        // TAP 12 proposes the wording "Clients MUST use each key only once during a
+                        // given signature verification". As the canonical key ID returned by the
+                        // key_id() method is a hash of the underlying key, we can check that no
+                        // other role has the same canonical key ID.
+                        if let Some(rhs) = contained_canonical_keyids
+                            .insert(canonical_key_id.clone(), keyid.clone())
+                        {
+                            return error::MultipleKeyIdsForOneKeySnafu {
+                                lhs: keyid.clone(),
+                                rhs,
+                            }
+                            .fail();
+                        }
+                    }
+                }
+
                 if key.verify(&data, &signature.sig) {
                     // we have ensured that this keyid is not already
                     // present in valid_keyids with the test on
@@ -105,12 +147,15 @@ fn verify_common<T: Role + Serialize>(
 #[cfg(test)]
 mod tests {
     use super::{Root, Signed};
+    use crate::KeyIdFormat;
 
     #[test]
     fn simple_rsa() {
         let root: Signed<Root> =
             serde_json::from_str(include_str!("../../tests/data/simple-rsa/root.json")).unwrap();
-        root.signed.verify_role(&root).unwrap();
+        root.signed
+            .verify_role(&root, KeyIdFormat::HashedKey)
+            .unwrap();
     }
 
     #[test]
@@ -120,7 +165,7 @@ mod tests {
         ))
         .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("missing signature should not verify");
     }
 
@@ -131,7 +176,7 @@ mod tests {
         ))
         .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("invalid (unauthentic) root signature should not verify");
     }
 
@@ -145,7 +190,7 @@ mod tests {
         ))
         .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("expired root signature should not verify");
     }
 
@@ -156,7 +201,7 @@ mod tests {
         ))
         .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("mismatched root role keyids (provided and signed) should not verify");
     }
 
@@ -166,7 +211,7 @@ mod tests {
             serde_json::from_str(include_str!("../../tests/data/duplicate-sigs/root.json"))
                 .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("expired root signature should not verify");
     }
 
@@ -179,7 +224,41 @@ mod tests {
         ))
         .expect("should be parsable root.json");
         root.signed
-            .verify_role(&root)
+            .verify_role(&root, KeyIdFormat::HashedKey)
             .expect_err("expired root signature should not verify");
+    }
+
+    #[test]
+    fn test_tap12_correct() {
+        let root: Signed<Root> =
+            serde_json::from_str(include_str!("../../tests/data/tap-12-good/root.json"))
+                .expect("should be parseable root.json");
+
+        let err = root
+            .signed
+            .verify_role(&root, KeyIdFormat::HashedKey)
+            .expect_err("TAP 12 key names with KeyIdFormat::HashedKey should not verify");
+        assert!(matches!(err, super::error::Error::InvalidKeyId { .. }));
+
+        root.signed
+            .verify_role(&root, KeyIdFormat::Any)
+            .expect("TAP 12 key names with KeyIdFormat::Any should verify");
+    }
+
+    #[test]
+    fn test_tap12_multiple_ids_for_a_key() {
+        let root: Signed<Root> = serde_json::from_str(include_str!(
+            "../../tests/data/tap-12-multiple-ids/root.json"
+        ))
+        .expect("should be parseable root.json");
+
+        let err = root
+            .signed
+            .verify_role(&root, KeyIdFormat::Any)
+            .expect_err("multiple key IDs pointing to the same key should not verify");
+        assert!(matches!(
+            err,
+            super::error::Error::MultipleKeyIdsForOneKey { .. }
+        ));
     }
 }

--- a/tough/src/schema/verify.rs
+++ b/tough/src/schema/verify.rs
@@ -100,12 +100,11 @@ fn verify_common<T: Role + Serialize>(
                 // Note that we cannot use the canonical key ID for this, as it contains arbitrary
                 // user-defined fields. That'd allow a malformed root manifest to define multiple
                 // keys (with unique canonical key IDs) pointing to the same key material.
-                if let Some(rhs) = contained_materials.insert(key.material(), keyid.clone()) {
-                    return error::MultipleKeyIdsForOneKeySnafu {
-                        lhs: keyid.clone(),
-                        rhs,
-                    }
-                    .fail();
+                if contained_materials
+                    .insert(key.material(), keyid.clone())
+                    .is_some()
+                {
+                    continue;
                 }
 
                 match key_id_format {
@@ -261,7 +260,7 @@ mod tests {
             .expect_err("multiple key IDs pointing to the same key should not verify");
         assert!(matches!(
             err,
-            super::error::Error::MultipleKeyIdsForOneKey { .. }
+            super::error::Error::SignatureThreshold { .. }
         ));
     }
 }

--- a/tough/tests/data/tap-12-good/root.json
+++ b/tough/tests/data/tap-12-good/root.json
@@ -1,0 +1,50 @@
+{
+  "signed": {
+    "_type": "root",
+    "spec_version": "1.0",
+    "consistent_snapshot": true,
+    "version": 1,
+    "expires": "3000-03-30T03:30:30Z",
+    "keys": {
+      "tap12": {
+        "keytype": "rsa",
+        "keyval": {
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAnL6u6Q9Q6pg1G5020a83\nGlH/aFUO0PQ5leIpwWL8kWgpaWuUG7oRlOUG2/4cwN5FCvJJGXqU5AtSKq2fZ42J\n5XR9QMip4Pg0Q6mE8XCvAXAoMnkWSchdzgT2GoEntaOeRRTCUGb/DsVoxsVXjV6m\nFaRMx7nh8ggshMWgTYgTUDK+CSIBCcBWapCFq1BrM60XZmGTqeAuHSHaUUuF9G3b\ngOflH5L9IpQkaHWbJtGvyKLr53mhWO2r8BPR3+CtNZojAnkwmu4lA94k8C7TLMdc\nutzU4OzODe9UPERc33lRv8DBgsH3F077ZQwv/ikZXWSlACTDWZwenncCEwqdeDd4\n+q2AHyqxRN7bUAh57mUN+kFd3SS/4T44sfBrJw6N4JV/mE+/YfRLWtpIKIsXnBCb\nrC+dt96Vqz6g6eVVvqPwhOCSKcYsmp/iS6qwVn0Dq2SCrGG1FTmBjeA9ZkcjZhUG\nQEMyMNhoS+U2Nx5oIEIq2kREpuu+KsBSTUaOgR07WNUxAgMBAAE=\n-----END PUBLIC KEY-----\n"
+        },
+        "scheme": "rsassa-pss-sha256"
+      }
+    },
+    "roles": {
+      "root": {
+        "keyids": [
+          "tap12"
+        ],
+        "threshold": 1
+      },
+      "snapshot": {
+        "keyids": [
+          "tap12"
+        ],
+        "threshold": 1
+      },
+      "timestamp": {
+        "keyids": [
+          "tap12"
+        ],
+        "threshold": 1
+      },
+      "targets": {
+        "keyids": [
+          "tap12"
+        ],
+        "threshold": 1
+      }
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "tap12",
+      "sig": "487482240bd95452323a0ce310ca23d321cac3fddcf722a93d71e7b2b2f3a0947235f1f5a3ade218c36fc2a1fee6871bed75b5a975c7e2b2fcd070e3c79cedb8fbe0309a7bc6da5ef0b204157ea820acf8d4d7f2bea9e6c7a5895d0c33ad7c49db87664873972293bc1e76f4331d9262107a8760abe28165c2c1cab568aa6065e9fe6a7893254e7fa663da5f22b1875183912af53dacae0a10b69a756226072e527da57e87e7d2c7ed2addb530c2556797468af5f4293bdb58c1492510a87874863a5136b9d02af455bd442c5cd9c759b730d8e253205c356a324f54afd7daf1f2e5ff3eacbd8e1c3722b3c0f05a15d89ff6e637b72d2d8aaab26ec3cf138b98b20254af96eedd1957c4152c120dd1d2d9d19373bdff4353a89097bd1d5bfb2e36fdf1e19ed903ab28efd003afe8b131ab6119a94c8ee67b37eb72a0273eb5bf06e874b16b8ec836666ba8050cc47f364f38a30e08e55081cb1df1bb5705e6fb8e31519e43be8db13f9d54180278af85b3d2c38003002ae6140596fc3073ac03"
+    }
+  ]
+}

--- a/tough/tests/data/tap-12-multiple-ids/root.json
+++ b/tough/tests/data/tap-12-multiple-ids/root.json
@@ -1,0 +1,65 @@
+{
+  "signed": {
+    "_type": "root",
+    "spec_version": "1.0",
+    "consistent_snapshot": true,
+    "version": 1,
+    "expires": "3000-03-30T03:30:30Z",
+    "keys": {
+      "taptwelve": {
+        "keytype": "rsa",
+        "keyval": {
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6+IVAKdJYUESkN4mlx+4\nnoGsitbTBlHWZTUbtv6B8vYTU9wiZqmfn6zWnU3uWXDsTkBNqp1TaL+mUUnKVcfx\nL28N+ZcgevRg7RGwpPoIsZVCMxo8NzLk4fGzpn2cT5BbB78vV2VSCX3ijpmoMQeM\nD0g5HNVE8XM39S8w3Zw+tnZ44oB1W5MRot+ad2aV7ZKRbFn0akE5Gv3wVqnO5Atk\nZIZSHViTOaHsN9oYEBK8/Fu0r1hX4/1HK5aW4JMIWdBwYJYa21gHW8ziDFWgqWD3\ndoNKy9OvPO3OaV91cXe9janTdTfHTg9aBI3Mh8VIUy7//A7iBOGk1PvIPFy/Gtgj\nMwIDAQAB\n-----END PUBLIC KEY-----"
+        },
+        "scheme": "rsassa-pss-sha256"
+      },
+      "tap12": {
+        "keytype": "rsa",
+        "keyval": {
+          "public": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6+IVAKdJYUESkN4mlx+4\nnoGsitbTBlHWZTUbtv6B8vYTU9wiZqmfn6zWnU3uWXDsTkBNqp1TaL+mUUnKVcfx\nL28N+ZcgevRg7RGwpPoIsZVCMxo8NzLk4fGzpn2cT5BbB78vV2VSCX3ijpmoMQeM\nD0g5HNVE8XM39S8w3Zw+tnZ44oB1W5MRot+ad2aV7ZKRbFn0akE5Gv3wVqnO5Atk\nZIZSHViTOaHsN9oYEBK8/Fu0r1hX4/1HK5aW4JMIWdBwYJYa21gHW8ziDFWgqWD3\ndoNKy9OvPO3OaV91cXe9janTdTfHTg9aBI3Mh8VIUy7//A7iBOGk1PvIPFy/Gtgj\nMwIDAQAB\n-----END PUBLIC KEY-----"
+        },
+        "scheme": "rsassa-pss-sha256"
+      }
+    },
+    "roles": {
+      "targets": {
+        "keyids": [
+          "tap12",
+          "taptwelve"
+        ],
+        "threshold": 2
+      },
+      "snapshot": {
+        "keyids": [
+          "tap12",
+          "taptwelve"
+        ],
+        "threshold": 2
+      },
+      "timestamp": {
+        "keyids": [
+          "tap12",
+          "taptwelve"
+        ],
+        "threshold": 2
+      },
+      "root": {
+        "keyids": [
+          "tap12",
+          "taptwelve"
+        ],
+        "threshold": 2
+      }
+    }
+  },
+  "signatures": [
+    {
+      "keyid": "taptwelve",
+      "sig": "a82bd49d8bd4de47f0cc6bbc52956c635a52b6bcb355ac140548e0309a317c4c29f3b0fc00c75776567e1c37bd8d2e3a220ed625d1393cbf28957f2e0173a634864e9eade2e405667e8d04c8d54efcc9cb77b8bbe377a32a529f7a35289f35e2fef09d34907dbc6b39429ed97ce7752503f2d4811ef4fe3d64186ef5aa70a0241fbb2492ad49560d81c5f9a56877519b76b5f08015ff1b01be533e84f9392e2715cad07ab18a6fe32fe0fa5da0aca4e2d3998e2888ef1e1abc51d0e97db2145ec55832b34dbb5cb68944e1cbbbbb5c2aa3d5cbfbbac0009897f23864dbfc9e9462812c095bd4cf5d950cbd350ff692203b2b84b2eebf6a68e63ed26089f93206"
+    },
+    {
+      "keyid": "tap12",
+      "sig": "a82bd49d8bd4de47f0cc6bbc52956c635a52b6bcb355ac140548e0309a317c4c29f3b0fc00c75776567e1c37bd8d2e3a220ed625d1393cbf28957f2e0173a634864e9eade2e405667e8d04c8d54efcc9cb77b8bbe377a32a529f7a35289f35e2fef09d34907dbc6b39429ed97ce7752503f2d4811ef4fe3d64186ef5aa70a0241fbb2492ad49560d81c5f9a56877519b76b5f08015ff1b01be533e84f9392e2715cad07ab18a6fe32fe0fa5da0aca4e2d3998e2888ef1e1abc51d0e97db2145ec55832b34dbb5cb68944e1cbbbbb5c2aa3d5cbfbbac0009897f23864dbfc9e9462812c095bd4cf5d950cbd350ff692203b2b84b2eebf6a68e63ed26089f93206"
+    }
+  ]
+}

--- a/tough/tests/repo_editor.rs
+++ b/tough/tests/repo_editor.rs
@@ -13,9 +13,7 @@ use tough::editor::signed::PathExists;
 use tough::editor::{targets::TargetsEditor, RepositoryEditor};
 use tough::key_source::KeySource;
 use tough::key_source::LocalKeySource;
-use tough::schema::decoded::Decoded;
-use tough::schema::decoded::Hex;
-use tough::schema::key::Key;
+use tough::schema::key::{Key, KeyId};
 use tough::schema::{PathPattern, PathSet};
 use tough::{Repository, RepositoryLoader, TargetName};
 use url::Url;
@@ -103,7 +101,7 @@ async fn test_repo_editor() -> RepositoryEditor {
     editor
 }
 
-async fn key_hash_map(keys: &[Box<dyn KeySource>]) -> HashMap<Decoded<Hex>, Key> {
+async fn key_hash_map(keys: &[Box<dyn KeySource>]) -> HashMap<KeyId, Key> {
     let mut key_pairs = HashMap::new();
     for source in keys {
         let key_pair = source.as_sign().await.unwrap().tuf_key();

--- a/tuftool/src/create_role.rs
+++ b/tuftool/src/create_role.rs
@@ -12,9 +12,7 @@ use std::num::NonZeroU64;
 use std::path::PathBuf;
 use tough::editor::targets::TargetsEditor;
 use tough::key_source::KeySource;
-use tough::schema::decoded::Decoded;
-use tough::schema::decoded::Hex;
-use tough::schema::key::Key;
+use tough::schema::key::{Key, KeyId};
 
 #[derive(Debug, Parser)]
 pub(crate) struct CreateRoleArgs {
@@ -65,7 +63,7 @@ impl CreateRoleArgs {
     }
 }
 
-async fn key_hash_map(keys: &[Box<dyn KeySource>]) -> HashMap<Decoded<Hex>, Key> {
+async fn key_hash_map(keys: &[Box<dyn KeySource>]) -> HashMap<KeyId, Key> {
     let mut key_pairs = HashMap::new();
     for source in keys {
         let key_pair = source.as_sign().await.unwrap().tuf_key();

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -7,6 +7,7 @@
 
 use snafu::{Backtrace, Snafu};
 use std::path::PathBuf;
+use tough::schema::key::KeyId;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
@@ -136,10 +137,7 @@ pub(crate) enum Error {
     },
 
     #[snafu(display("Duplicate key ID: {}", key_id))]
-    KeyDuplicate {
-        key_id: String,
-        backtrace: Backtrace,
-    },
+    KeyDuplicate { key_id: KeyId, backtrace: Backtrace },
 
     #[snafu(display("Failed to calculate key ID: {}", source))]
     KeyId {

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -11,7 +11,7 @@ use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use tough::editor::targets::TargetsEditor;
-use tough::schema::decoded::{Decoded, Hex};
+use tough::schema::key::KeyId;
 use url::Url;
 
 #[derive(Debug, Parser)]
@@ -31,7 +31,7 @@ pub(crate) struct RemoveKeyArgs {
 
     /// Key to be removed will look similar to `8ec3a843a0f9328c863cac4046ab1cacbbc67888476ac7acf73d9bcd9a223ada`
     #[arg(long = "keyid", required = true)]
-    remove: Decoded<Hex>,
+    remove: KeyId,
 
     /// TUF repository metadata base URL
     #[arg(short, long = "metadata-url")]

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 use tough::editor::signed::SignedRole;
 use tough::key_source::KeySource;
-use tough::schema::decoded::{Decoded, Hex};
+use tough::schema::key::KeyId;
 use tough::schema::{key::Key, KeyHolder, RoleKeys, RoleType, Root, Signed};
 use tough::sign::{parse_keypair, Sign};
 
@@ -82,7 +82,7 @@ pub(crate) enum Command {
         /// Path to root.json
         path: PathBuf,
         /// The key ID to remove
-        key_id: Decoded<Hex>,
+        key_id: KeyId,
         /// Role to remove the key ID from (if provided, the public key will still be listed in the
         /// file)
         role: Option<RoleType>,
@@ -257,14 +257,14 @@ impl Command {
                 .await
                 .context(error::KeyPairFromKeySourceSnafu)?
                 .tuf_key();
-            let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair)?);
+            let key_id = add_key(&mut root.signed, roles, key_pair)?;
             println!("Added key: {key_id}");
         }
 
         write_file(path, root).await
     }
 
-    async fn remove_key(path: &Path, key_id: &Decoded<Hex>, role: Option<RoleType>) -> Result<()> {
+    async fn remove_key(path: &Path, key_id: &KeyId, role: Option<RoleType>) -> Result<()> {
         let mut root: Signed<Root> = load_file(path).await?;
         if let Some(role) = role {
             if let Some(role_keys) = root.signed.roles.get_mut(&role) {
@@ -322,9 +322,9 @@ impl Command {
                 .join("\n")
         );
         let key_pair = parse_keypair(pem.as_bytes()).context(error::KeyPairParseSnafu)?;
-        let key_id = hex::encode(add_key(&mut root.signed, roles, key_pair.tuf_key())?);
+        let key_id = add_key(&mut root.signed, roles, key_pair.tuf_key())?;
         let key = parse_key_source(key_source)?;
-        key.write(&pem, &key_id)
+        key.write(&pem, &key_id.to_string())
             .await
             .context(error::WriteKeySourceSnafu)?;
         clear_sigs(&mut root);
@@ -440,7 +440,7 @@ fn clear_sigs<T>(role: &mut Signed<T>) {
 }
 
 /// Adds a key to the root role if not already present, and adds its key ID to the specified role.
-fn add_key(root: &mut Root, role: &[RoleType], key: Key) -> Result<Decoded<Hex>> {
+fn add_key(root: &mut Root, role: &[RoleType], key: Key) -> Result<KeyId> {
     let key_id = if let Some((key_id, _)) = root
         .keys
         .iter()
@@ -452,9 +452,7 @@ fn add_key(root: &mut Root, role: &[RoleType], key: Key) -> Result<Decoded<Hex>>
         let key_id = key.key_id().context(error::KeyIdSnafu)?;
         ensure!(
             !root.keys.contains_key(&key_id),
-            error::KeyDuplicateSnafu {
-                key_id: hex::encode(&key_id)
-            }
+            error::KeyDuplicateSnafu { key_id }
         );
         root.keys.insert(key_id.clone(), key);
         key_id

--- a/tuftool/tests/root_command.rs
+++ b/tuftool/tests/root_command.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::num::NonZeroU64;
 use tempfile::TempDir;
 use tough::key_source::{KeySource, LocalKeySource};
-use tough::schema::decoded::{Decoded, Hex};
+use tough::schema::key::KeyId;
 use tough::schema::{Root, Signed};
 
 fn initialize_root_json(root_json: &str) {
@@ -138,7 +138,7 @@ fn get_sign_len(root_json: &str) -> usize {
     root.signatures.len()
 }
 
-fn check_signature_exists(root_json: &str, key_id: Decoded<Hex>) -> bool {
+fn check_signature_exists(root_json: &str, key_id: KeyId) -> bool {
     let root = get_signed_root(root_json);
     root.signatures.iter().any(|sig| sig.keyid == key_id)
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/tough/issues/766

*Description of changes:*

This PR implements optional support for the accepted [TAP 12](https://github.com/theupdateframework/taps/blob/master/tap12.md), removing the requirements that Key IDs must be a hash of the key. Support for arbitrary Key IDs can be enabled by passing `.key_id_format(KeyIdFormat::Any)` during repository loading.

This PR is best reviewed commit-by-commit: the first commit switches the codebase to use a `KeyId` newtype to represent Key IDs (I would've had to otherwise switch everything to `String`, as there is no requirement in TAP 12 that Key IDs must be hex-encoded), the second commit deduplicates the validation logic, and the third commit actually implements the feature.

Allowing users to choose between the TUF 1.0.0 and TAP 12 behavior regarding Key IDs means the `KeyIdFormat` enum has to be passed around the codebase a lot, if you all prefer I can switch the PR to unconditionally use the TAP 12 behavior instead.

Support for TAP 12 is required to load [GitHub's TUF repo](https://tuf-repo.github.com/). Note that #886 was also opened to support TAP 12, but it used a crate feature to toggle the behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
