### PR TITLE
feat!: migrate from chrono to jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,10 +791,7 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "iana-time-zone",
  "num-traits",
- "serde",
- "windows-link",
 ]
 
 [[package]]
@@ -1626,30 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1770,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -2259,6 +2264,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,7 +2707,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3293,7 +3313,6 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "bytes",
- "chrono",
  "dyn-clone",
  "failure-server",
  "futures",
@@ -3302,6 +3321,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "httptest",
+ "jiff",
  "log",
  "maplit",
  "olpc-cjson",
@@ -3503,12 +3523,12 @@ dependencies = [
  "aws-sdk-kms",
  "aws-sdk-ssm",
  "base64 0.22.1",
- "chrono",
  "clap",
  "futures",
  "futures-core",
  "hex",
  "httptest",
+ "jiff",
  "log",
  "maplit",
  "olpc-cjson",
@@ -3842,63 +3862,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/tough/CHANGELOG.md
+++ b/tough/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Breaking Changes
+- Migrated from `chrono` to `jiff`. Public API: `DateTime<Utc>` types replaced with `jiff::Timestamp` on `Role::expires`, `Root`/`Snapshot`/`Targets`/`Timestamp` `expires` fields, `RepositoryEditor::*_expires` setters, and the `SystemTimeSteppedBackward` error variant. Wire format unchanged (RFC 3339, `Z` suffix). [#948]
+
+[#948]: https://github.com/awslabs/tough/pull/948
+
 ## [0.22.0] - 2026-04-24
 ### Fixes
 - Update delegations code [#933]

--- a/tough/Cargo.toml
+++ b/tough/Cargo.toml
@@ -13,12 +13,12 @@ async-recursion = "1"
 async-trait = "0.1"
 aws-lc-rs = "1"
 bytes = "1"
-chrono = { version = "0.4", default-features = false, features = ["std", "alloc", "serde", "clock"] }
 dyn-clone = "1"
 futures = "0.3"
 futures-core = "0.3"
 globset = { version = "0.4" }
 hex = "0.4"
+jiff = { version = "0.2", features = ["serde"] }
 log = "0.4"
 olpc-cjson = { version = "0.1", path = "../olpc-cjson" }
 pem = "3"

--- a/tough/src/datastore.rs
+++ b/tough/src/datastore.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::error::{self, Result};
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use log::debug;
 use serde::Serialize;
 use snafu::{ensure, ResultExt};
@@ -85,7 +85,7 @@ impl Datastore {
 
     /// Ensures that system time has not stepped backward since it was last sampled. This function
     /// is protected by a lock guard to ensure thread safety.
-    pub(crate) async fn system_time(&self) -> Result<DateTime<Utc>> {
+    pub(crate) async fn system_time(&self) -> Result<Timestamp> {
         // Treat this function as a critical section. This lock is not used for anything else.
         let lock = self.time_lock.lock().await;
 
@@ -94,10 +94,10 @@ impl Datastore {
         let poss_latest_known_time = self
             .bytes(file)
             .await?
-            .map(|b| serde_json::from_slice::<DateTime<Utc>>(&b));
+            .map(|b| serde_json::from_slice::<Timestamp>(&b));
 
         // Get 'current' system time
-        let sys_time = Utc::now();
+        let sys_time = Timestamp::now();
 
         if let Some(Ok(latest_known_time)) = poss_latest_known_time {
             // Make sure the sampled system time did not go back in time

--- a/tough/src/editor/mod.rs
+++ b/tough/src/editor/mod.rs
@@ -25,7 +25,7 @@ use crate::{encode_filename, Limits};
 use crate::{Repository, TargetName};
 use aws_lc_rs::digest::{SHA256, SHA256_OUTPUT_LEN};
 use aws_lc_rs::rand::SystemRandom;
-use chrono::{DateTime, Utc};
+use jiff::Timestamp as JiffTimestamp;
 use serde_json::Value;
 use snafu::{ensure, OptionExt, ResultExt};
 use std::borrow::Cow;
@@ -69,11 +69,11 @@ pub struct RepositoryEditor {
     signed_root: SignedRole<Root>,
 
     snapshot_version: Option<NonZeroU64>,
-    snapshot_expires: Option<DateTime<Utc>>,
+    snapshot_expires: Option<JiffTimestamp>,
     snapshot_extra: Option<HashMap<String, Value>>,
 
     timestamp_version: Option<NonZeroU64>,
-    timestamp_expires: Option<DateTime<Utc>>,
+    timestamp_expires: Option<JiffTimestamp>,
     timestamp_extra: Option<HashMap<String, Value>>,
 
     targets_editor: Option<TargetsEditor>,
@@ -354,7 +354,7 @@ impl RepositoryEditor {
         paths: PathSet,
         terminating: bool,
         threshold: NonZeroU64,
-        expiration: DateTime<Utc>,
+        expiration: JiffTimestamp,
         version: NonZeroU64,
     ) -> Result<&mut Self> {
         // Create the new targets using targets editor
@@ -404,7 +404,7 @@ impl RepositoryEditor {
     }
 
     /// Set the `Snapshot` expiration
-    pub fn snapshot_expires(&mut self, snapshot_expires: DateTime<Utc>) -> &mut Self {
+    pub fn snapshot_expires(&mut self, snapshot_expires: JiffTimestamp) -> &mut Self {
         self.snapshot_expires = Some(snapshot_expires);
         self
     }
@@ -416,7 +416,7 @@ impl RepositoryEditor {
     }
 
     /// Set the `Targets` expiration
-    pub fn targets_expires(&mut self, targets_expires: DateTime<Utc>) -> Result<&mut Self> {
+    pub fn targets_expires(&mut self, targets_expires: JiffTimestamp) -> Result<&mut Self> {
         self.targets_editor_mut()?.expires(targets_expires);
         Ok(self)
     }
@@ -428,7 +428,7 @@ impl RepositoryEditor {
     }
 
     /// Set the `Timestamp` expiration
-    pub fn timestamp_expires(&mut self, timestamp_expires: DateTime<Utc>) -> &mut Self {
+    pub fn timestamp_expires(&mut self, timestamp_expires: JiffTimestamp) -> &mut Self {
         self.timestamp_expires = Some(timestamp_expires);
         self
     }

--- a/tough/src/editor/targets.rs
+++ b/tough/src/editor/targets.rs
@@ -18,7 +18,7 @@ use crate::transport::{IntoVec, Transport};
 use crate::{encode_filename, Limits};
 use crate::{Repository, TargetName};
 use aws_lc_rs::rand::SystemRandom;
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use serde_json::Value;
 use snafu::{OptionExt, ResultExt};
 use std::borrow::Cow;
@@ -73,7 +73,7 @@ pub struct TargetsEditor {
     /// Version of the `Targets`
     version: Option<NonZeroU64>,
     /// Expiration of the `Targets`
-    expires: Option<DateTime<Utc>>,
+    expires: Option<Timestamp>,
     /// New roles that were created with the editor
     new_roles: Option<Vec<DelegatedRole>>,
 
@@ -265,7 +265,7 @@ impl TargetsEditor {
     }
 
     /// Set the expiration
-    pub fn expires(&mut self, expires: DateTime<Utc>) -> &mut Self {
+    pub fn expires(&mut self, expires: Timestamp) -> &mut Self {
         self.expires = Some(expires);
         self
     }

--- a/tough/src/editor/test.rs
+++ b/tough/src/editor/test.rs
@@ -5,14 +5,14 @@
 mod tests {
     use crate::editor::RepositoryEditor;
     use crate::key_source::LocalKeySource;
-    use crate::schema::{Signed, Snapshot, Target, Targets, Timestamp};
+    use crate::schema::{Signed, Snapshot, Target, Targets, Timestamp as TimestampRole};
     use crate::TargetName;
-    use chrono::{TimeDelta, Utc};
+    use jiff::{SignedDuration, Timestamp};
     use std::num::NonZeroU64;
     use std::path::PathBuf;
 
-    fn days(value: i64) -> TimeDelta {
-        TimeDelta::try_days(value).unwrap()
+    fn days(value: i64) -> SignedDuration {
+        SignedDuration::from_hours(value * 24)
     }
 
     // Path to the root.json in the reference implementation
@@ -113,11 +113,11 @@ mod tests {
         let root = root_path();
         let root_key = key_path();
         let key_source = LocalKeySource { path: root_key };
-        let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+        let timestamp_expiration = Timestamp::now() + days(3);
         let timestamp_version = NonZeroU64::new(1234).unwrap();
-        let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+        let snapshot_expiration = Timestamp::now() + days(21);
         let snapshot_version = NonZeroU64::new(5432).unwrap();
-        let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+        let targets_expiration = Timestamp::now() + days(13);
         let targets_version = NonZeroU64::new(789).unwrap();
         let target1 = targets_path().join("file1.txt");
         let target2 = targets_path().join("file2.txt");
@@ -151,7 +151,7 @@ mod tests {
             "../../tests/data/tuf-reference-impl/metadata/snapshot.json"
         ))
         .unwrap();
-        let timestamp: Signed<Timestamp> = serde_json::from_str(include_str!(
+        let timestamp: Signed<TimestampRole> = serde_json::from_str(include_str!(
             "../../tests/data/tuf-reference-impl/metadata/timestamp.json"
         ))
         .unwrap();

--- a/tough/src/error.rs
+++ b/tough/src/error.rs
@@ -7,7 +7,7 @@
 
 use crate::schema::RoleType;
 use crate::{schema, TargetName, TransportError};
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use snafu::{Backtrace, Snafu};
 use std::io;
 use std::path::PathBuf;
@@ -471,8 +471,8 @@ pub enum Error {
         latest_known_time,
     ))]
     SystemTimeSteppedBackward {
-        sys_time: DateTime<Utc>,
-        latest_known_time: DateTime<Utc>,
+        sys_time: Timestamp,
+        latest_known_time: Timestamp,
     },
 
     #[snafu(display("Refusing to replace {} with requested {} for target {}", found, expected, path.display()))]

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -65,10 +65,10 @@ pub use crate::urlpath::SafeUrlPath;
 use async_recursion::async_recursion;
 pub use async_trait::async_trait;
 pub use bytes::Bytes;
-use chrono::{DateTime, Utc};
 use error::SnapshotTargetsMetaMissingSnafu;
 use futures::StreamExt;
 use futures_core::Stream;
+use jiff::Timestamp as JiffTimestamp;
 use log::warn;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use snafu::{ensure, OptionExt, ResultExt};
@@ -315,7 +315,7 @@ pub struct Repository {
     transport: Box<dyn Transport + Send + Sync>,
     consistent_snapshot: bool,
     datastore: Datastore,
-    earliest_expiration: DateTime<Utc>,
+    earliest_expiration: JiffTimestamp,
     earliest_expiration_role: RoleType,
     root: Signed<Root>,
     snapshot: Signed<Snapshot>,
@@ -661,7 +661,7 @@ pub(crate) fn encode_filename<S: AsRef<str>>(name: S) -> String {
 
 /// TUF v1.0.16, 5.2.9, 5.3.3, 5.4.5, 5.5.4, The expiration timestamp in the `[metadata]` file MUST
 /// be higher than the fixed update start time.
-fn check_expired<T: Role>(update_start: &DateTime<Utc>, role: &T) -> Result<()> {
+fn check_expired<T: Role>(update_start: &JiffTimestamp, role: &T) -> Result<()> {
     ensure!(
         *update_start <= role.expires(),
         error::ExpiredMetadataSnafu { role: T::TYPE }
@@ -694,7 +694,7 @@ async fn load_root<R: AsRef<[u8]>>(
     max_root_updates: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
-    update_start: &DateTime<Utc>,
+    update_start: &JiffTimestamp,
 ) -> Result<Signed<Root>> {
     // 5.2. Load the trusted root metadata file. We assume that a good, trusted copy of this file was
     //    shipped with the package manager or software updater using an out-of-band process. Note
@@ -866,7 +866,7 @@ async fn load_timestamp(
     max_timestamp_size: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
-    update_start: &DateTime<Utc>,
+    update_start: &JiffTimestamp,
 ) -> Result<Signed<Timestamp>> {
     // 2. Download the timestamp metadata file, up to Y number of bytes (because the size is
     //    unknown.) The value for Y is set by the authors of the application using TUF. For
@@ -990,7 +990,7 @@ async fn load_snapshot(
     datastore: &Datastore,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
-    update_start: &DateTime<Utc>,
+    update_start: &JiffTimestamp,
 ) -> Result<Signed<Snapshot>> {
     // 3. Download snapshot metadata file, up to the number of bytes specified in the timestamp
     //    metadata file. If consistent snapshots are not used (see Section 7), then the filename
@@ -1184,7 +1184,7 @@ async fn load_targets(
     max_targets_size: u64,
     metadata_base_url: &Url,
     expiration_enforcement: ExpirationEnforcement,
-    update_start: &DateTime<Utc>,
+    update_start: &JiffTimestamp,
 ) -> Result<(
     Signed<crate::schema::Targets>,
     std::collections::HashMap<String, Vec<u8>>,
@@ -1322,7 +1322,7 @@ async fn load_delegations(
     delegation: &mut Delegations,
     datastore: &Datastore,
     loaded_roles: &mut BTreeSet<String>,
-    update_start: &DateTime<Utc>,
+    update_start: &JiffTimestamp,
     expiration_enforcement: ExpirationEnforcement,
     delegated_metadata_bytes: &mut std::collections::HashMap<String, Vec<u8>>,
 ) -> Result<()> {

--- a/tough/src/schema/mod.rs
+++ b/tough/src/schema/mod.rs
@@ -18,7 +18,6 @@ use crate::sign::Sign;
 pub use crate::transport::{FilesystemTransport, Transport};
 use crate::{encode_filename, TargetName};
 use aws_lc_rs::digest::{digest, Context, SHA256};
-use chrono::{DateTime, Utc};
 use globset::{Glob, GlobMatcher};
 use hex::ToHex;
 use olpc_cjson::CanonicalFormatter;
@@ -73,7 +72,7 @@ pub trait Role: Serialize {
     const TYPE: RoleType;
 
     /// Determines when metadata should be considered expired and no longer trusted by clients.
-    fn expires(&self) -> DateTime<Utc>;
+    fn expires(&self) -> jiff::Timestamp;
 
     /// An integer that is greater than 0. Clients MUST NOT replace a metadata file with a version
     /// number less than the one currently trusted.
@@ -150,7 +149,7 @@ pub struct Root {
     pub version: NonZeroU64,
 
     /// Determines when metadata should be considered expired and no longer trusted by clients.
-    pub expires: DateTime<Utc>,
+    pub expires: jiff::Timestamp,
 
     /// The KEYID must be correct for the specified KEY. Clients MUST calculate each KEYID to verify
     /// this is correct for the associated key. Clients MUST ensure that for any KEYID represented
@@ -223,7 +222,7 @@ impl Root {
 impl Role for Root {
     const TYPE: RoleType = RoleType::Root;
 
-    fn expires(&self) -> DateTime<Utc> {
+    fn expires(&self) -> jiff::Timestamp {
         self.expires
     }
 
@@ -254,7 +253,7 @@ pub struct Snapshot {
     pub version: NonZeroU64,
 
     /// Determines when metadata should be considered expired and no longer trusted by clients.
-    pub expires: DateTime<Utc>,
+    pub expires: jiff::Timestamp,
 
     /// A list of what the TUF spec calls 'METAFILES' (`Metafiles` objects). The TUF spec
     /// describes the hash key in 4.4: METAPATH is the file path of the metadata on the repository
@@ -337,7 +336,7 @@ pub struct Hashes {
 
 impl Snapshot {
     /// Create a new `Snapshot` object.
-    pub fn new(spec_version: String, version: NonZeroU64, expires: DateTime<Utc>) -> Self {
+    pub fn new(spec_version: String, version: NonZeroU64, expires: jiff::Timestamp) -> Self {
         Snapshot {
             spec_version,
             version,
@@ -350,7 +349,7 @@ impl Snapshot {
 impl Role for Snapshot {
     const TYPE: RoleType = RoleType::Snapshot;
 
-    fn expires(&self) -> DateTime<Utc> {
+    fn expires(&self) -> jiff::Timestamp {
         self.expires
     }
 
@@ -395,7 +394,7 @@ pub struct Targets {
     pub version: NonZeroU64,
 
     /// Determines when metadata should be considered expired and no longer trusted by clients.
-    pub expires: DateTime<Utc>,
+    pub expires: jiff::Timestamp,
 
     /// Each key of the TARGETS object is a TARGETPATH. A TARGETPATH is a path to a file that is
     /// relative to a mirror's base URL of targets.
@@ -500,7 +499,7 @@ impl Target {
 
 impl Targets {
     /// Create a new `Targets` object.
-    pub fn new(spec_version: String, version: NonZeroU64, expires: DateTime<Utc>) -> Self {
+    pub fn new(spec_version: String, version: NonZeroU64, expires: jiff::Timestamp) -> Self {
         Targets {
             spec_version,
             version,
@@ -767,7 +766,7 @@ impl Targets {
 impl Role for Targets {
     const TYPE: RoleType = RoleType::Targets;
 
-    fn expires(&self) -> DateTime<Utc> {
+    fn expires(&self) -> jiff::Timestamp {
         self.expires
     }
 
@@ -812,7 +811,7 @@ impl DerefMut for DelegatedTargets {
 impl Role for DelegatedTargets {
     const TYPE: RoleType = RoleType::DelegatedTargets;
 
-    fn expires(&self) -> DateTime<Utc> {
+    fn expires(&self) -> jiff::Timestamp {
         self.targets.expires
     }
 
@@ -1142,7 +1141,7 @@ pub struct Timestamp {
     pub version: NonZeroU64,
 
     /// Determines when metadata should be considered expired and no longer trusted by clients.
-    pub expires: DateTime<Utc>,
+    pub expires: jiff::Timestamp,
 
     /// METAFILES is the same as described for the snapshot.json file. In the case of the
     /// timestamp.json file, this MUST only include a description of the snapshot.json file.
@@ -1160,7 +1159,7 @@ pub struct Timestamp {
 
 impl Timestamp {
     /// Creates a new `Timestamp` object.
-    pub fn new(spec_version: String, version: NonZeroU64, expires: DateTime<Utc>) -> Self {
+    pub fn new(spec_version: String, version: NonZeroU64, expires: jiff::Timestamp) -> Self {
         Timestamp {
             spec_version,
             version,
@@ -1174,7 +1173,7 @@ impl Timestamp {
 impl Role for Timestamp {
     const TYPE: RoleType = RoleType::Timestamp;
 
-    fn expires(&self) -> DateTime<Utc> {
+    fn expires(&self) -> jiff::Timestamp {
         self.expires
     }
 
@@ -1213,7 +1212,7 @@ fn targets_iter_and_map_test() {
             signed: Targets {
                 spec_version: String::new(),
                 version: NonZeroU64::new(1).unwrap(),
-                expires: Utc::now(),
+                expires: jiff::Timestamp::now(),
                 targets: hashmap! {
                     TargetName::new("c.txt").unwrap() => nothing.clone(),
                 },
@@ -1237,7 +1236,7 @@ fn targets_iter_and_map_test() {
             signed: Targets {
                 spec_version: String::new(),
                 version: NonZeroU64::new(1).unwrap(),
-                expires: Utc::now(),
+                expires: jiff::Timestamp::now(),
                 targets: hashmap! {
                     TargetName::new("b.txt").unwrap() => nothing.clone(),
                 },
@@ -1254,7 +1253,7 @@ fn targets_iter_and_map_test() {
     let a = Targets {
         spec_version: String::new(),
         version: NonZeroU64::new(1).unwrap(),
-        expires: Utc::now(),
+        expires: jiff::Timestamp::now(),
         targets: hashmap! {
             TargetName::new("a.txt").unwrap() => nothing,
         },

--- a/tough/tests/repo_editor.rs
+++ b/tough/tests/repo_editor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::test_utils::{days, dir_url, read_to_end, test_data};
-use chrono::Utc;
+use jiff::Timestamp;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
@@ -78,11 +78,11 @@ async fn load_tuf_reference_impl(paths: &mut RepoPaths) -> Repository {
 
 async fn test_repo_editor() -> RepositoryEditor {
     let root = root_path();
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version = NonZeroU64::new(1234).unwrap();
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version = NonZeroU64::new(5432).unwrap();
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version = NonZeroU64::new(789).unwrap();
     let target3 = targets_path().join("file3.txt");
     let target_list = vec![target3];
@@ -127,11 +127,11 @@ async fn repository_editor_from_repository() {
 #[tokio::test]
 async fn create_sign_write_reload_repo() {
     let root = root_path();
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version = NonZeroU64::new(1234).unwrap();
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version = NonZeroU64::new(5432).unwrap();
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version = NonZeroU64::new(789).unwrap();
     let target3 = targets_path().join("file3.txt");
     let target_list = vec![target3];
@@ -152,13 +152,13 @@ async fn create_sign_write_reload_repo() {
         .await
         .unwrap();
 
-    let targets_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let targets_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource { path: key_path() })];
-    let role1_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role1_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path(),
         })];
-    let role2_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role2_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path1(),
         })];
@@ -171,7 +171,7 @@ async fn create_sign_write_reload_repo() {
             PathSet::Paths(vec![PathPattern::new("file?.txt").unwrap()]),
             false,
             NonZeroU64::new(1).unwrap(),
-            Utc::now().checked_add_signed(days(21)).unwrap(),
+            Timestamp::now() + days(21),
             NonZeroU64::new(1).unwrap(),
         )
         .await
@@ -192,7 +192,7 @@ async fn create_sign_write_reload_repo() {
             PathSet::Paths(vec![PathPattern::new("file1.txt").unwrap()]),
             false,
             NonZeroU64::new(1).unwrap(),
-            Utc::now().checked_add_signed(days(21)).unwrap(),
+            Timestamp::now() + days(21),
             NonZeroU64::new(1).unwrap(),
         )
         .await
@@ -203,7 +203,7 @@ async fn create_sign_write_reload_repo() {
             PathSet::Paths(vec![PathPattern::new("file1.txt").unwrap()]),
             false,
             NonZeroU64::new(1).unwrap(),
-            Utc::now().checked_add_signed(days(21)).unwrap(),
+            Timestamp::now() + days(21),
             NonZeroU64::new(1).unwrap(),
         )
         .await
@@ -224,7 +224,7 @@ async fn create_sign_write_reload_repo() {
             PathSet::Paths(vec![PathPattern::new("file1.txt").unwrap()]),
             false,
             NonZeroU64::new(1).unwrap(),
-            Utc::now().checked_add_signed(days(21)).unwrap(),
+            Timestamp::now() + days(21),
             NonZeroU64::new(1).unwrap(),
         )
         .await
@@ -260,13 +260,13 @@ async fn create_sign_write_reload_repo() {
 async fn create_role_flow() {
     let editor = test_repo_editor().await;
 
-    let targets_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let targets_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource { path: key_path() })];
-    let role1_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role1_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path(),
         })];
-    let role2_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role2_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path1(),
         })];
@@ -281,7 +281,7 @@ async fn create_role_flow() {
     // create new delegated target as "A" and sign with role1_key
     let new_role = TargetsEditor::new("A")
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .expires(Timestamp::now() + days(21))
         .sign(role1_key)
         .await
         .unwrap();
@@ -326,11 +326,11 @@ async fn create_role_flow() {
     //sign everything since targets key is the same as snapshot and timestamp
     let root_key = key_path();
     let key_source = LocalKeySource { path: root_key };
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version = NonZeroU64::new(1234).unwrap();
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version = NonZeroU64::new(5432).unwrap();
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version = NonZeroU64::new(789).unwrap();
     editor
         .targets_expires(targets_expiration)
@@ -367,7 +367,7 @@ async fn create_role_flow() {
     // create new delegated target as "B" and sign with role2_key
     let new_role = TargetsEditor::new("B")
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .expires(Timestamp::now() + days(21))
         .sign(role2_key)
         .await
         .unwrap();
@@ -408,7 +408,7 @@ async fn create_role_flow() {
         .await
         .unwrap()
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap());
+        .expires(Timestamp::now() + days(21));
 
     // sign A and write A and B metadata to output directory
     let signed_roles = editor.sign(role1_key).await.unwrap();
@@ -447,9 +447,9 @@ async fn create_role_flow() {
         .unwrap();
     editor
         .snapshot_version(NonZeroU64::new(1).unwrap())
-        .snapshot_expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .snapshot_expires(Timestamp::now() + days(21))
         .timestamp_version(NonZeroU64::new(1).unwrap())
-        .timestamp_expires(Utc::now().checked_add_signed(days(21)).unwrap());
+        .timestamp_expires(Timestamp::now() + days(21));
 
     let signed_refreshed_repo = editor.sign(&[Box::new(key_source)]).await.unwrap();
 
@@ -486,13 +486,13 @@ async fn update_targets_flow() {
     // The beginning of this creates a repo with Target -> A ('*.txt') -> B ('file?.txt')
     let editor = test_repo_editor().await;
 
-    let targets_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let targets_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource { path: key_path() })];
-    let role1_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role1_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path(),
         })];
-    let role2_key: &[std::boxed::Box<(dyn tough::key_source::KeySource + 'static)>] =
+    let role2_key: &[std::boxed::Box<dyn tough::key_source::KeySource + 'static>] =
         &[Box::new(LocalKeySource {
             path: targets_key_path1(),
         })];
@@ -507,7 +507,7 @@ async fn update_targets_flow() {
     // create new delegated target as "A" and sign with role1_key
     let new_role = TargetsEditor::new("A")
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .expires(Timestamp::now() + days(21))
         .sign(role1_key)
         .await
         .unwrap();
@@ -552,11 +552,11 @@ async fn update_targets_flow() {
     //sign everything since targets key is the same as snapshot and timestamp
     let root_key = key_path();
     let key_source = LocalKeySource { path: root_key };
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version = NonZeroU64::new(1234).unwrap();
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version = NonZeroU64::new(5432).unwrap();
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version = NonZeroU64::new(789).unwrap();
     editor
         .targets_expires(targets_expiration)
@@ -593,7 +593,7 @@ async fn update_targets_flow() {
     // create new delegated target as "B" and sign with role2_key
     let new_role = TargetsEditor::new("B")
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .expires(Timestamp::now() + days(21))
         .sign(role2_key)
         .await
         .unwrap();
@@ -634,7 +634,7 @@ async fn update_targets_flow() {
         .await
         .unwrap()
         .version(NonZeroU64::new(1).unwrap())
-        .expires(Utc::now().checked_add_signed(days(21)).unwrap());
+        .expires(Timestamp::now() + days(21));
 
     // sign A and write A and B metadata to output directory
     let signed_roles = editor.sign(role1_key).await.unwrap();
@@ -673,9 +673,9 @@ async fn update_targets_flow() {
         .unwrap();
     editor
         .snapshot_version(NonZeroU64::new(1).unwrap())
-        .snapshot_expires(Utc::now().checked_add_signed(days(21)).unwrap())
+        .snapshot_expires(Timestamp::now() + days(21))
         .timestamp_version(NonZeroU64::new(1).unwrap())
-        .timestamp_expires(Utc::now().checked_add_signed(days(21)).unwrap());
+        .timestamp_expires(Timestamp::now() + days(21));
 
     let signed_refreshed_repo = editor.sign(&[Box::new(key_source)]).await.unwrap();
 

--- a/tough/tests/target_path_safety.rs
+++ b/tough/tests/target_path_safety.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 
 use aws_lc_rs::rand::SystemRandom;
-use chrono::{DateTime, TimeZone, Utc};
+use jiff::{civil, tz::TimeZone, Timestamp};
 use maplit::hashmap;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -18,8 +18,11 @@ use tough::{Prefix, RepositoryLoader, TargetName};
 /// Returns a date in the future when Rust programs will no longer exist. `MAX_DATETIME` is so huge
 /// that it serializes to something weird-looking, so we use something that is recognizable to
 /// humans as a date.
-fn later() -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(2999, 1, 1, 0, 0, 0).unwrap()
+fn later() -> Timestamp {
+    civil::date(2999, 1, 1)
+        .to_zoned(TimeZone::UTC)
+        .unwrap()
+        .timestamp()
 }
 
 /// This test ensures that we can safely handle path-like target names with ../'s in them.

--- a/tough/tests/test_utils.rs
+++ b/tough/tests/test_utils.rs
@@ -5,9 +5,9 @@
 // cause compiler warnings for unused code, so we suppress them.
 #![allow(unused)]
 
-use chrono::TimeDelta;
 use futures::TryStreamExt;
 use futures_core::Stream;
+use jiff::SignedDuration;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use tough::IntoVec;
@@ -39,6 +39,6 @@ where
     stream.into_vec().await.unwrap()
 }
 
-pub fn days(value: i64) -> TimeDelta {
-    TimeDelta::try_days(value).unwrap()
+pub fn days(value: i64) -> SignedDuration {
+    SignedDuration::from_hours(value * 24)
 }

--- a/tuftool/CHANGELOG.md
+++ b/tuftool/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changes
+- Migrated from `chrono` to `jiff`. CLI behavior unchanged; `--expires` continues to accept RFC 3339 and `in N hours/days/weeks`. [#948]
+
+[#948]: https://github.com/awslabs/tough/pull/948
+
 ## [0.15.0] - 2026-04-24
 ### Changes
 - Replace `openssl` shell-out in `gen-rsa-key` with `aws-lc-rs` (thanks @jeremydosborn!) [#923]

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -22,10 +22,10 @@ aws-lc-rs = "1"
 aws-sdk-kms = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sdk-ssm = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 base64 = "0.22"
-chrono = { version = "0.4", default-features = false, features = ["alloc", "std", "clock"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 hex = "0.4"
+jiff = { version = "0.2", features = ["serde"] }
 log = "0.4"
 maplit = "1"
 olpc-cjson = { version = "0.1", path = "../olpc-cjson" }

--- a/tuftool/src/add_key_role.rs
+++ b/tuftool/src/add_key_role.rs
@@ -5,8 +5,8 @@ use crate::common::load_metadata_repo;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -23,7 +23,7 @@ pub(crate) struct AddKeyArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Key files to sign with
     #[arg(short, long = "key", required = true)]

--- a/tuftool/src/add_role.rs
+++ b/tuftool/src/add_role.rs
@@ -5,8 +5,8 @@ use crate::common::load_metadata_repo;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::{OptionExt, ResultExt};
 use std::num::NonZeroU64;
 use std::path::PathBuf;
@@ -23,7 +23,7 @@ pub(crate) struct AddRoleArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Incoming metadata
     #[arg(short, long = "incoming-metadata")]
@@ -60,7 +60,7 @@ pub(crate) struct AddRoleArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    snapshot_expires: Option<DateTime<Utc>>,
+    snapshot_expires: Option<Timestamp>,
     /// Version of snapshot.json file
     #[arg(long)]
     snapshot_version: Option<NonZeroU64>,
@@ -72,7 +72,7 @@ pub(crate) struct AddRoleArgs {
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    timestamp_expires: Option<DateTime<Utc>>,
+    timestamp_expires: Option<Timestamp>,
     /// Version of timestamp.json file
     #[arg(long)]
     timestamp_version: Option<NonZeroU64>,

--- a/tuftool/src/create.rs
+++ b/tuftool/src/create.rs
@@ -5,8 +5,8 @@ use crate::build_targets;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
@@ -42,7 +42,7 @@ pub(crate) struct CreateArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    snapshot_expires: DateTime<Utc>,
+    snapshot_expires: Timestamp,
 
     /// Version of snapshot.json file
     #[arg(long)]
@@ -61,7 +61,7 @@ pub(crate) struct CreateArgs {
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    targets_expires: DateTime<Utc>,
+    targets_expires: Timestamp,
 
     /// Version of targets.json file
     #[arg(long)]
@@ -70,7 +70,7 @@ pub(crate) struct CreateArgs {
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    timestamp_expires: DateTime<Utc>,
+    timestamp_expires: Timestamp,
 
     /// Version of timestamp.json file
     #[arg(long)]

--- a/tuftool/src/create_role.rs
+++ b/tuftool/src/create_role.rs
@@ -4,8 +4,8 @@
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -21,7 +21,7 @@ pub(crate) struct CreateRoleArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, required = true, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Key files to sign with
     #[arg(short, long, required = true)]

--- a/tuftool/src/datetime.rs
+++ b/tuftool/src/datetime.rs
@@ -3,18 +3,15 @@
 
 use crate::error::{self, Result};
 
-use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
-use snafu::{ensure, OptionExt, ResultExt};
+use jiff::{SignedDuration, Timestamp};
+use snafu::{ensure, ResultExt};
 
 /// Parses a user-specified datetime, either in full RFC 3339 format, or a shorthand like "in 7
 /// days"
-pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
+pub(crate) fn parse_datetime(input: &str) -> Result<Timestamp> {
     // If the user gave an absolute date in a standard format, accept it.
-    let try_dt: std::result::Result<DateTime<FixedOffset>, chrono::format::ParseError> =
-        DateTime::parse_from_rfc3339(input);
-    if let Ok(dt) = try_dt {
-        let utc = dt.into();
-        return Ok(utc);
+    if let Ok(ts) = input.parse::<Timestamp>() {
+        return Ok(ts);
     }
 
     // Otherwise, pull apart a request like "in 5 days" to get an exact datetime.
@@ -23,15 +20,14 @@ pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
         parts.len() == 3,
         error::DateArgInvalidSnafu {
             input,
-            msg: "expected RFC 3339, or something like 'in 7 days'"
+            msg: "expected RFC 3339, or 3 space-separated values like 'in 7 days'",
         }
     );
     let unit_str = parts.pop().unwrap();
     let count_str = parts.pop().unwrap();
-    let prefix_str = parts.pop().unwrap();
-
+    let prefix = parts.pop().unwrap();
     ensure!(
-        prefix_str == "in",
+        prefix == "in",
         error::DateArgInvalidSnafu {
             input,
             msg: "expected RFC 3339, or prefix 'in', something like 'in 7 days'",
@@ -43,24 +39,27 @@ pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
         .context(error::DateArgCountSnafu { input })?;
 
     let duration = match unit_str {
-        "hour" | "hours" => {
-            TimeDelta::try_hours(i64::from(count)).context(error::DateArgInvalidSnafu {
-                input: count.to_string(),
-                msg: format!("unable to convert {count} to a number of hours"),
-            })?
-        }
-        "day" | "days" => {
-            TimeDelta::try_days(i64::from(count)).context(error::DateArgInvalidSnafu {
-                input: count.to_string(),
-                msg: format!("unable to convert {count} to a number of days"),
-            })?
-        }
-        "week" | "weeks" => {
-            TimeDelta::try_weeks(i64::from(count)).context(error::DateArgInvalidSnafu {
-                input: count.to_string(),
-                msg: format!("unable to convert {count} to a number of weeks"),
-            })?
-        }
+        "hour" | "hours" => SignedDuration::from_hours(i64::from(count)),
+        "day" | "days" => i64::from(count)
+            .checked_mul(24)
+            .map(SignedDuration::from_hours)
+            .ok_or_else(|| {
+                error::DateArgInvalidSnafu {
+                    input: count.to_string(),
+                    msg: format!("unable to convert {count} to a number of days"),
+                }
+                .build()
+            })?,
+        "week" | "weeks" => i64::from(count)
+            .checked_mul(24 * 7)
+            .map(SignedDuration::from_hours)
+            .ok_or_else(|| {
+                error::DateArgInvalidSnafu {
+                    input: count.to_string(),
+                    msg: format!("unable to convert {count} to a number of weeks"),
+                }
+                .build()
+            })?,
         _ => {
             return error::DateArgInvalidSnafu {
                 input,
@@ -70,7 +69,7 @@ pub(crate) fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
         }
     };
 
-    let now = Utc::now();
+    let now = Timestamp::now();
     let then = now + duration;
     Ok(then)
 }

--- a/tuftool/src/remove_key_role.rs
+++ b/tuftool/src/remove_key_role.rs
@@ -5,8 +5,8 @@ use crate::common::load_metadata_repo;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
@@ -23,7 +23,7 @@ pub(crate) struct RemoveKeyArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Key files to sign with
     #[arg(short, long = "key", required = true)]

--- a/tuftool/src/remove_role.rs
+++ b/tuftool/src/remove_role.rs
@@ -5,8 +5,8 @@ use crate::common::load_metadata_repo;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
@@ -22,7 +22,7 @@ pub(crate) struct RemoveRoleArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Key files to sign with
     #[arg(short, long = "key", required = true)]

--- a/tuftool/src/root.rs
+++ b/tuftool/src/root.rs
@@ -9,8 +9,8 @@ use aws_lc_rs::encoding::{AsDer, Pkcs8V1Der};
 use aws_lc_rs::rand::SystemRandom;
 use aws_lc_rs::rsa::{KeySize, PrivateDecryptingKey};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use chrono::{DateTime, Timelike, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use log::warn;
 use maplit::hashmap;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -50,7 +50,7 @@ pub(crate) enum Command {
         /// Expiration of root; can be in full RFC 3339 format, or something like 'in
         /// 7 days'
         #[arg(value_parser = parse_datetime)]
-        time: DateTime<Utc>,
+        time: Timestamp,
     },
     /// Generate a new RSA key pair, saving it to a file, and add it to a role
     GenRsaKey {
@@ -186,7 +186,7 @@ impl Command {
                     spec_version: crate::SPEC_VERSION.to_owned(),
                     consistent_snapshot: true,
                     version: NonZeroU64::new(init_version).unwrap(),
-                    expires: round_time(Utc::now()),
+                    expires: round_time(Timestamp::now()),
                     keys: HashMap::new(),
                     roles: hashmap! {
                         RoleType::Root => role_keys!(),
@@ -216,7 +216,7 @@ impl Command {
         write_file(path, root).await
     }
 
-    async fn expire(path: &Path, time: &DateTime<Utc>) -> Result<()> {
+    async fn expire(path: &Path, time: &Timestamp) -> Result<()> {
         let mut root: Signed<Root> = load_file(path).await?;
         root.signed.expires = round_time(*time);
         clear_sigs(&mut root);
@@ -429,9 +429,9 @@ impl Command {
     }
 }
 
-fn round_time(time: DateTime<Utc>) -> DateTime<Utc> {
-    // `Timelike::with_nanosecond` returns None only when passed a value >= 2_000_000_000
-    time.with_nanosecond(0).unwrap()
+fn round_time(time: Timestamp) -> Timestamp {
+    // Truncate sub-second precision; jiff guarantees `from_second(as_second())` round-trips.
+    Timestamp::from_second(time.as_second()).unwrap()
 }
 
 /// Removes signatures from a role. Useful if the content is updated.

--- a/tuftool/src/transfer_metadata.rs
+++ b/tuftool/src/transfer_metadata.rs
@@ -4,8 +4,8 @@
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
@@ -42,7 +42,7 @@ pub(crate) struct TransferMetadataArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long = "snapshot-expires", value_parser = parse_datetime)]
-    snapshot_expires: DateTime<Utc>,
+    snapshot_expires: Timestamp,
     /// Version of snapshot.json file
     #[arg(long = "snapshot-version")]
     snapshot_version: NonZeroU64,
@@ -54,7 +54,7 @@ pub(crate) struct TransferMetadataArgs {
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long = "targets-expires", value_parser = parse_datetime)]
-    targets_expires: DateTime<Utc>,
+    targets_expires: Timestamp,
     /// Version of targets.json file
     #[arg(long = "targets-version")]
     targets_version: NonZeroU64,
@@ -62,7 +62,7 @@ pub(crate) struct TransferMetadataArgs {
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long = "timestamp-expires", value_parser = parse_datetime)]
-    timestamp_expires: DateTime<Utc>,
+    timestamp_expires: Timestamp,
     /// Version of timestamp.json file
     #[arg(long = "timestamp-version")]
     timestamp_version: NonZeroU64,

--- a/tuftool/src/update.rs
+++ b/tuftool/src/update.rs
@@ -6,8 +6,8 @@ use crate::common::UNUSED_URL;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::{NonZeroU64, NonZeroUsize};
 use std::path::{Path, PathBuf};
@@ -61,7 +61,7 @@ pub(crate) struct UpdateArgs {
     /// Expiration of snapshot.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    snapshot_expires: DateTime<Utc>,
+    snapshot_expires: Timestamp,
 
     /// Version of snapshot.json file
     #[arg(long)]
@@ -80,7 +80,7 @@ pub(crate) struct UpdateArgs {
     /// Expiration of targets.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    targets_expires: DateTime<Utc>,
+    targets_expires: Timestamp,
 
     /// Version of targets.json file
     #[arg(long)]
@@ -89,7 +89,7 @@ pub(crate) struct UpdateArgs {
     /// Expiration of timestamp.json file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(long, value_parser = parse_datetime)]
-    timestamp_expires: DateTime<Utc>,
+    timestamp_expires: Timestamp,
 
     /// Version of timestamp.json file
     #[arg(long)]

--- a/tuftool/src/update_targets.rs
+++ b/tuftool/src/update_targets.rs
@@ -6,8 +6,8 @@ use crate::common::load_metadata_repo;
 use crate::datetime::parse_datetime;
 use crate::error::{self, Result};
 use crate::source::parse_key_source;
-use chrono::{DateTime, Utc};
 use clap::Parser;
+use jiff::Timestamp;
 use snafu::ResultExt;
 use std::num::NonZeroU64;
 use std::num::NonZeroUsize;
@@ -21,7 +21,7 @@ pub(crate) struct UpdateTargetsArgs {
     /// Expiration of new role file; can be in full RFC 3339 format, or something like 'in
     /// 7 days'
     #[arg(short, long, value_parser = parse_datetime)]
-    expires: DateTime<Utc>,
+    expires: Timestamp,
 
     /// Follow symbolic links in the given directory when adding targets
     #[arg(short, long)]

--- a/tuftool/tests/create_command.rs
+++ b/tuftool/tests/create_command.rs
@@ -5,7 +5,7 @@ mod test_utils;
 
 use crate::test_utils::days;
 use assert_cmd::cargo_bin_cmd;
-use chrono::Utc;
+use jiff::Timestamp;
 use tempfile::TempDir;
 use test_utils::dir_url;
 use tough::{RepositoryLoader, TargetName};
@@ -13,11 +13,11 @@ use tough::{RepositoryLoader, TargetName};
 #[tokio::test]
 // Ensure we can read a repo created by the `tuftool` binary using the `tough` library
 async fn create_command() {
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version: u64 = 1234;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version: u64 = 5432;
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version: u64 = 789;
     let targets_input_dir = test_utils::test_data()
         .join("tuf-reference-impl")
@@ -39,15 +39,15 @@ async fn create_command() {
             "--root",
             root_json.to_str().unwrap(),
             "--targets-expires",
-            targets_expiration.to_rfc3339().as_str(),
+            targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", targets_version).as_str(),
             "--snapshot-expires",
-            snapshot_expiration.to_rfc3339().as_str(),
+            snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", snapshot_version).as_str(),
             "--timestamp-expires",
-            timestamp_expiration.to_rfc3339().as_str(),
+            timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", timestamp_version).as_str(),
         ])

--- a/tuftool/tests/create_repository_integration.rs
+++ b/tuftool/tests/create_repository_integration.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use assert_cmd::cargo_bin_cmd;
-use chrono::Utc;
+use jiff::Timestamp;
 use std::env;
 use tempfile::TempDir;
 use test_utils::{days, dir_url};
@@ -118,11 +118,11 @@ async fn create_repository(root_key: &str, auto_generate: bool) {
     add_key_all_role(root_key, root_json.to_str().unwrap());
     sign_root_json(root_key, root_json.to_str().unwrap());
     // Use root.json file to generate metadata using create command.
-    let timestamp_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(3);
     let timestamp_version: u64 = 1234;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(21)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(21);
     let snapshot_version: u64 = 5432;
-    let targets_expiration = Utc::now().checked_add_signed(days(13)).unwrap();
+    let targets_expiration = Timestamp::now() + days(13);
     let targets_version: u64 = 789;
     let targets_input_dir = test_utils::test_data()
         .join("tuf-reference-impl")
@@ -141,15 +141,15 @@ async fn create_repository(root_key: &str, auto_generate: bool) {
             "--root",
             root_json.to_str().unwrap(),
             "--targets-expires",
-            targets_expiration.to_rfc3339().as_str(),
+            targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", targets_version).as_str(),
             "--snapshot-expires",
-            snapshot_expiration.to_rfc3339().as_str(),
+            snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", snapshot_version).as_str(),
             "--timestamp-expires",
-            timestamp_expiration.to_rfc3339().as_str(),
+            timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", timestamp_version).as_str(),
         ])

--- a/tuftool/tests/delegation_commands.rs
+++ b/tuftool/tests/delegation_commands.rs
@@ -5,18 +5,18 @@ mod test_utils;
 
 use crate::test_utils::days;
 use assert_cmd::cargo_bin_cmd;
-use chrono::Utc;
+use jiff::Timestamp;
 use std::path::Path;
 use tempfile::TempDir;
 use test_utils::dir_url;
 use tough::{RepositoryLoader, TargetName};
 
 fn create_repo<P: AsRef<Path>>(repo_dir: P) {
-    let timestamp_expiration = Utc::now().checked_add_signed(days(1)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(1);
     let timestamp_version: u64 = 31;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(2)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(2);
     let snapshot_version: u64 = 25;
-    let targets_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let targets_expiration = Timestamp::now() + days(3);
     let targets_version: u64 = 17;
     let targets_input_dir = test_utils::test_data()
         .join("tuf-reference-impl")
@@ -37,15 +37,15 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
             "--root",
             root_json.to_str().unwrap(),
             "--targets-expires",
-            targets_expiration.to_rfc3339().as_str(),
+            targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", targets_version).as_str(),
             "--snapshot-expires",
-            snapshot_expiration.to_rfc3339().as_str(),
+            snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", snapshot_version).as_str(),
             "--timestamp-expires",
-            timestamp_expiration.to_rfc3339().as_str(),
+            timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", timestamp_version).as_str(),
         ])
@@ -64,18 +64,18 @@ async fn create_add_role_command() {
     let repo_dir = TempDir::new().unwrap();
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
 
     // Set new expiration date for the new role
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -91,7 +91,7 @@ async fn create_add_role_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -117,7 +117,7 @@ async fn create_add_role_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -126,11 +126,11 @@ async fn create_add_role_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -164,7 +164,7 @@ async fn create_add_role_command() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -190,7 +190,7 @@ async fn create_add_role_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "B",
             "-t",
@@ -218,15 +218,15 @@ async fn create_add_role_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -259,16 +259,16 @@ async fn update_target_command() {
     let repo_dir = TempDir::new().unwrap();
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
 
     // Set new expiration date for the new role
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -284,7 +284,7 @@ async fn update_target_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -310,7 +310,7 @@ async fn update_target_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -319,11 +319,11 @@ async fn update_target_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -362,11 +362,11 @@ async fn update_target_command() {
 
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
@@ -383,15 +383,15 @@ async fn update_target_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -437,11 +437,11 @@ async fn add_key_command() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -457,7 +457,7 @@ async fn add_key_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -483,7 +483,7 @@ async fn add_key_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -492,11 +492,11 @@ async fn add_key_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -523,7 +523,7 @@ async fn add_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
             "--delegated-role",
@@ -550,15 +550,15 @@ async fn add_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--targets-version",
             "1",
             "--snapshot-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--snapshot-version",
             "1",
             "--timestamp-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--timestamp-version",
             "1",
         ])
@@ -580,7 +580,7 @@ async fn add_key_command() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -606,7 +606,7 @@ async fn add_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "B",
             "-t",
@@ -634,15 +634,15 @@ async fn add_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_snapshot_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -678,11 +678,11 @@ fn remove_key_command() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -700,7 +700,7 @@ fn remove_key_command() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -726,7 +726,7 @@ fn remove_key_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -735,11 +735,11 @@ fn remove_key_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -759,7 +759,7 @@ fn remove_key_command() {
             "-o",
             key_out.path().to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
             "--keyid",
@@ -794,15 +794,15 @@ fn remove_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--targets-version",
             "1",
             "--snapshot-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--snapshot-version",
             "1",
             "--timestamp-expires",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--timestamp-version",
             "1",
         ])
@@ -824,7 +824,7 @@ fn remove_key_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -850,7 +850,7 @@ fn remove_key_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "B",
             "-t",
@@ -875,11 +875,11 @@ async fn remove_role_command() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -895,7 +895,7 @@ async fn remove_role_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -921,7 +921,7 @@ async fn remove_role_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -930,11 +930,11 @@ async fn remove_role_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -968,7 +968,7 @@ async fn remove_role_command() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -994,7 +994,7 @@ async fn remove_role_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "B",
             "-t",
@@ -1007,11 +1007,11 @@ async fn remove_role_command() {
 
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
@@ -1028,15 +1028,15 @@ async fn remove_role_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -1078,11 +1078,11 @@ async fn remove_role_command() {
 
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
@@ -1099,15 +1099,15 @@ async fn remove_role_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -1145,11 +1145,11 @@ async fn remove_role_recursive_command() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -1165,7 +1165,7 @@ async fn remove_role_recursive_command() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -1191,7 +1191,7 @@ async fn remove_role_recursive_command() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "A",
             "-t",
@@ -1200,11 +1200,11 @@ async fn remove_role_recursive_command() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -1237,7 +1237,7 @@ async fn remove_role_recursive_command() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -1263,7 +1263,7 @@ async fn remove_role_recursive_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             "B",
             "-t",
@@ -1276,11 +1276,11 @@ async fn remove_role_recursive_command() {
 
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
@@ -1297,15 +1297,15 @@ async fn remove_role_recursive_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -1348,11 +1348,11 @@ async fn remove_role_recursive_command() {
 
     // update repo with new metadata
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let update_out = TempDir::new().unwrap();
 
@@ -1369,15 +1369,15 @@ async fn remove_role_recursive_command() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",
@@ -1419,18 +1419,18 @@ async fn dubious_role_name() {
     let repo_dir = TempDir::new().unwrap();
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
 
     // Create a repo using tuftool and the reference tuf implementation data
     create_repo(repo_dir.path());
 
     // Set new expiration date for the new role
-    let expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let expiration = Timestamp::now() + days(4);
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let meta_out = TempDir::new().unwrap();
 
@@ -1446,7 +1446,7 @@ async fn dubious_role_name() {
             "-k",
             targets_key.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -1472,7 +1472,7 @@ async fn dubious_role_name() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             dubious_role_name,
             "-t",
@@ -1481,11 +1481,11 @@ async fn dubious_role_name() {
             "2",
             "--sign-all",
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -1519,7 +1519,7 @@ async fn dubious_role_name() {
             "-k",
             targets_key1.to_str().unwrap(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "-v",
             "1",
         ])
@@ -1545,7 +1545,7 @@ async fn dubious_role_name() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "-e",
-            expiration.to_rfc3339().as_str(),
+            expiration.to_string().as_str(),
             "--delegated-role",
             funny_role_name,
             "-t",
@@ -1585,15 +1585,15 @@ async fn dubious_role_name() {
             "--metadata-url",
             updated_metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
             "--role",

--- a/tuftool/tests/test_utils.rs
+++ b/tuftool/tests/test_utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use assert_cmd::cargo_bin_cmd;
-use chrono::{TimeDelta, Utc};
+use jiff::{SignedDuration, Timestamp};
 use std::path::{Path, PathBuf};
 use tough::IntoVec;
 use url::Url;
@@ -33,19 +33,19 @@ where
 }
 
 #[allow(unused)]
-pub fn days(value: i64) -> TimeDelta {
-    TimeDelta::try_days(value).unwrap()
+pub fn days(value: i64) -> SignedDuration {
+    SignedDuration::from_hours(value * 24)
 }
 
 /// Creates a repository with expired timestamp metadata.
 #[allow(unused)]
 pub fn create_expired_repo<P: AsRef<Path>>(repo_dir: P) {
     // Expired time stamp
-    let timestamp_expiration = Utc::now().checked_add_signed(days(-1)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(-1);
     let timestamp_version: u64 = 31;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(2)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(2);
     let snapshot_version: u64 = 25;
-    let targets_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let targets_expiration = Timestamp::now() + days(3);
     let targets_version: u64 = 17;
     let targets_input_dir = test_data().join("tuf-reference-impl").join("targets");
     let root_json = test_data().join("simple-rsa").join("root.json");
@@ -64,15 +64,15 @@ pub fn create_expired_repo<P: AsRef<Path>>(repo_dir: P) {
             "--root",
             root_json.to_str().unwrap(),
             "--targets-expires",
-            targets_expiration.to_rfc3339().as_str(),
+            targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", targets_version).as_str(),
             "--snapshot-expires",
-            snapshot_expiration.to_rfc3339().as_str(),
+            snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", snapshot_version).as_str(),
             "--timestamp-expires",
-            timestamp_expiration.to_rfc3339().as_str(),
+            timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", timestamp_version).as_str(),
         ])

--- a/tuftool/tests/update_command.rs
+++ b/tuftool/tests/update_command.rs
@@ -6,18 +6,18 @@ mod test_utils;
 use crate::test_utils::days;
 use assert_cmd::assert::Assert;
 use assert_cmd::cargo_bin_cmd;
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use std::path::Path;
 use tempfile::TempDir;
 use test_utils::dir_url;
 use tough::{RepositoryLoader, TargetName};
 
 fn create_repo<P: AsRef<Path>>(repo_dir: P) {
-    let timestamp_expiration = Utc::now().checked_add_signed(days(1)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(1);
     let timestamp_version: u64 = 31;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(2)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(2);
     let snapshot_version: u64 = 25;
-    let targets_expiration = Utc::now().checked_add_signed(days(3)).unwrap();
+    let targets_expiration = Timestamp::now() + days(3);
     let targets_version: u64 = 17;
     let targets_input_dir = test_utils::test_data()
         .join("tuf-reference-impl")
@@ -38,15 +38,15 @@ fn create_repo<P: AsRef<Path>>(repo_dir: P) {
             "--root",
             root_json.to_str().unwrap(),
             "--targets-expires",
-            targets_expiration.to_rfc3339().as_str(),
+            targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", targets_version).as_str(),
             "--snapshot-expires",
-            snapshot_expiration.to_rfc3339().as_str(),
+            snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", snapshot_version).as_str(),
             "--timestamp-expires",
-            timestamp_expiration.to_rfc3339().as_str(),
+            timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", timestamp_version).as_str(),
         ])
@@ -65,11 +65,11 @@ async fn update_command_without_new_targets() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
     let update_out = TempDir::new().unwrap();
@@ -87,15 +87,15 @@ async fn update_command_without_new_targets() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -136,11 +136,11 @@ async fn update_command_with_new_targets() {
     create_repo(repo_dir.path());
 
     // Set new expiration dates and version numbers for the update command
-    let new_timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let new_timestamp_expiration = Timestamp::now() + days(4);
     let new_timestamp_version: u64 = 310;
-    let new_snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let new_snapshot_expiration = Timestamp::now() + days(5);
     let new_snapshot_version: u64 = 250;
-    let new_targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let new_targets_expiration = Timestamp::now() + days(6);
     let new_targets_version: u64 = 170;
     let new_targets_input_dir = test_utils::test_data().join("targets");
     let metadata_base_url = &dir_url(repo_dir.path().join("metadata"));
@@ -161,15 +161,15 @@ async fn update_command_with_new_targets() {
             "--metadata-url",
             metadata_base_url.as_str(),
             "--targets-expires",
-            new_targets_expiration.to_rfc3339().as_str(),
+            new_targets_expiration.to_string().as_str(),
             "--targets-version",
             format!("{}", new_targets_version).as_str(),
             "--snapshot-expires",
-            new_snapshot_expiration.to_rfc3339().as_str(),
+            new_snapshot_expiration.to_string().as_str(),
             "--snapshot-version",
             format!("{}", new_snapshot_version).as_str(),
             "--timestamp-expires",
-            new_timestamp_expiration.to_rfc3339().as_str(),
+            new_timestamp_expiration.to_string().as_str(),
             "--timestamp-version",
             format!("{}", new_timestamp_version).as_str(),
         ])
@@ -283,23 +283,15 @@ fn updates_expired_repo(
     outdir: &TempDir,
     repo_dir: &TempDir,
     allow_expired_repo: bool,
-) -> (
-    Assert,
-    DateTime<Utc>,
-    u64,
-    DateTime<Utc>,
-    u64,
-    DateTime<Utc>,
-    u64,
-) {
+) -> (Assert, Timestamp, u64, Timestamp, u64, Timestamp, u64) {
     let root_json = test_utils::test_data().join("simple-rsa").join("root.json");
     let root_key = test_utils::test_data().join("snakeoil.pem");
     // Set expiration dates and version numbers for the update command
-    let timestamp_expiration = Utc::now().checked_add_signed(days(4)).unwrap();
+    let timestamp_expiration = Timestamp::now() + days(4);
     let timestamp_version: u64 = 310;
-    let snapshot_expiration = Utc::now().checked_add_signed(days(5)).unwrap();
+    let snapshot_expiration = Timestamp::now() + days(5);
     let snapshot_version: u64 = 250;
-    let targets_expiration = Utc::now().checked_add_signed(days(6)).unwrap();
+    let targets_expiration = Timestamp::now() + days(6);
     let targets_version: u64 = 170;
     let metadata_base_url = &test_utils::dir_url(repo_dir.path().join("metadata"));
     let mut cmd = cargo_bin_cmd!("tuftool");
@@ -314,15 +306,15 @@ fn updates_expired_repo(
         "--metadata-url",
         metadata_base_url.as_str(),
         "--targets-expires",
-        targets_expiration.to_rfc3339().as_str(),
+        targets_expiration.to_string().as_str(),
         "--targets-version",
         format!("{}", targets_version).as_str(),
         "--snapshot-expires",
-        snapshot_expiration.to_rfc3339().as_str(),
+        snapshot_expiration.to_string().as_str(),
         "--snapshot-version",
         format!("{}", snapshot_version).as_str(),
         "--timestamp-expires",
-        timestamp_expiration.to_rfc3339().as_str(),
+        timestamp_expiration.to_string().as_str(),
         "--timestamp-version",
         format!("{}", timestamp_version).as_str(),
     ]);


### PR DESCRIPTION
*Issues*: #942 

*Description of changes:*
Due to chrono being soft deprecated, we need to migrate tough from chrono -> jiff. This PR performs this migration as a hard cutover. The commit is marked as breaking as it does cause API breakage for consumers who consume tough and still use chrono. Upon merge we should put a sticky issue calling this out.

*Testing done*

- [ ] Local twoliter that has also been migrated to jiff, building a variant and creating a tuf repo and publishing

Please comment with what more testing we should do here

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
