### PR TITLE
Fix/keyid recompute tuf on ci

### DIFF
--- a/tough/src/schema/de.rs
+++ b/tough/src/schema/de.rs
@@ -6,31 +6,29 @@ use snafu::ensure;
 use std::collections::HashMap;
 use std::fmt;
 
-/// Validates the key ID for each key during deserialization and fails if any don't match.
+/// Deserializes the keys map, rejecting duplicate key IDs.
 pub(super) fn deserialize_keys<'de, D>(
     deserializer: D,
 ) -> Result<HashMap<Decoded<Hex>, Key>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    // An inner function that does actual key ID validation:
-    // * fails if a key ID doesn't match its contents
-    // * fails if there is a duplicate key ID
-    // If this passes we insert the entry.
+    // An inner function that inserts each entry, failing if there is a duplicate key ID.
+    //
+    // Note: we intentionally do NOT recompute each key ID and reject mismatches. In modern
+    // TUF a key ID is an opaque identifier chosen by the metadata producer; the spec does
+    // not require `keyid == hash(key)`. Recomputing is also not interoperable in practice:
+    // securesystemslib (tuf-on-ci) hashes only the canonical `{keytype, scheme, keyval}` and
+    // excludes custom fields such as `x-tuf-on-ci-keyowner`, while older roots included them,
+    // so no single canonicalization matches every real-world root. python-tuf and go-tuf both
+    // treat the declared key ID as authoritative; tough now does the same. Signatures are still
+    // fully verified against the key the producer associated with each ID.
     fn validate_and_insert_entry(
         keyid: Decoded<Hex>,
         key: Key,
         map: &mut HashMap<Decoded<Hex>, Key>,
     ) -> Result<(), error::Error> {
-        let calculated = key.key_id()?;
         let keyid_hex = hex::encode(&keyid);
-        ensure!(
-            keyid == calculated,
-            error::InvalidKeyIdSnafu {
-                keyid: &keyid_hex,
-                calculated: hex::encode(&calculated),
-            }
-        );
         ensure!(
             map.insert(keyid, key).is_none(),
             error::DuplicateKeyIdSnafu { keyid: keyid_hex }
@@ -115,6 +113,19 @@ mod tests {
     fn ecdsa_new_type_keys() {
         assert!(serde_json::from_str::<Signed<Root>>(include_str!(
             "../../tests/data/ecdsa-new-type-sig-keys/root.json"
+        ))
+        .is_ok());
+    }
+
+    /// Regression: roots produced by tuf-on-ci / modern securesystemslib carry custom key
+    /// fields (e.g. `x-tuf-on-ci-keyowner`) and compute the declared key ID over only
+    /// `{keytype, scheme, keyval}`, excluding those fields. tough previously recomputed the
+    /// key ID over the whole key and rejected the root with "Invalid key ID". This is
+    /// GitHub's public TUF root (`https://tuf-repo.github.com`).
+    #[test]
+    fn tuf_on_ci_extra_key_fields() {
+        assert!(serde_json::from_str::<Signed<Root>>(include_str!(
+            "../../tests/data/tuf-on-ci-extra-fields/root.json"
         ))
         .is_ok());
     }

--- a/tough/src/schema/de.rs
+++ b/tough/src/schema/de.rs
@@ -122,11 +122,18 @@ mod tests {
     /// `{keytype, scheme, keyval}`, excluding those fields. tough previously recomputed the
     /// key ID over the whole key and rejected the root with "Invalid key ID". This is
     /// GitHub's public TUF root (`https://tuf-repo.github.com`).
+    ///
+    /// We not only deserialize the root but verify its self-signatures against the
+    /// producer-declared key IDs (exactly what `RepositoryLoader` does on bootstrap), to
+    /// confirm that accepting declared key IDs does not weaken signature verification.
     #[test]
     fn tuf_on_ci_extra_key_fields() {
-        assert!(serde_json::from_str::<Signed<Root>>(include_str!(
+        let root: Signed<Root> = serde_json::from_str(include_str!(
             "../../tests/data/tuf-on-ci-extra-fields/root.json"
         ))
-        .is_ok());
+        .expect("tuf-on-ci root with custom key fields must deserialize");
+        root.signed
+            .verify_role(&root)
+            .expect("root self-signatures must verify against declared key IDs");
     }
 }

--- a/tough/tests/data/tuf-on-ci-extra-fields/root.json
+++ b/tough/tests/data/tuf-on-ci-extra-fields/root.json
@@ -1,0 +1,153 @@
+{
+ "signatures": [
+  {
+   "keyid": "4f4d1dd75f2d7f3860e3a068d7bed90dec5f0faafcbe1ace7fb7d95d29e07228",
+   "sig": ""
+  },
+  {
+   "keyid": "8b498a80a1b7af188c10c9abdf6aade81d14faaffcde2abcd6063baa673ebd12",
+   "sig": "3045022100e7c697520b19dc138a8282a70ecd4c227fe3e3a137e33c14cd062ca6f715cf9f0220240d759facfaa327b8949d337e5fb044dfcb90a01c8b83d557ddaff7b2c64d1a"
+  },
+  {
+   "keyid": "56db9f7d64bef1feab6190760336643b20196af4875ee8be915e78f239863aae",
+   "sig": "30440220080440818e94015857c39cf0685576b4fc06431739b7d5165bf6c46688c2ce6f022066a587687b776747af5b4139cf2c6c5e9ea3cb9a5962899b5cbb90fbb3d2c9c4"
+  },
+  {
+   "keyid": "d6a89e23fb22801a0d1186bf1bdd007e228f65a8aa9964d24d06cb5fbb0ce91c",
+   "sig": "3045022100899b6625056265ef6936e9ec0014b2b25e868fe6643bfd1684cf8ffae83a0c9902207aab827e42b78cdbfe086806923ff8d9e0d214587655e397247713da58362918"
+  },
+  {
+   "keyid": "a10513a5ab61acd0c6b6fbe0504856ead18f3b17c4fabbe3fa848c79a5a187cf",
+   "sig": "3045022034108f5a60e5788b009d0fb752aa171f7b478667b1d0c2f9a2a274e4ccfe3e43022100fbdadd0c0beffe3e1ec8624f5f426fe7acdf1a3ba1d2c160592eda742e7707bb"
+  },
+  {
+   "keyid": "54809115b40137aac01af4b7ac2408c77ea0d58fa4dad48fc3196497d2a26f44",
+   "sig": "304502205bb6132b658629a522db3869568da2ac31a1d22b75aa1e243c0819675606a700022100c962eb9c3430c4291b4e187f3304408e603b38246baa14a9f11f09485cce2dc0"
+  },
+  {
+   "keyid": "88737ccdac7b49cc237e9aaead81be2a40278b886a693d8149a19cf543f093d3",
+   "sig": "3045022100e9c8485e047dff42f6c0e9e5e8b8035309dc5e1105d3dfe980b179750b2ea9bf022056d4e3fd31714ca49a873a01951e9c6e7dc0895dc99dd8858b0830fdec1caa65"
+  },
+  {
+   "keyid": "1b8fa2a77525b38ef24804d3d907ca96f76d178a49520333626ba36d319c5790",
+   "sig": "3046022100e5472ca54e8b975285a268126e243e8fd46ee87d72eafd1d184b0f4441ba1cfe022100d87f32dc39388a8e57bc09d94a6e22ede6307232ed636410034917aafb84811f"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2026-08-01T17:27:39Z",
+  "keys": {
+   "1b8fa2a77525b38ef24804d3d907ca96f76d178a49520333626ba36d319c5790": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZcUP5fUpUgUiGMusabv7lmn+6nVI\nManyvT8Qr7IJ88pbCdDQdh5rdfjvk+AjQja4l+xOh7V9GtRUcM3gbJSD+w==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@aaroncathcart"
+   },
+   "54809115b40137aac01af4b7ac2408c77ea0d58fa4dad48fc3196497d2a26f44": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEimKcdST+ORD+g0aGEFDOVZDAaIYg\nIgesNKiIe2L7MUsYx5UHhzQ08quvew13eYSCNJnfwooFZu7cdTu8AwqFjQ==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@alexiswales"
+   },
+   "56db9f7d64bef1feab6190760336643b20196af4875ee8be915e78f239863aae": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwnBUd4d18zbFzkdjQMwqQUcOA6S6\nYpNvdQNckHtjwiGlJyvqjzrRYeObBLMKA/TnqeFAipDfiqsDoqDVwL2cVQ==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@tquinn86"
+   },
+   "88737ccdac7b49cc237e9aaead81be2a40278b886a693d8149a19cf543f093d3": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBagkskNOpOTbetTX5CdnvMy+LiWn\nonRrNrqAHL4WgiebH7Uig7GLhC3bkeA/qgb926/vr9qhOPG9Buj2HatrPw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@gregose"
+   },
+   "8b498a80a1b7af188c10c9abdf6aade81d14faaffcde2abcd6063baa673ebd12": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7IEoVNwrprchXGhT5sAhSax7SOd3\n8duuISghCzfmHdKJWSbV2wJRamRiUVRtmA83K/qm5cT20WXMCT5QeM/D3A==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@trevrosen"
+   },
+   "a10513a5ab61acd0c6b6fbe0504856ead18f3b17c4fabbe3fa848c79a5a187cf": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEC2wJ3xscyXxBLybJ9FVjwkyQMe53\nRHUz77AjMO8MzVaT8xw6ZvJqdNZiytYtigWULlINxw6frNsWJKb/f7lC8A==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@kommendorkapten"
+   },
+   "d6a89e23fb22801a0d1186bf1bdd007e228f65a8aa9964d24d06cb5fbb0ce91c": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDdORwcruW3gqAgaLjH/nNdGMB4kQ\nAvA+wD6DyO4P/wR8ee2ce83NZHq1ZADKhve0rlYKaKy3CqyQ5SmlZ36Zhw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-keyowner": "@krukow"
+   },
+   "eb9799b483affac9da87ef4c9ea467928415c961349e607e5e6e485679b07f8f": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENKNcNcX+d73lS1TRFb9Vnp8JvOoh\nzYQ+in43iGenbG8RGo9L/6FJ2hoRbVU6xskvyuErcdPbCdI4GxrQ5i8hkw==\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp256",
+    "x-tuf-on-ci-online-uri": "azurekms://production-tuf-root.vault.azure.net/keys/Online-Key/aaf375fd8ed24acb949a5cc173700b05"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "a10513a5ab61acd0c6b6fbe0504856ead18f3b17c4fabbe3fa848c79a5a187cf",
+     "88737ccdac7b49cc237e9aaead81be2a40278b886a693d8149a19cf543f093d3",
+     "d6a89e23fb22801a0d1186bf1bdd007e228f65a8aa9964d24d06cb5fbb0ce91c",
+     "8b498a80a1b7af188c10c9abdf6aade81d14faaffcde2abcd6063baa673ebd12",
+     "54809115b40137aac01af4b7ac2408c77ea0d58fa4dad48fc3196497d2a26f44",
+     "56db9f7d64bef1feab6190760336643b20196af4875ee8be915e78f239863aae",
+     "1b8fa2a77525b38ef24804d3d907ca96f76d178a49520333626ba36d319c5790"
+    ],
+    "threshold": 3
+   },
+   "snapshot": {
+    "keyids": [
+     "eb9799b483affac9da87ef4c9ea467928415c961349e607e5e6e485679b07f8f"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 21,
+    "x-tuf-on-ci-signing-period": 7
+   },
+   "targets": {
+    "keyids": [
+     "a10513a5ab61acd0c6b6fbe0504856ead18f3b17c4fabbe3fa848c79a5a187cf",
+     "88737ccdac7b49cc237e9aaead81be2a40278b886a693d8149a19cf543f093d3",
+     "d6a89e23fb22801a0d1186bf1bdd007e228f65a8aa9964d24d06cb5fbb0ce91c",
+     "8b498a80a1b7af188c10c9abdf6aade81d14faaffcde2abcd6063baa673ebd12",
+     "54809115b40137aac01af4b7ac2408c77ea0d58fa4dad48fc3196497d2a26f44",
+     "56db9f7d64bef1feab6190760336643b20196af4875ee8be915e78f239863aae",
+     "1b8fa2a77525b38ef24804d3d907ca96f76d178a49520333626ba36d319c5790"
+    ],
+    "threshold": 3
+   },
+   "timestamp": {
+    "keyids": [
+     "eb9799b483affac9da87ef4c9ea467928415c961349e607e5e6e485679b07f8f"
+    ],
+    "threshold": 1,
+    "x-tuf-on-ci-expiry-period": 7,
+    "x-tuf-on-ci-signing-period": 6
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 8,
+  "x-tuf-on-ci-expiry-period": 240,
+  "x-tuf-on-ci-signing-period": 60
+ }
+}


### PR DESCRIPTION
Issue https://github.com/awslabs/tough/issues/946

*Description of changes:*

tough cannot load TUF roots produced by modern tuf-on-ci / securesystemslib — most notably GitHub's public TUF root (https://tuf-repo.github.com). Deserialization fails with:

Invalid key ID 1b8fa2a77525b38ef24804d3d907ca96f76d178a49520333626ba36d319c5790:
calculated d40badaea967938b57b5257e19103af08fcbf3ad850e045c60366d910c64ba2e

Root cause. deserialize_keys recomputes every key ID via Key::key_id() and rejects the metadata on mismatch. Key::key_id() canonical-JSON-hashes the entire Key struct, which — via #[serde(flatten)] _extra — includes custom fields such as x-tuf-on-ci-keyowner. The producer instead computes the declared key ID over only the canonical {keytype, scheme, keyval}, excluding those fields, so the IDs diverge. (It is not a PEM/ECDSA encoding issue — Decoded preserves the key string verbatim; the only difference is which fields enter the hash. I reproduced both hashes exactly: 1b8fa2… excludes the custom field, d40badae… includes it.)

This is fundamentally non-interoperable: different securesystemslib versions hash different field sets, so no single recompute rule works for all real-world roots — e.g. the current Sigstore production root declared its key IDs including the custom fields (so it loads today), while GitHub's newer root excludes them (so it's rejected). Stripping _extra from key_id() would just flip which roots break.

Fix. Stop recomputing-and-rejecting key IDs. Per the TUF spec a key ID is an opaque identifier chosen by the metadata producer; python-tuf and go-tuf both treat the declared ID as authoritative. We keep the declared ID as the map key, retain the duplicate-key-ID check, and continue to verify signatures against the key the producer associated with each ID — so signature verification is unchanged.

Testing. Adds a regression test using GitHub's public TUF root as a fixture. It does not merely deserialize the root — it calls Root::verify_role against the producer-declared key IDs (mirroring RepositoryLoader bootstrap), confirming the root's self-signatures still verify and that accepting declared key IDs does not weaken signature verification. All existing tough tests pass.

PR written by Claude Code (Opus 4.8)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
