### PR TITLE
Add pkcs11 backend for keys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,3 +42,11 @@ jobs:
       - run: rustup component add rustfmt
       - run: rustup component add clippy
       - run: make ${{ matrix.make_target }}
+      - name: Install pkcs11-tool and SoftHSM (Linux only)
+        if: matrix.os == 'ubuntu-latest' && matrix.make_target == 'integ'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y opensc softhsm2
+      - name: Run PKCS11/SoftHSM integration target (Linux only)
+        if: matrix.os == 'ubuntu-latest' && matrix.make_target == 'integ'
+        run: make integ-pkcs11-softhsm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,12 +1053,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cryptoki"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff765b99fc49f3116c9a908484486a2b92fd73c48da45c3a69716471c6cc56c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cryptoki-sys",
+ "libloading",
+ "log",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fd850498411e4057f1cba79e6e2bc7cbe960544c1046ab46d4685c403a1121"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -1056,6 +1106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1093,6 +1144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1149,10 +1210,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "crypto-common",
+ "hybrid-array",
+ "rand_core 0.10.1",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1590,7 +1679,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2260,6 +2351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +2923,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct",
+ "ctutils",
+ "der",
+ "hybrid-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +3087,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3142,7 +3275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3262,9 +3395,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -3433,7 +3566,12 @@ dependencies = [
 name = "tough-pkcs11"
 version = "0.19.0"
 dependencies = [
+ "aws-lc-rs",
+ "cryptoki",
+ "p256",
  "snafu",
+ "tempfile",
+ "tokio",
  "tough",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,6 +3430,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tough-pkcs11"
+version = "0.19.0"
+dependencies = [
+ "snafu",
+ "tough",
+]
+
+[[package]]
 name = "tough-ssm"
 version = "0.19.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "tokio",
  "tough",
  "tough-kms",
+ "tough-pkcs11",
  "tough-ssm",
  "url",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3569,6 +3569,7 @@ dependencies = [
  "aws-lc-rs",
  "cryptoki",
  "p256",
+ "pem",
  "snafu",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pk11-uri-parser"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f14f8e63b84d5a0970a50afa1d1ec88e22eb0a76dc8460fc57acceb5ff9d2e"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +3580,9 @@ dependencies = [
  "cryptoki",
  "p256",
  "pem",
+ "percent-encoding",
+ "pk11-uri-parser",
+ "secrecy",
  "snafu",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "tough",
     "tough-ssm",
     "tough-kms",
+    "tough-pkcs11",
     "tuftool",
 ]

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ build:
 	cargo build --locked -p tough
 	cargo build --locked -p tough-ssm
 	cargo build --locked -p tough-kms
+	cargo build --locked -p tough-pkcs11
 	cargo build --locked -p tuftool
 	cargo test --locked
 
@@ -49,3 +50,6 @@ integ-fips: noxious
 	set +e
 	cargo test --manifest-path tough/Cargo.toml --features 'fips' --locked
 	cargo test --manifest-path tough/Cargo.toml --all-features --locked
+
+integ-pkcs11-softhsm:
+	cargo test --manifest-path tough-pkcs11/Cargo.toml --features test-softhsm

--- a/tough-pkcs11/CHANGELOG.md
+++ b/tough-pkcs11/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/tough-pkcs11/Cargo.toml
+++ b/tough-pkcs11/Cargo.toml
@@ -9,5 +9,12 @@ keywords = ["TUF", "PKCS11"]
 edition = "2018"
 
 [dependencies]
-tough = { version = "0.24", path = "../tough" }
+aws-lc-rs = "1"
+cryptoki = "0.12.0"
+p256 = { version = "0.14.0", default-features = false, features = ["ecdsa-core"] }
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
+tokio = { version = "1.53.0", features = ["rt"] }
+tough = { version = "0.24", path = "../tough" }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/tough-pkcs11/Cargo.toml
+++ b/tough-pkcs11/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tough-pkcs11"
+version = "0.19.0"
+description = "Implements PKCS11 as a key source for TUF signing keys"
+authors = []
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/awslabs/tough"
+keywords = ["TUF", "PKCS11"]
+edition = "2018"
+
+[dependencies]
+tough = { version = "0.24", path = "../tough" }
+snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }

--- a/tough-pkcs11/Cargo.toml
+++ b/tough-pkcs11/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 aws-lc-rs = "1"
 cryptoki = "0.12.0"
 p256 = { version = "0.14.0", default-features = false, features = ["ecdsa-core"] }
+pem = "3.0.6"
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 tokio = { version = "1.53.0", features = ["rt"] }
 tough = { version = "0.24", path = "../tough" }

--- a/tough-pkcs11/Cargo.toml
+++ b/tough-pkcs11/Cargo.toml
@@ -13,9 +13,12 @@ aws-lc-rs = "1"
 cryptoki = "0.12.0"
 p256 = { version = "0.14.0", default-features = false, features = ["ecdsa-core"] }
 pem = "3.0.6"
+percent-encoding = "2.3.2"
+pk11-uri-parser = "0.1.5"
 snafu = { version = "0.8", features = ["backtraces-impl-backtrace-crate"] }
 tokio = { version = "1.53.0", features = ["rt"] }
 tough = { version = "0.24", path = "../tough" }
 
 [dev-dependencies]
+secrecy = "0.10.3"
 tempfile = "3.27.0"

--- a/tough-pkcs11/Cargo.toml
+++ b/tough-pkcs11/Cargo.toml
@@ -11,7 +11,9 @@ edition = "2018"
 [dependencies]
 aws-lc-rs = "1"
 cryptoki = "0.12.0"
-p256 = { version = "0.14.0", default-features = false, features = ["ecdsa-core"] }
+p256 = { version = "0.14.0", default-features = false, features = [
+    "ecdsa-core",
+] }
 pem = "3.0.6"
 percent-encoding = "2.3.2"
 pk11-uri-parser = "0.1.5"
@@ -22,3 +24,7 @@ tough = { version = "0.24", path = "../tough" }
 [dev-dependencies]
 secrecy = "0.10.3"
 tempfile = "3.27.0"
+
+[features]
+# Enable softhsm integration tests
+test-softhsm = []

--- a/tough-pkcs11/LICENSE-APACHE
+++ b/tough-pkcs11/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tough-pkcs11/LICENSE-MIT
+++ b/tough-pkcs11/LICENSE-MIT
@@ -1,0 +1,8 @@
+MIT License
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including  without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to  the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN  NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tough-pkcs11/src/error.rs
+++ b/tough-pkcs11/src/error.rs
@@ -2,6 +2,8 @@ use aws_lc_rs::error::KeyRejected;
 use pk11_uri_parser::PK11URIError;
 use snafu::{Backtrace, Snafu};
 
+use crate::TokenId;
+
 /// Alias for `Result<T, Error>`.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -23,9 +25,8 @@ pub enum Error {
     #[snafu(display("failed to get key object"))]
     GetKey { source: cryptoki::error::Error },
 
-    // TODO: add token info
-    #[snafu(display("token not found"))]
-    TokenNotFound,
+    #[snafu(display("token not found (searched for {token_id:?})"))]
+    TokenNotFound { token_id: TokenId },
 
     #[snafu(display("key not found"))]
     KeyNotFound,
@@ -42,11 +43,11 @@ pub enum Error {
     #[snafu(display("failed to parse public key"))]
     ParsePubkey { source: KeyRejected },
 
-    #[snafu(display("token return unexpected response"))]
-    UnexpectedResponse,
+    #[snafu(display("token return unexpected response: {reason}"))]
+    UnexpectedResponse { reason: &'static str },
 
-    #[snafu(display("unsupported key type"))]
-    UnsupportedKeyType,
+    #[snafu(display("unsupported key type, got: {got}"))]
+    UnsupportedKeyType { got: String },
 
     #[snafu(display("failed to sign"))]
     SigningFailed { source: cryptoki::error::Error },

--- a/tough-pkcs11/src/error.rs
+++ b/tough-pkcs11/src/error.rs
@@ -1,4 +1,5 @@
 use aws_lc_rs::error::KeyRejected;
+use pk11_uri_parser::PK11URIError;
 use snafu::{Backtrace, Snafu};
 
 /// Alias for `Result<T, Error>`.
@@ -57,6 +58,31 @@ pub enum Error {
     JoinSpawnBlockingTask {
         source: tokio::task::JoinError,
         backtrace: Backtrace,
+    },
+}
+
+/// The error type for URI parsing.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub enum ParseUriError {
+    #[snafu(display("failed to parse URI: {source}"))]
+    Pk11UriError { source: PK11URIError },
+
+    #[snafu(display("failed to decode field {field:?}: {cause}"))]
+    DecodeField { cause: String, field: &'static str },
+
+    #[snafu(display("pkcs11 URI requires {what}"))]
+    Requires { what: &'static str },
+
+    #[snafu(display("pkcs11 URI requires one of {oneof}"))]
+    Conflict { oneof: &'static str },
+
+    #[snafu(display("failed to read PIN from {path}: {source}"))]
+    PinReadingFailed {
+        source: std::io::Error,
+        path: String,
     },
 }
 

--- a/tough-pkcs11/src/error.rs
+++ b/tough-pkcs11/src/error.rs
@@ -1,0 +1,67 @@
+use aws_lc_rs::error::KeyRejected;
+use snafu::{Backtrace, Snafu};
+
+/// Alias for `Result<T, Error>`.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The error type for this library.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub enum Error {
+    #[snafu(display("failed to load module"))]
+    LoadModule { source: cryptoki::error::Error },
+
+    #[snafu(display("failed to initialise module"))]
+    InitModule { source: cryptoki::error::Error },
+
+    #[snafu(display("failed to get slot infos"))]
+    GetSlotInfo { source: cryptoki::error::Error },
+
+    #[snafu(display("failed to get key object"))]
+    GetKey { source: cryptoki::error::Error },
+
+    // TODO: add token info
+    #[snafu(display("token not found"))]
+    TokenNotFound,
+
+    #[snafu(display("key not found"))]
+    KeyNotFound,
+
+    #[snafu(display("failed to open RO session"))]
+    OpenRoSession { source: cryptoki::error::Error },
+
+    #[snafu(display("login failed"))]
+    LoginFailed { source: cryptoki::error::Error },
+
+    #[snafu(display("failed to read public key"))]
+    GetPubkey { source: cryptoki::error::Error },
+
+    #[snafu(display("failed to parse public key"))]
+    ParsePubkey { source: KeyRejected },
+
+    #[snafu(display("token return unexpected response"))]
+    UnexpectedResponse,
+
+    #[snafu(display("unsupported key type"))]
+    UnsupportedKeyType,
+
+    #[snafu(display("failed to sign"))]
+    SigningFailed { source: cryptoki::error::Error },
+
+    #[snafu(display("returned signature is invalid"))]
+    InvalidSignature,
+
+    #[snafu(display("failed to join spawn_blocking task: {source}"))]
+    JoinSpawnBlockingTask {
+        source: tokio::task::JoinError,
+        backtrace: Backtrace,
+    },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub struct WritingUnsupportedError;

--- a/tough-pkcs11/src/lib.rs
+++ b/tough-pkcs11/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use tough::async_trait;
+use tough::key_source::KeySource;
+use tough::sign::Sign;
+
+/// Implements the KeySource trait for keys that live in AWS SSM.
+#[derive(Debug)]
+pub struct Pkcs11KeySource {}
+
+/// Implements the KeySource trait.
+#[async_trait]
+impl KeySource for Pkcs11KeySource {
+    async fn as_sign(
+        &self,
+    ) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
+        todo!()
+    }
+
+    async fn write(
+        &self,
+        _value: &str,
+        _key_id_hex: &str,
+    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        todo!()
+    }
+}

--- a/tough-pkcs11/src/lib.rs
+++ b/tough-pkcs11/src/lib.rs
@@ -1,14 +1,37 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 pub mod error;
 mod signer;
 
-use tough::async_trait;
+use aws_lc_rs::rand::SecureRandom;
+use snafu::ResultExt;
 use tough::key_source::KeySource;
 use tough::sign::Sign;
+use tough::{async_trait, schema::key::Key};
 
-pub use signer::{KeyId, Pkcs11KeySource, TokenId};
+pub use signer::{KeyId, Pkcs11Key, Pkcs11KeySource, TokenId};
+
+#[async_trait]
+impl Sign for Pkcs11Key {
+    fn tuf_key(&self) -> Key {
+        self.pub_key()
+    }
+
+    async fn sign(
+        &self,
+        msg: &[u8],
+        _rng: &(dyn SecureRandom + Sync),
+    ) -> core::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let this = self.clone();
+        let msg = msg.to_vec();
+        let signature = tokio::task::spawn_blocking(move || this.sign(&msg))
+            .await
+            .context(error::JoinSpawnBlockingTaskSnafu)??;
+
+        Ok(signature)
+    }
+}
 
 /// Implements the KeySource trait.
 #[async_trait]
@@ -17,7 +40,12 @@ impl KeySource for Pkcs11KeySource {
         &self,
     ) -> std::result::Result<Box<dyn Sign>, Box<dyn std::error::Error + Send + Sync + 'static>>
     {
-        todo!()
+        let this = self.clone();
+        let key = tokio::task::spawn_blocking(move || this.to_key())
+            .await
+            .context(error::JoinSpawnBlockingTaskSnafu)??;
+
+        Ok(Box::new(key))
     }
 
     async fn write(
@@ -25,6 +53,6 @@ impl KeySource for Pkcs11KeySource {
         _value: &str,
         _key_id_hex: &str,
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        todo!()
+        Err(error::WritingUnsupportedError.into())
     }
 }

--- a/tough-pkcs11/src/lib.rs
+++ b/tough-pkcs11/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod error;
 mod signer;
+pub mod uri;
 
 use aws_lc_rs::rand::SecureRandom;
 use snafu::ResultExt;

--- a/tough-pkcs11/src/lib.rs
+++ b/tough-pkcs11/src/lib.rs
@@ -1,13 +1,14 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub mod error;
+mod signer;
+
 use tough::async_trait;
 use tough::key_source::KeySource;
 use tough::sign::Sign;
 
-/// Implements the KeySource trait for keys that live in AWS SSM.
-#[derive(Debug)]
-pub struct Pkcs11KeySource {}
+pub use signer::{KeyId, Pkcs11KeySource, TokenId};
 
 /// Implements the KeySource trait.
 #[async_trait]

--- a/tough-pkcs11/src/signer.rs
+++ b/tough-pkcs11/src/signer.rs
@@ -5,6 +5,7 @@ mod ec;
 mod obj;
 mod rsa;
 
+mod debug;
 #[cfg(test)]
 mod tests;
 
@@ -106,7 +107,9 @@ fn find_slot(pkcs11: &Pkcs11, token_id: &TokenId) -> Result<Slot> {
             return Ok(slot);
         }
     }
-    Err(Error::TokenNotFound)
+    Err(Error::TokenNotFound {
+        token_id: token_id.to_owned(),
+    })
 }
 
 fn key_type(session: &Session, key: ObjectHandle) -> Result<KeyType> {
@@ -117,7 +120,9 @@ fn key_type(session: &Session, key: ObjectHandle) -> Result<KeyType> {
         .next()
     {
         Some(Attribute::KeyType(kt)) => Ok(kt),
-        _ => Err(Error::UnexpectedResponse),
+        _ => Err(Error::UnexpectedResponse {
+            reason: "failed to get key attributes ",
+        }),
     }
 }
 
@@ -126,8 +131,7 @@ fn export_public_key(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
         KeyType::EC => ec::export_pubkey(session, pubkey),
         KeyType::EC_EDWARDS => ec::export_pubkey(session, pubkey),
         KeyType::RSA => rsa::export_pubkey(session, pubkey),
-        // TODO: provide more info
-        _ => Err(Error::UnsupportedKeyType),
+        k => Err(Error::UnsupportedKeyType { got: k.to_string() }),
     }
 }
 
@@ -142,7 +146,9 @@ fn sign(session: &Session, pubkey: &Key, privkey: ObjectHandle, message: &[u8]) 
             scheme: RsaScheme::RsassaPssSha256,
             ..
         } => rsa::sign_pss_sha256(session, privkey, message),
-        _ => Err(Error::UnsupportedKeyType),
+        k => Err(Error::UnsupportedKeyType {
+            got: format!("{:?}", k),
+        }),
     }
 }
 

--- a/tough-pkcs11/src/signer.rs
+++ b/tough-pkcs11/src/signer.rs
@@ -27,7 +27,7 @@ use tough::schema::key::{EcdsaScheme, RsaScheme};
 
 use crate::error::{self, Error, Result};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenId {
     /// Match by `CKT_TOKEN_LABEL` - `token=` in the URI.
     Label(String),
@@ -37,7 +37,7 @@ pub enum TokenId {
     SlotId(u64),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyId {
     /// Match by `CKA_LABEL` - `object=` in the URI.
     Label(String),
@@ -48,10 +48,10 @@ pub enum KeyId {
 /// Implements the KeySource trait for keys that live in AWS SSM.
 #[derive(Debug, Clone)]
 pub struct Pkcs11KeySource {
-    module_path: PathBuf,
-    token: TokenId,
-    key: KeyId,
-    pin: Option<AuthPin>,
+    pub module_path: PathBuf,
+    pub token: TokenId,
+    pub key: KeyId,
+    pub pin: Option<AuthPin>,
 }
 
 fn key_source_to_pkcs11_key(source: &Pkcs11KeySource) -> Result<Pkcs11Key> {

--- a/tough-pkcs11/src/signer.rs
+++ b/tough-pkcs11/src/signer.rs
@@ -3,6 +3,7 @@
 
 mod ec;
 mod obj;
+mod rsa;
 
 #[cfg(test)]
 mod tests;
@@ -21,8 +22,8 @@ use cryptoki::{
     types::AuthPin,
 };
 use snafu::{ensure, ResultExt};
-use tough::schema::key::EcdsaScheme;
 use tough::schema::key::Key;
+use tough::schema::key::{EcdsaScheme, RsaScheme};
 
 use crate::error::{self, Error, Result};
 
@@ -124,6 +125,7 @@ fn export_public_key(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
     match key_type(session, pubkey)? {
         KeyType::EC => ec::export_pubkey(session, pubkey),
         KeyType::EC_EDWARDS => ec::export_pubkey(session, pubkey),
+        KeyType::RSA => rsa::export_pubkey(session, pubkey),
         // TODO: provide more info
         _ => Err(Error::UnsupportedKeyType),
     }
@@ -136,6 +138,10 @@ fn sign(session: &Session, pubkey: &Key, privkey: ObjectHandle, message: &[u8]) 
             ..
         } => ec::sign_p256(session, privkey, message),
         Key::Ed25519 { .. } => ec::sign_ed25519(session, privkey, message),
+        Key::Rsa {
+            scheme: RsaScheme::RsassaPssSha256,
+            ..
+        } => rsa::sign_pss_sha256(session, privkey, message),
         _ => Err(Error::UnsupportedKeyType),
     }
 }

--- a/tough-pkcs11/src/signer.rs
+++ b/tough-pkcs11/src/signer.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod ec;
+mod obj;
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use cryptoki::{
+    context::{CInitializeArgs, CInitializeFlags, Pkcs11},
+    error::RvError,
+    object::{Attribute, AttributeType, KeyType, ObjectHandle},
+    session::{Session, UserType},
+    slot::Slot,
+    types::AuthPin,
+};
+use snafu::{ensure, ResultExt};
+use tough::schema::key::EcdsaScheme;
+use tough::schema::key::Key;
+
+use crate::error::{self, Error, Result};
+
+#[derive(Debug, Clone)]
+pub enum TokenId {
+    /// Match by `CKT_TOKEN_LABEL` - `token=` in the URI.
+    Label(String),
+    /// Match by `CKT_TOKEN_SERIAL_NUMBER` - `serial=` in the URI.
+    Serial(String),
+    /// Use the slot directly - `slot-id=` in the URI.
+    SlotId(u64),
+}
+
+#[derive(Debug, Clone)]
+pub enum KeyId {
+    /// Match by `CKA_LABEL` - `object=` in the URI.
+    Label(String),
+    /// Match by `CKA_ID` (raw bytes) - `id=` (percent-encoded) in the URI.
+    Id(Vec<u8>),
+}
+
+/// Implements the KeySource trait for keys that live in AWS SSM.
+#[derive(Debug, Clone)]
+pub struct Pkcs11KeySource {
+    module_path: PathBuf,
+    token: TokenId,
+    key: KeyId,
+    pin: Option<AuthPin>,
+}
+
+fn key_source_to_pkcs11_key(source: &Pkcs11KeySource) -> Result<Pkcs11Key> {
+    let pkcs11 = Pkcs11::new(&source.module_path).context(error::LoadModuleSnafu)?;
+
+    match pkcs11.initialize(CInitializeArgs::new(CInitializeFlags::OS_LOCKING_OK)) {
+        Ok(()) => {}
+        // Another instance in the same process already initialized the
+        // library. This is harmless — we can reuse the existing state.
+        Err(cryptoki::error::Error::Pkcs11(RvError::CryptokiAlreadyInitialized, _)) => {}
+        Err(err) => return Err(Error::InitModule { source: err }),
+    }
+
+    let slot = find_slot(&pkcs11, &source.token)?;
+    let session = pkcs11
+        .open_ro_session(slot)
+        .context(error::OpenRoSessionSnafu)?;
+
+    session
+        .login(UserType::User, source.pin.as_ref())
+        .context(error::LoginFailedSnafu)?;
+
+    let (obj::Pub(pub_obj), obj::Priv(priv_obj)) = obj::get_pub_priv(&session, &source.key)?;
+
+    let pubkey = export_public_key(&session, pub_obj)?;
+
+    Ok(Pkcs11Key {
+        inner: Arc::new(Mutex::new(Pkcs11KeyInner {
+            pub_key: pubkey,
+            priv_obj,
+            session,
+        })),
+    })
+}
+
+fn find_slot(pkcs11: &Pkcs11, token_id: &TokenId) -> Result<Slot> {
+    let slots = pkcs11
+        .get_slots_with_initialized_token()
+        .context(error::GetSlotInfoSnafu)?;
+
+    for slot in slots {
+        let info = pkcs11
+            .get_token_info(slot)
+            .context(error::GetSlotInfoSnafu)?;
+
+        let matched = match token_id {
+            TokenId::Label(label) => info.label().trim() == label.trim(),
+            TokenId::Serial(serial) => info.serial_number().trim() == serial.trim(),
+            TokenId::SlotId(id) => slot.id() == *id,
+        };
+        if matched {
+            return Ok(slot);
+        }
+    }
+    Err(Error::TokenNotFound)
+}
+
+fn key_type(session: &Session, key: ObjectHandle) -> Result<KeyType> {
+    match session
+        .get_attributes(key, &[AttributeType::KeyType])
+        .context(error::GetPubkeySnafu)?
+        .into_iter()
+        .next()
+    {
+        Some(Attribute::KeyType(kt)) => Ok(kt),
+        _ => Err(Error::UnexpectedResponse),
+    }
+}
+
+fn export_public_key(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
+    match key_type(session, pubkey)? {
+        KeyType::EC => ec::export_pubkey(session, pubkey),
+        // TODO: provide more info
+        _ => Err(Error::UnsupportedKeyType),
+    }
+}
+
+fn sign(session: &Session, pubkey: &Key, privkey: ObjectHandle, message: &[u8]) -> Result<Vec<u8>> {
+    match pubkey {
+        Key::Ecdsa {
+            scheme: EcdsaScheme::EcdsaSha2Nistp256,
+            ..
+        } => ec::sign_p256(session, privkey, message),
+        _ => Err(Error::UnsupportedKeyType),
+    }
+}
+
+impl Pkcs11KeySource {
+    /// Load and initialize pkcs11 module, find the key objects,
+    /// export the public key and prepare for signing.
+    pub fn to_key(&self) -> Result<Pkcs11Key> {
+        key_source_to_pkcs11_key(self)
+    }
+}
+
+struct Pkcs11KeyInner {
+    pub_key: Key,
+    priv_obj: ObjectHandle,
+    session: Session,
+}
+
+#[derive(Clone)]
+pub struct Pkcs11Key {
+    inner: Arc<Mutex<Pkcs11KeyInner>>,
+}
+
+impl Pkcs11Key {
+    /// Get public key of the object.
+    pub fn pub_key(&self) -> Key {
+        self.inner.lock().expect("mutex poisoned").pub_key.clone()
+    }
+
+    /// Sign a message with PKCS11 key.
+    pub fn sign(&self, msg: &[u8]) -> Result<Vec<u8>> {
+        let state = self.inner.lock().expect("mutex poisoned");
+        let sig = sign(&state.session, &state.pub_key, state.priv_obj, msg)?;
+        ensure!(
+            state.pub_key.verify(msg, &sig),
+            error::InvalidSignatureSnafu
+        );
+        Ok(sig)
+    }
+}

--- a/tough-pkcs11/src/signer.rs
+++ b/tough-pkcs11/src/signer.rs
@@ -123,6 +123,7 @@ fn key_type(session: &Session, key: ObjectHandle) -> Result<KeyType> {
 fn export_public_key(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
     match key_type(session, pubkey)? {
         KeyType::EC => ec::export_pubkey(session, pubkey),
+        KeyType::EC_EDWARDS => ec::export_pubkey(session, pubkey),
         // TODO: provide more info
         _ => Err(Error::UnsupportedKeyType),
     }
@@ -134,6 +135,7 @@ fn sign(session: &Session, pubkey: &Key, privkey: ObjectHandle, message: &[u8]) 
             scheme: EcdsaScheme::EcdsaSha2Nistp256,
             ..
         } => ec::sign_p256(session, privkey, message),
+        Key::Ed25519 { .. } => ec::sign_ed25519(session, privkey, message),
         _ => Err(Error::UnsupportedKeyType),
     }
 }

--- a/tough-pkcs11/src/signer/debug.rs
+++ b/tough-pkcs11/src/signer/debug.rs
@@ -1,0 +1,30 @@
+use std::fmt::Write;
+
+pub fn oid_to_string(oid: &[u8]) -> String {
+    if oid.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::new();
+
+    // First byte encodes the first two arcs: value = arc1 * 40 + arc2
+    let first = oid[0] as u32;
+    let arc1 = first / 40;
+    let arc2 = first % 40;
+    let _ = write!(result, "{arc1}.{arc2}");
+
+    // Remaining arcs are base-128 encoded, 7 bits per byte,
+    // high bit set means "more bytes follow".
+    let mut value: u64 = 0;
+    for &byte in &oid[1..] {
+        value = (value << 7) | (byte & 0x7F) as u64;
+        if byte & 0x80 == 0 {
+            // end of this arc's encoding
+            result.push('.');
+            result.push_str(&value.to_string());
+            value = 0;
+        }
+    }
+
+    result
+}

--- a/tough-pkcs11/src/signer/ec.rs
+++ b/tough-pkcs11/src/signer/ec.rs
@@ -8,16 +8,59 @@ use aws_lc_rs::{
     signature::{self, UnparsedPublicKey},
 };
 use cryptoki::{
-    mechanism::Mechanism,
+    mechanism::{
+        eddsa::{EddsaParams, EddsaSignatureScheme},
+        Mechanism,
+    },
     object::{Attribute, AttributeType, ObjectHandle},
     session::Session,
 };
-use snafu::{ensure, OptionExt, ResultExt};
-use tough::schema::key::EcdsaKey;
-use tough::schema::key::EcdsaScheme;
+use snafu::{OptionExt, ResultExt};
 use tough::schema::key::Key;
+use tough::schema::key::{EcdsaKey, Ed25519Key};
+use tough::schema::key::{EcdsaScheme, Ed25519Scheme};
 
 use crate::error::{self, Result};
+
+const P256_OID_DER: [u8; 10] = [0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+const ED25519_OID_DER: [u8; 5] = [0x06, 0x03, 0x2B, 0x65, 0x70];
+// Some tokens (e.g. SoftHSM builds) label the curve with the DER
+// printable string "edwards25519" rather than the id-Ed25519 OID.
+const ED25519_PARAMS_STR: [u8; 14] = [
+    0x13, 0x0C, b'e', b'd', b'w', b'a', b'r', b'd', b's', b'2', b'5', b'5', b'1', b'9',
+];
+
+fn export_p256(point: &[u8]) -> Result<Key> {
+    let sec1 = unwrap_p256_der1_to_sec1(point).context(error::UnexpectedResponseSnafu)?;
+
+    let parsed = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, sec1)
+        .parse()
+        .context(error::ParsePubkeySnafu)?;
+
+    Ok(Key::Ecdsa {
+        keyval: EcdsaKey {
+            public: parsed.as_ref().to_vec().into(),
+            _extra: HashMap::new(),
+        },
+        scheme: EcdsaScheme::EcdsaSha2Nistp256,
+        _extra: HashMap::new(),
+    })
+}
+
+fn export_ed25519(point: &[u8]) -> Result<Key> {
+    // TUF/tough stores the bare 32-byte Ed25519 public key (hex-encoded), so
+    // there's no SEC1/DER re-encoding to do like there is for P-256.
+    let raw = unwrap_ed25519_der_to_raw(point).context(error::UnexpectedResponseSnafu)?;
+
+    Ok(Key::Ed25519 {
+        keyval: Ed25519Key {
+            public: raw.to_vec().into(),
+            _extra: HashMap::new(),
+        },
+        scheme: Ed25519Scheme::Ed25519,
+        _extra: HashMap::new(),
+    })
+}
 
 pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
     let attrs = session
@@ -33,27 +76,17 @@ pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
         }
     }
 
-    const P256_OID_DER: [u8; 10] = [0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
-
     // TODO: add more info to the error
     let ec_params = params.context(error::UnexpectedResponseSnafu)?;
     let point = point.context(error::UnexpectedResponseSnafu)?;
 
-    ensure!(ec_params == P256_OID_DER, error::UnsupportedKeyTypeSnafu);
-    let sec1 = unwrap_p256_der1_to_sec1(&point).context(error::UnexpectedResponseSnafu)?;
-
-    let parsed = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, sec1)
-        .parse()
-        .context(error::ParsePubkeySnafu)?;
-
-    Ok(Key::Ecdsa {
-        keyval: EcdsaKey {
-            public: parsed.as_ref().to_vec().into(),
-            _extra: HashMap::new(),
-        },
-        scheme: EcdsaScheme::EcdsaSha2Nistp256,
-        _extra: HashMap::new(),
-    })
+    if ec_params == P256_OID_DER {
+        export_p256(&point)
+    } else if ec_params == ED25519_OID_DER || ec_params == ED25519_PARAMS_STR {
+        export_ed25519(&point)
+    } else {
+        Err(error::Error::UnsupportedKeyType)
+    }
 }
 
 pub fn sign_p256(session: &Session, privkey: ObjectHandle, message: &[u8]) -> Result<Vec<u8>> {
@@ -70,12 +103,38 @@ pub fn sign_p256(session: &Session, privkey: ObjectHandle, message: &[u8]) -> Re
     Ok(signature.to_der().as_bytes().to_vec())
 }
 
+pub fn sign_ed25519(session: &Session, privkey: ObjectHandle, message: &[u8]) -> Result<Vec<u8>> {
+    // Ed25519 hashes the message internally, so no need to do it here.
+    //
+    // PKCS#11 returns the 64-byte raw signature (r || s), which is exactly the
+    // encoding TUF/tough expects for ed25519.
+    let signature = session
+        .sign(
+            &Mechanism::Eddsa(EddsaParams::new(EddsaSignatureScheme::Ed25519)),
+            privkey,
+            message,
+        )
+        .context(error::SigningFailedSnafu)?;
+
+    Ok(signature)
+}
+
 fn unwrap_p256_der1_to_sec1(raw: &[u8]) -> Option<&[u8]> {
     match raw {
         // DER OCTET STRING wrapped
         [0x04, 0x41, rest @ ..] if rest.len() == 65 => Some(rest),
         // already bare SEC1
         [0x04, ..] if raw.len() == 65 => Some(raw),
+        _ => None,
+    }
+}
+
+fn unwrap_ed25519_der_to_raw(raw: &[u8]) -> Option<&[u8]> {
+    match raw {
+        // DER OCTET STRING wrapped: 0x04 (OCTET STRING) 0x20 (len = 32) || key
+        [0x04, 0x20, rest @ ..] if rest.len() == 32 => Some(rest),
+        // already the bare 32-byte public key
+        _ if raw.len() == 32 => Some(raw),
         _ => None,
     }
 }

--- a/tough-pkcs11/src/signer/ec.rs
+++ b/tough-pkcs11/src/signer/ec.rs
@@ -31,7 +31,9 @@ const ED25519_PARAMS_STR: [u8; 14] = [
 ];
 
 fn export_p256(point: &[u8]) -> Result<Key> {
-    let sec1 = unwrap_p256_der1_to_sec1(point).context(error::UnexpectedResponseSnafu)?;
+    let sec1 = unwrap_p256_der1_to_sec1(point).context(error::UnexpectedResponseSnafu {
+        reason: "failed to parse P256 point",
+    })?;
 
     let parsed = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, sec1)
         .parse()
@@ -50,7 +52,9 @@ fn export_p256(point: &[u8]) -> Result<Key> {
 fn export_ed25519(point: &[u8]) -> Result<Key> {
     // TUF/tough stores the bare 32-byte Ed25519 public key (hex-encoded), so
     // there's no SEC1/DER re-encoding to do like there is for P-256.
-    let raw = unwrap_ed25519_der_to_raw(point).context(error::UnexpectedResponseSnafu)?;
+    let raw = unwrap_ed25519_der_to_raw(point).context(error::UnexpectedResponseSnafu {
+        reason: "failed to parse ed25519 point",
+    })?;
 
     Ok(Key::Ed25519 {
         keyval: Ed25519Key {
@@ -76,16 +80,21 @@ pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
         }
     }
 
-    // TODO: add more info to the error
-    let ec_params = params.context(error::UnexpectedResponseSnafu)?;
-    let point = point.context(error::UnexpectedResponseSnafu)?;
+    let ec_params = params.context(error::UnexpectedResponseSnafu {
+        reason: "failed to get EC params",
+    })?;
+    let point = point.context(error::UnexpectedResponseSnafu {
+        reason: "failed to get EC point",
+    })?;
 
     if ec_params == P256_OID_DER {
         export_p256(&point)
     } else if ec_params == ED25519_OID_DER || ec_params == ED25519_PARAMS_STR {
         export_ed25519(&point)
     } else {
-        Err(error::Error::UnsupportedKeyType)
+        Err(error::Error::UnsupportedKeyType {
+            got: format!("EC params {}", super::debug::oid_to_string(&ec_params)),
+        })
     }
 }
 

--- a/tough-pkcs11/src/signer/ec.rs
+++ b/tough-pkcs11/src/signer/ec.rs
@@ -1,0 +1,81 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+
+use aws_lc_rs::{
+    digest::{digest, SHA256},
+    signature::{self, UnparsedPublicKey},
+};
+use cryptoki::{
+    mechanism::Mechanism,
+    object::{Attribute, AttributeType, ObjectHandle},
+    session::Session,
+};
+use snafu::{ensure, OptionExt, ResultExt};
+use tough::schema::key::EcdsaKey;
+use tough::schema::key::EcdsaScheme;
+use tough::schema::key::Key;
+
+use crate::error::{self, Result};
+
+pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
+    let attrs = session
+        .get_attributes(pubkey, &[AttributeType::EcParams, AttributeType::EcPoint])
+        .context(error::GetPubkeySnafu)?;
+
+    let (mut params, mut point) = (None, None);
+    for a in attrs {
+        match a {
+            Attribute::EcParams(v) => params = Some(v),
+            Attribute::EcPoint(v) => point = Some(v),
+            _ => {}
+        }
+    }
+
+    const P256_OID_DER: [u8; 10] = [0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07];
+
+    // TODO: add more info to the error
+    let ec_params = params.context(error::UnexpectedResponseSnafu)?;
+    let point = point.context(error::UnexpectedResponseSnafu)?;
+
+    ensure!(ec_params == P256_OID_DER, error::UnsupportedKeyTypeSnafu);
+    let sec1 = unwrap_p256_der1_to_sec1(&point).context(error::UnexpectedResponseSnafu)?;
+
+    let parsed = UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_ASN1, sec1)
+        .parse()
+        .context(error::ParsePubkeySnafu)?;
+
+    Ok(Key::Ecdsa {
+        keyval: EcdsaKey {
+            public: parsed.as_ref().to_vec().into(),
+            _extra: HashMap::new(),
+        },
+        scheme: EcdsaScheme::EcdsaSha2Nistp256,
+        _extra: HashMap::new(),
+    })
+}
+
+pub fn sign_p256(session: &Session, privkey: ObjectHandle, message: &[u8]) -> Result<Vec<u8>> {
+    let hash = digest(&SHA256, message);
+    let raw_sig = session
+        .sign(&Mechanism::Ecdsa, privkey, hash.as_ref())
+        .context(error::SigningFailedSnafu)?;
+
+    // PKCS11 returns "2nLen" signature, or in other words "r || s" values,
+    // which we need to convert to DER format
+    let signature =
+        p256::ecdsa::Signature::from_slice(&raw_sig).map_err(|_| error::Error::InvalidSignature)?;
+
+    Ok(signature.to_der().as_bytes().to_vec())
+}
+
+fn unwrap_p256_der1_to_sec1(raw: &[u8]) -> Option<&[u8]> {
+    match raw {
+        // DER OCTET STRING wrapped
+        [0x04, 0x41, rest @ ..] if rest.len() == 65 => Some(rest),
+        // already bare SEC1
+        [0x04, ..] if raw.len() == 65 => Some(raw),
+        _ => None,
+    }
+}

--- a/tough-pkcs11/src/signer/obj.rs
+++ b/tough-pkcs11/src/signer/obj.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use cryptoki::{
+    object::{Attribute, ObjectClass, ObjectHandle},
+    session::Session,
+};
+use snafu::{OptionExt, ResultExt};
+
+use crate::{
+    error::{self, Result},
+    signer::KeyId,
+};
+
+fn key_search_template(class: ObjectClass, key: &KeyId) -> [Attribute; 2] {
+    let key_attr = match key {
+        KeyId::Label(label) => Attribute::Label(label.as_bytes().to_vec()),
+        KeyId::Id(id) => Attribute::Id(id.clone()),
+    };
+    [Attribute::Class(class), key_attr]
+}
+
+fn find_objects(
+    session: &Session,
+    class: ObjectClass,
+    key: &KeyId,
+) -> core::result::Result<Vec<ObjectHandle>, cryptoki::error::Error> {
+    session.find_objects(&key_search_template(class, key))
+}
+
+pub struct Pub(pub ObjectHandle);
+pub struct Priv(pub ObjectHandle);
+
+pub fn get_pub_priv(session: &Session, key: &KeyId) -> Result<(Pub, Priv)> {
+    let pub_objects =
+        find_objects(session, ObjectClass::PUBLIC_KEY, key).context(error::GetKeySnafu)?;
+
+    let priv_objects =
+        find_objects(session, ObjectClass::PRIVATE_KEY, key).context(error::GetKeySnafu)?;
+
+    let pub_obj = pub_objects
+        .into_iter()
+        .next()
+        .context(error::KeyNotFoundSnafu)?;
+    let priv_obj = priv_objects
+        .into_iter()
+        .next()
+        .context(error::KeyNotFoundSnafu)?;
+
+    Ok((Pub(pub_obj), Priv(priv_obj)))
+}

--- a/tough-pkcs11/src/signer/rsa.rs
+++ b/tough-pkcs11/src/signer/rsa.rs
@@ -39,9 +39,12 @@ pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
         }
     }
 
-    // TODO: add more info to the error
-    let modulus = modulus.context(error::UnexpectedResponseSnafu)?;
-    let exponent = exponent.context(error::UnexpectedResponseSnafu)?;
+    let modulus = modulus.context(error::UnexpectedResponseSnafu {
+        reason: "failed to get modulus",
+    })?;
+    let exponent = exponent.context(error::UnexpectedResponseSnafu {
+        reason: "failed to get exponent",
+    })?;
 
     let rsa = PublicKeyComponents {
         n: modulus,
@@ -50,7 +53,9 @@ pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
     .to_parsed_public_key(&RSA_PSS_2048_8192_SHA256)
     .context(error::ParsePubkeySnafu)?;
 
-    let der = rsa.as_der().ok().context(error::UnexpectedResponseSnafu)?;
+    let der = rsa.as_der().ok().context(error::UnexpectedResponseSnafu {
+        reason: "failed to serialise RSA public key to DER",
+    })?;
 
     let key = pem::encode_config(
         &pem::Pem::new("PUBLIC KEY".to_owned(), der.as_ref()),
@@ -59,7 +64,9 @@ pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
 
     Ok(Key::Rsa {
         keyval: RsaKey {
-            public: key.parse().ok().context(error::UnexpectedResponseSnafu)?,
+            public: key.parse().ok().context(error::UnexpectedResponseSnafu {
+                reason: "failed to parse RSA pubkey",
+            })?,
             _extra: HashMap::new(),
         },
         scheme: RsaScheme::RsassaPssSha256,

--- a/tough-pkcs11/src/signer/rsa.rs
+++ b/tough-pkcs11/src/signer/rsa.rs
@@ -1,0 +1,90 @@
+// Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashMap;
+
+use aws_lc_rs::{
+    digest::{digest, SHA256},
+    encoding::AsDer,
+    rsa::PublicKeyComponents,
+    signature::RSA_PSS_2048_8192_SHA256,
+};
+use cryptoki::{
+    mechanism::{
+        rsa::{PkcsMgfType, PkcsPssParams},
+        Mechanism, MechanismType,
+    },
+    object::{Attribute, AttributeType, ObjectHandle},
+    session::Session,
+};
+use snafu::{OptionExt, ResultExt};
+use tough::schema::key::{Key, RsaKey, RsaScheme};
+
+use crate::error::{self, Result};
+
+pub fn export_pubkey(session: &Session, pubkey: ObjectHandle) -> Result<Key> {
+    let attrs = session
+        .get_attributes(
+            pubkey,
+            &[AttributeType::Modulus, AttributeType::PublicExponent],
+        )
+        .context(error::GetPubkeySnafu)?;
+
+    let (mut modulus, mut exponent) = (None, None);
+    for a in attrs {
+        match a {
+            Attribute::Modulus(v) => modulus = Some(v),
+            Attribute::PublicExponent(v) => exponent = Some(v),
+            _ => {}
+        }
+    }
+
+    // TODO: add more info to the error
+    let modulus = modulus.context(error::UnexpectedResponseSnafu)?;
+    let exponent = exponent.context(error::UnexpectedResponseSnafu)?;
+
+    let rsa = PublicKeyComponents {
+        n: modulus,
+        e: exponent,
+    }
+    .to_parsed_public_key(&RSA_PSS_2048_8192_SHA256)
+    .context(error::ParsePubkeySnafu)?;
+
+    let der = rsa.as_der().ok().context(error::UnexpectedResponseSnafu)?;
+
+    let key = pem::encode_config(
+        &pem::Pem::new("PUBLIC KEY".to_owned(), der.as_ref()),
+        pem::EncodeConfig::new().set_line_ending(pem::LineEnding::LF),
+    );
+
+    Ok(Key::Rsa {
+        keyval: RsaKey {
+            public: key.parse().ok().context(error::UnexpectedResponseSnafu)?,
+            _extra: HashMap::new(),
+        },
+        scheme: RsaScheme::RsassaPssSha256,
+        _extra: HashMap::new(),
+    })
+}
+
+pub fn sign_pss_sha256(
+    session: &Session,
+    privkey: ObjectHandle,
+    message: &[u8],
+) -> Result<Vec<u8>> {
+    let hash = digest(&SHA256, message);
+
+    let params = PkcsPssParams {
+        hash_alg: MechanismType::SHA256,
+        mgf: PkcsMgfType::MGF1_SHA256,
+        // Salt length must be equal the digest length
+        s_len: 32.into(),
+    };
+
+    let signature = session
+        .sign(&Mechanism::RsaPkcsPss(params), privkey, hash.as_ref())
+        .context(error::SigningFailedSnafu)?;
+
+    // RSASSA-PSS signatures are already the raw big-endian octet strings
+    Ok(signature)
+}

--- a/tough-pkcs11/src/signer/tests.rs
+++ b/tough-pkcs11/src/signer/tests.rs
@@ -1,0 +1,179 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard},
+};
+
+use tempfile::TempDir;
+use tough::schema::key::{EcdsaScheme, Key};
+
+use crate::signer::{KeyId, TokenId};
+
+const TEST_PIN: &str = "12345678";
+const TEST_SO_PIN: &str = "00000000";
+const TEST_TOKEN_LABEL: &str = "test-token";
+const TEST_KEY_LABEL: &str = "test-key";
+
+struct SoftHsmEnv {
+    _dir: TempDir,
+    module: PathBuf,
+    conf_path: PathBuf,
+    // Should be last to release the test lock only after all clenaup
+    _guard: MutexGuard<'static, ()>,
+}
+
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+impl SoftHsmEnv {
+    fn setup() -> Self {
+        let guard = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+
+        let module = find_softhsm2_lib();
+
+        let dir = TempDir::new().expect("tempdir");
+        let tokens_dir = dir.path().join("tokens");
+        std::fs::create_dir(&tokens_dir).expect("create tokens dir");
+
+        let conf_path = dir.path().join("softhsm2.conf");
+        std::fs::write(
+            &conf_path,
+            format!("directories.tokendir = {}\n", tokens_dir.display()),
+        )
+        .expect("write softhsm2.conf");
+
+        // Safety: TEST_MUTEX is held by the caller for the duration of this
+        // test, so no other thread reads SOFTHSM2_CONF concurrently.
+        unsafe { std::env::set_var("SOFTHSM2_CONF", &conf_path) };
+
+        Self {
+            _dir: dir,
+            conf_path,
+            module,
+            _guard: guard,
+        }
+    }
+
+    fn key_source(&self, token: TokenId, key: KeyId) -> super::Pkcs11KeySource {
+        super::Pkcs11KeySource {
+            module_path: self.module.clone(),
+            token,
+            key,
+            pin: Some(TEST_PIN.into()),
+        }
+    }
+
+    fn init_token(&self, label: &str) {
+        let status = std::process::Command::new("softhsm2-util")
+            .args([
+                "--init-token",
+                "--free",
+                "--so-pin",
+                TEST_SO_PIN,
+                "--pin",
+                TEST_PIN,
+                "--label",
+                label,
+            ])
+            .env("SOFTHSM2_CONF", &self.conf_path)
+            .status()
+            .expect("softhsm2-util failed");
+
+        assert!(status.success(), "softhsm2-util --init-token failed");
+    }
+
+    fn pksc11_tool(&self, token_label: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new("pkcs11-tool");
+        cmd.arg("--module")
+            .arg(&self.module)
+            .arg("--token-label")
+            .arg(token_label)
+            .arg("--login")
+            .arg("--pin")
+            .arg(TEST_PIN)
+            .env("SOFTHSM2_CONF", &self.conf_path);
+
+        cmd
+    }
+
+    fn generate_ecdsa_key(&self, token_label: &str, id: &str, label: &str) {
+        let status = self
+            .pksc11_tool(token_label)
+            .arg("--keypairgen")
+            .arg("--key-type=EC:prime256v1")
+            .arg("--id")
+            .arg(id)
+            .arg("--label")
+            .arg(label)
+            .status()
+            .expect("pkcs11-tool failed");
+
+        assert!(status.success(), "pkcs11-tool failed");
+    }
+}
+
+fn find_softhsm2_lib() -> PathBuf {
+    if let Some(path) = std::env::var_os("SOFTHSM2_SO_PATH") {
+        let path = PathBuf::from(path);
+        assert!(path.exists(), "SOFTHSM2_SO_PATH doesn't exist ({:?})", path);
+        return path;
+    }
+
+    let candidates = [
+        "/usr/lib/softhsm/libsofthsm2.so",
+        "/usr/local/lib/softhsm/libsofthsm2.so",
+        "/opt/homebrew/lib/softhsm/libsofthsm2.so",
+        "/opt/homebrew/opt/softhsm/lib/softhsm/libsofthsm2.so",
+        "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
+        "/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so",
+    ];
+    candidates
+        .iter()
+        .map(Path::new)
+        .find(|p| p.exists())
+        .map(PathBuf::from)
+        .expect("libsofthsm2.so not found; install SoftHSM2 or disable the softhsm-tests feature")
+}
+
+#[test]
+fn test_match_key_by_id() {
+    let env = SoftHsmEnv::setup();
+    env.init_token(TEST_TOKEN_LABEL);
+    env.generate_ecdsa_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL);
+
+    let source = env.key_source(
+        TokenId::Label(TEST_TOKEN_LABEL.into()),
+        KeyId::Id(vec![0x01]),
+    );
+
+    let key = source.to_key().unwrap();
+    let Key::Ecdsa {
+        scheme: EcdsaScheme::EcdsaSha2Nistp256,
+        ..
+    } = key.pub_key()
+    else {
+        panic!("key is not ecdsa");
+    };
+}
+
+#[test]
+fn test_sign_ecdsa_p256() {
+    let env = SoftHsmEnv::setup();
+    env.init_token(TEST_TOKEN_LABEL);
+    env.generate_ecdsa_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL);
+
+    let source = env.key_source(
+        TokenId::Label(TEST_TOKEN_LABEL.into()),
+        KeyId::Label(TEST_KEY_LABEL.into()),
+    );
+
+    let key = source.to_key().unwrap();
+    let Key::Ecdsa {
+        scheme: EcdsaScheme::EcdsaSha2Nistp256,
+        ..
+    } = key.pub_key()
+    else {
+        panic!("key is not ecdsa");
+    };
+
+    let signature = key.sign(b"test_message").unwrap();
+    key.pub_key().verify(b"test_message", &signature);
+}

--- a/tough-pkcs11/src/signer/tests.rs
+++ b/tough-pkcs11/src/signer/tests.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-softhsm")]
+
 use std::{
     path::{Path, PathBuf},
     sync::{Mutex, MutexGuard},

--- a/tough-pkcs11/src/signer/tests.rs
+++ b/tough-pkcs11/src/signer/tests.rs
@@ -198,3 +198,23 @@ fn test_sign_ed25519() {
     let signature = key.sign(b"test_message").unwrap();
     key.pub_key().verify(b"test_message", &signature);
 }
+
+#[test]
+fn test_sign_rsa() {
+    let env = SoftHsmEnv::setup();
+    env.init_token(TEST_TOKEN_LABEL);
+    env.generate_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL, "RSA:2048");
+
+    let source = env.key_source(
+        TokenId::Label(TEST_TOKEN_LABEL.into()),
+        KeyId::Label(TEST_KEY_LABEL.into()),
+    );
+
+    let key = source.to_key().unwrap();
+    let Key::Rsa { .. } = key.pub_key() else {
+        panic!("key is not rsa");
+    };
+
+    let signature = key.sign(b"test_message").unwrap();
+    key.pub_key().verify(b"test_message", &signature);
+}

--- a/tough-pkcs11/src/signer/tests.rs
+++ b/tough-pkcs11/src/signer/tests.rs
@@ -94,11 +94,12 @@ impl SoftHsmEnv {
         cmd
     }
 
-    fn generate_ecdsa_key(&self, token_label: &str, id: &str, label: &str) {
+    fn generate_key(&self, token_label: &str, id: &str, label: &str, key_type: &str) {
         let status = self
             .pksc11_tool(token_label)
             .arg("--keypairgen")
-            .arg("--key-type=EC:prime256v1")
+            .arg("--key-type")
+            .arg(key_type)
             .arg("--id")
             .arg(id)
             .arg("--label")
@@ -137,7 +138,7 @@ fn find_softhsm2_lib() -> PathBuf {
 fn test_match_key_by_id() {
     let env = SoftHsmEnv::setup();
     env.init_token(TEST_TOKEN_LABEL);
-    env.generate_ecdsa_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL);
+    env.generate_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL, "EC:prime256v1");
 
     let source = env.key_source(
         TokenId::Label(TEST_TOKEN_LABEL.into()),
@@ -158,7 +159,7 @@ fn test_match_key_by_id() {
 fn test_sign_ecdsa_p256() {
     let env = SoftHsmEnv::setup();
     env.init_token(TEST_TOKEN_LABEL);
-    env.generate_ecdsa_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL);
+    env.generate_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL, "EC:prime256v1");
 
     let source = env.key_source(
         TokenId::Label(TEST_TOKEN_LABEL.into()),
@@ -172,6 +173,26 @@ fn test_sign_ecdsa_p256() {
     } = key.pub_key()
     else {
         panic!("key is not ecdsa");
+    };
+
+    let signature = key.sign(b"test_message").unwrap();
+    key.pub_key().verify(b"test_message", &signature);
+}
+
+#[test]
+fn test_sign_ed25519() {
+    let env = SoftHsmEnv::setup();
+    env.init_token(TEST_TOKEN_LABEL);
+    env.generate_key(TEST_TOKEN_LABEL, "01", TEST_KEY_LABEL, "EC:edwards25519");
+
+    let source = env.key_source(
+        TokenId::Label(TEST_TOKEN_LABEL.into()),
+        KeyId::Label(TEST_KEY_LABEL.into()),
+    );
+
+    let key = source.to_key().unwrap();
+    let Key::Ed25519 { .. } = key.pub_key() else {
+        panic!("key is not ed25519");
     };
 
     let signature = key.sign(b"test_message").unwrap();

--- a/tough-pkcs11/src/uri.rs
+++ b/tough-pkcs11/src/uri.rs
@@ -1,0 +1,227 @@
+use std::{borrow::Cow, path::PathBuf};
+
+use cryptoki::types::AuthPin;
+use snafu::{OptionExt, ResultExt};
+
+use crate::{error, KeyId, Pkcs11KeySource, TokenId};
+
+type Result<T> = core::result::Result<T, error::ParseUriError>;
+
+trait PercentDecode<'a> {
+    fn percent_decode(self, field: &'static str) -> Result<Cow<'a, str>>;
+}
+
+impl<'a> PercentDecode<'a> for &'a str {
+    fn percent_decode(self, field: &'static str) -> Result<Cow<'a, str>> {
+        percent_encoding::percent_decode_str(self)
+            .decode_utf8()
+            .map_err(|err| error::ParseUriError::DecodeField {
+                field,
+                cause: err.to_string(),
+            })
+    }
+}
+
+pub fn parse_key_source(uri: &str) -> Result<Pkcs11KeySource> {
+    let uri = pk11_uri_parser::parse(uri).context(error::Pk11UriSnafu)?;
+    let module = uri
+        .module_path()
+        .context(error::RequiresSnafu {
+            what: "module-path field",
+        })?
+        .percent_decode("module-path")?;
+
+    let token = parse_token_id(&uri)?;
+
+    let key = parse_key_id(&uri)?;
+
+    let pin = read_pin(uri.pin_value(), uri.pin_source())?;
+
+    Ok(Pkcs11KeySource {
+        module_path: PathBuf::from(module.to_string()),
+        token,
+        key,
+        pin,
+    })
+}
+
+fn parse_key_id(uri: &pk11_uri_parser::PK11URIMapping<'_>) -> Result<KeyId> {
+    let key = match (uri.object(), uri.id()) {
+        (Some(s), None) => KeyId::Label(s.percent_decode("object")?.into_owned()),
+        (None, Some(s)) => KeyId::Id(percent_encoding::percent_decode_str(s).collect()),
+        (None, None) => {
+            return Err(error::ParseUriError::Requires {
+                what: "key identifier (object= or id=)",
+            })
+        }
+        (Some(_), Some(_)) => {
+            return Err(error::ParseUriError::Conflict {
+                oneof: "key identifiers (object= OR id=, not both)",
+            })
+        }
+    };
+    Ok(key)
+}
+
+fn parse_token_id(uri: &pk11_uri_parser::PK11URIMapping<'_>) -> Result<TokenId> {
+    let token = match (uri.token(), uri.serial(), uri.slot_id()) {
+        (Some(s), None, None) => TokenId::Label(s.percent_decode("token")?.into_owned()),
+        (None, Some(s), None) => TokenId::Serial(s.percent_decode("serial")?.into_owned()),
+        (None, None, Some(s)) => {
+            let id = s
+                .parse::<u64>()
+                .map_err(|err| error::ParseUriError::DecodeField {
+                    cause: err.to_string(),
+                    field: "slot-id",
+                })?;
+            TokenId::SlotId(id)
+        }
+        (None, None, None) => {
+            return Err(error::ParseUriError::Requires {
+                what: "token identifier (one of token=, serial=, or slot-id=)",
+            });
+        }
+        _ => {
+            return Err(error::ParseUriError::Conflict {
+                oneof: "one token identifier (token=, serial=, or slot-id=), but got multiple",
+            })
+        }
+    };
+    Ok(token)
+}
+
+fn read_pin(pin_value: Option<&str>, pin_source: Option<&str>) -> Result<Option<AuthPin>> {
+    if let Some(pin) = pin_value {
+        return Ok(Some(pin.percent_decode("pin-value")?.to_string().into()));
+    }
+
+    if let Some(pin_source) = pin_source {
+        let pin =
+            std::fs::read_to_string(pin_source).with_context(|_| error::PinReadingFailedSnafu {
+                path: pin_source.to_string(),
+            })?;
+
+        Ok(Some(pin.trim().to_string().into()))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{KeyId, TokenId};
+    use secrecy::ExposeSecret;
+    use std::io::Write;
+
+    #[test]
+    fn parses_token_label_and_object_label() {
+        let uri = "pkcs11:token=My%20Token;object=my-key\
+                    ?module-path=/usr/lib/softhsm/libsofthsm2.so&pin-value=1234";
+
+        let source = parse_key_source(uri).unwrap();
+
+        assert_eq!(
+            source.module_path,
+            PathBuf::from("/usr/lib/softhsm/libsofthsm2.so")
+        );
+        assert_eq!(source.token, TokenId::Label("My Token".into()));
+        assert_eq!(source.key, KeyId::Label("my-key".into()));
+        assert_eq!(source.pin.unwrap().expose_secret(), "1234");
+    }
+
+    #[test]
+    fn parses_serial_and_percent_encoded_id() {
+        let uri = "pkcs11:serial=1234ABCD;id=%DE%AD%BE%EF\
+                    ?module-path=/usr/lib/pkcs11.so&pin-value=secret";
+
+        let source = parse_key_source(uri).unwrap();
+
+        assert_eq!(source.token, TokenId::Serial("1234ABCD".into()));
+        assert_eq!(source.key, KeyId::Id(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+    }
+
+    #[test]
+    fn parses_slot_id_as_number() {
+        let uri = "pkcs11:slot-id=42;object=my-key?module-path=/usr/lib/pkcs11.so";
+
+        let source = parse_key_source(uri).unwrap();
+
+        assert!(matches!(source.token, TokenId::SlotId(42)));
+        assert!(source.pin.is_none());
+    }
+
+    #[test]
+    fn reads_pin_from_pin_source_file() {
+        let mut file = tempfile::NamedTempFile::new().expect("create temp file");
+        writeln!(file, "  supersecretpin  ").expect("write pin to temp file");
+        let path = file.path().to_str().expect("path is valid utf8");
+
+        let uri = format!(
+            "pkcs11:token=Tok;object=my-key?module-path=/usr/lib/pkcs11.so&pin-source={path}"
+        );
+
+        let source = parse_key_source(&uri).unwrap();
+        assert_eq!(source.pin.unwrap().expose_secret(), "supersecretpin");
+    }
+
+    #[test]
+    fn module_path_is_percent_decoded() {
+        let uri = "pkcs11:token=Tok;object=my-key\
+                    ?module-path=/usr/lib/pkcs11%2Dv2.so";
+        let source = parse_key_source(uri).unwrap();
+        assert_eq!(source.module_path, PathBuf::from("/usr/lib/pkcs11-v2.so"));
+    }
+
+    #[test]
+    fn missing_module_path_is_an_error() {
+        let uri = "pkcs11:token=Tok;object=my-key";
+        let err = parse_key_source(uri).expect_err("missing module-path must fail");
+        assert!(format!("{err:?}").contains("module-path field"));
+    }
+
+    #[test]
+    fn missing_token_identifier_is_an_error() {
+        let uri = "pkcs11:object=my-key?module-path=/usr/lib/pkcs11.so";
+        let err = parse_key_source(uri).expect_err("missing token identifier must fail");
+        assert!(format!("{err:?}").contains("token identifier"));
+    }
+
+    #[test]
+    fn conflicting_token_identifiers_is_an_error() {
+        let uri = "pkcs11:token=Tok;serial=1234;object=my-key?module-path=/usr/lib/pkcs11.so";
+        let err = parse_key_source(uri).expect_err("conflicting token identifiers must fail");
+        assert!(format!("{err:?}").contains("token identifier"));
+    }
+
+    #[test]
+    fn missing_key_identifier_is_an_error() {
+        let uri = "pkcs11:token=Tok?module-path=/usr/lib/pkcs11.so";
+        let err = parse_key_source(uri).expect_err("missing key identifier must fail");
+        assert!(format!("{err:?}").contains("key identifier"));
+    }
+
+    #[test]
+    fn conflicting_key_identifiers_is_an_error() {
+        let uri = "pkcs11:token=Tok;object=my-key;id=%01%02?module-path=/usr/lib/pkcs11.so";
+        let err = parse_key_source(uri).expect_err("conflicting key identifiers must fail");
+        assert!(format!("{err:?}").contains("key identifiers"));
+    }
+
+    #[test]
+    fn invalid_slot_id_is_an_error() {
+        let uri = "pkcs11:slot-id=not-a-number;object=my-key\
+                    ?module-path=/usr/lib/pkcs11.so";
+
+        let err = parse_key_source(uri).expect_err("non-numeric slot-id must fail");
+        assert!(format!("{err:?}").contains("slot-id"));
+    }
+
+    #[test]
+    fn missing_pin_source_file_is_an_error() {
+        let uri = "pkcs11:token=Tok;object=my-key\
+                    ?module-path=/usr/lib/pkcs11.so&pin-source=/nonexistent/path/to/pin";
+        let err = parse_key_source(uri).expect_err("unreadable pin-source file must fail");
+        assert!(format!("{err:?}").contains("/nonexistent/path/to/pin"));
+    }
+}

--- a/tough/src/lib.rs
+++ b/tough/src/lib.rs
@@ -1338,7 +1338,7 @@ async fn load_delegations(
         let role_meta = snapshot
             .signed
             .meta
-            .get(&format!("{}.json", &delegated_role.name));
+            .get(&format!("{}.json", delegated_role.name));
 
         if role_meta.is_none() {
             // 5.6.7: If any metadata requested in steps 5.6.7.1 - 5.6.7.2 cannot be downloaded nor validated, end the search and report that the target cannot be found.
@@ -1349,7 +1349,7 @@ async fn load_delegations(
         let path = if consistent_snapshot {
             format!(
                 "{}.{}.json",
-                &role_meta.version,
+                role_meta.version,
                 encode_filename(&delegated_role.name)
             )
         } else {

--- a/tough/src/schema/key.rs
+++ b/tough/src/schema/key.rs
@@ -151,7 +151,7 @@ impl Key {
     }
 
     /// Verify a signature of an object made with this key.
-    pub(super) fn verify(&self, msg: &[u8], signature: &[u8]) -> bool {
+    pub fn verify(&self, msg: &[u8], signature: &[u8]) -> bool {
         let (alg, public_key): (&dyn VerificationAlgorithm, untrusted::Input<'_>) = match self {
             Key::Ecdsa {
                 scheme: EcdsaScheme::EcdsaSha2Nistp256,

--- a/tuftool/Cargo.toml
+++ b/tuftool/Cargo.toml
@@ -40,6 +40,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tough = { version = "0.24", path = "../tough", features = ["http"] }
 tough-kms = { version = "0.16", path = "../tough-kms" }
+tough-pkcs11 = { version = "0.19", path = "../tough-pkcs11" }
 tough-ssm = { version = "0.19", path = "../tough-ssm" }
 url = "2"
 walkdir = "2"

--- a/tuftool/src/error.rs
+++ b/tuftool/src/error.rs
@@ -344,6 +344,11 @@ pub(crate) enum Error {
         source: tokio::task::JoinError,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Failed to parse PKCS11 URI"))]
+    Pkcs11UrlParse {
+        source: tough_pkcs11::error::ParseUriError,
+    },
 }
 
 // Extracts the status code from a reqwest::Error and converts it to a string to be displayed

--- a/tuftool/src/source.rs
+++ b/tuftool/src/source.rs
@@ -9,13 +9,17 @@
 //! This module parses a key source command line parameter as a URL, relative to `file://$PWD`,
 //! then matches the URL scheme against ones we understand.
 //!
-//! Currently supported key sources are local files and AWS SSM.
+//! Currently supported key sources are local files, AWS SSM and PKCS#11.
 //!
 //! Examples of currently supported formats:
+//!
+//! # Files
 //!
 //! Local files may be specified using a path or "file:///" prefixed path:
 //! "./a/key/file/here"
 //! "file:///./a/key/file/here" (notice the 3 slashes after the colon)
+//!
+//! # AWS SSM
 //!
 //! Keys stored in AWS SSM use a special format:
 //! "aws-ssm://<aws profile>/key/path/in/SSM?kms-key-id=12345"
@@ -32,6 +36,30 @@
 //!
 //! You may also skip the profile bit and just use your local environment's default profile:
 //! "aws-ssm:///a/key" (notice the 3 slashes after the colon)
+//!
+//! # PKCS#11
+//!
+//! PKCS11 uses RFC 7512 URI scheme:
+//!
+//! ```txt
+//! pkcs11:slot-id=0;id=%02?module-path=/usr/local/lib/libykcs11.so&pin-source=/run/pin
+//! ```
+//!
+//! There are a couple of parts:
+//! - Slot identifier (required), one of:
+//!   * `token=` - Find slot by token label
+//!   * `serial=` - Find slot by token serial number
+//!   * `slot-id=` - Find slot by its numeric ID
+//! - Key identifier (required), one of:
+//!   * `object=` - Find key by label
+//!   * `id=` - Find key by ID (often percent-encoded)
+//! - Query:
+//!   * `module-path=` (required) - path to the pkcs11 .so/.dylib/.dll file.
+//!   * `pin-source=` (optional) - path to the file with PIN.
+//!   * `pin-value=` (optional) - inline PIN. NOTE: this not recommended to
+//!     use this option, because PIN can be leaked in the process list and in
+//!     error messages.
+//!
 
 use crate::error::{self, Result};
 use snafu::ResultExt;
@@ -53,6 +81,11 @@ pub(crate) fn parse_key_source(input: &str) -> Result<Box<dyn KeySource>> {
     let path_or_url = parse_path_or_url(input)?;
     match path_or_url {
         PathOrUrl::Path(path) => Ok(Box::new(LocalKeySource { path })),
+        PathOrUrl::Pkcs11Url(url) => {
+            let key_source =
+                tough_pkcs11::uri::parse_key_source(&url).context(error::Pkcs11UrlParseSnafu)?;
+            Ok(Box::new(key_source))
+        }
         PathOrUrl::Url(url) => {
             match url.scheme() {
                 #[cfg(any(feature = "aws-sdk-rust", feature = "aws-sdk-rust-rustls"))]
@@ -92,6 +125,7 @@ pub(crate) fn parse_key_source(input: &str) -> Result<Box<dyn KeySource>> {
                     client: None,
                     signing_algorithm: KmsSigningAlgorithm::RsassaPssSha256,
                 })),
+
                 _ => error::UnrecognizedSchemeSnafu {
                     scheme: url.scheme(),
                 }
@@ -106,6 +140,7 @@ pub(crate) fn parse_key_source(input: &str) -> Result<Box<dyn KeySource>> {
 enum PathOrUrl {
     Path(PathBuf),
     Url(Url),
+    Pkcs11Url(String),
 }
 
 fn parse_path_or_url(s: &str) -> Result<PathOrUrl> {
@@ -119,6 +154,20 @@ fn parse_path_or_url(s: &str) -> Result<PathOrUrl> {
         Ok(PathOrUrl::Url(
             Url::parse(s).context(error::UrlParseSnafu { url: s })?,
         ))
+    } else if s.starts_with("pkcs11:") {
+        // RFC 7512 dictates that the pkcs11 url consists of:
+        //
+        //     "pkcs11:" pk11-path [ "?" pk11-query ]
+        //
+        // But, for consistency with other key sources, let's allow the "pkcs11://"
+        // scheme. Just replace it with the "pkcs11:" before parsing.
+        let input = if let Some(suffix) = s.strip_prefix("pkcs11://") {
+            format!("pkcs11:{suffix}")
+        } else {
+            s.to_string()
+        };
+
+        Ok(PathOrUrl::Pkcs11Url(input))
     } else {
         // It's not one of our known schemes and it's not a file:// scheme, treat is as a path.
         Ok(PathOrUrl::Path(PathBuf::from(s)))


### PR DESCRIPTION
*Issue:* https://github.com/awslabs/tough/issues/537

This PR adds a new key source for tuftool using PKCS11 libs.

PKCS11 is a universal interface for crypto operations on various modules: from Smart Cards, TPMs, YubiKeys to various network and cloud crypto devices. So by implementing it, the tuftool can cover many backends and bring more HSMs to the tool.

The implementation is in the separate crate `tough-pkcs11`.

The key source is configured with [RFC 7512](https://datatracker.ietf.org/doc/html/rfc7512) URI scheme, which looks like (for YubiKey ykcs):

```
pkcs11:serial=12345678;id=%05?module-path=/usr/lib/x86_64-linux-gnu/libykcs11.so&pin-source=/tmp/pin
```

Check the module doc for info for the supported params, but overall the design for pkcs11 handling is similar to the [step-cli](https://github.com/smallstep/cli).

I added support for P256, Ed25519 and RSA keys. I also added softhsm integration tests behind a feature flag. They are also run on the CI.

Because of all these, the PR is pretty big, so I recommend reviewing it commit-by-commit.